### PR TITLE
ISSUE-19: Updated CONTRIBUTING.md with information for MacOSX devs including the gradlex Shell Script

### DIFF
--- a/bin/gradlex
+++ b/bin/gradlex
@@ -38,9 +38,9 @@ ${TAGLINE}
 "
   docker pull $DOCKER_IMAGE
   if [ -d "${GRADLE_CACHES}" ]; then
-    docker run -t -i -v $GRADLE_CACHES:$DOCKER_GRADLE_CACHES --user gradle -v $(pwd):/docker/tmp -w /docker/tmp $DOCKER_IMAGE gradle $1
+    docker run -t -i -v $GRADLE_CACHES:$DOCKER_GRADLE_CACHES --user gradle -v $(pwd):/docker/tmp -w /docker/tmp $DOCKER_IMAGE gradle "$@"
   else
     echo "WARNING: No Gradle build cache found."
-    docker run -t -i --user gradle -v $(pwd):/docker/tmp -w /docker/tmp $DOCKER_IMAGE gradle $1
+    docker run -t -i --user gradle -v $(pwd):/docker/tmp -w /docker/tmp $DOCKER_IMAGE gradle "$@"
   fi
 fi

--- a/bin/gradlex
+++ b/bin/gradlex
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Usage: gradlex build
+#
+# 1.) Mounts current directory into specified DOCKER_IMAGE (default: gradle:7.4.2-jdk11-focal)
+# 2.) Mounts GRADLE_CACHES (default: ~/docker-gradle-caches) into Docker image's .gradle/caches.
+# 3.) Evaluates gradle $1 (where any gradle task can be specified in as an argument to the script).
+
+TAGLINE="GradleX: Gradle Built in the Image of Docker"
+DEFAULT_DOCKER_IMAGE=gradle:7.4.2-jdk11-focal
+DEFAULT_GRADLE_CACHES=~/docker-gradle-caches
+DOCKER_GRADLE_CACHES="/home/gradle/.gradle/caches"
+
+## USAGE
+if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
+  echo "${TAGLINE}
+  DOCKER_IMAGE (default: ${DEFAULT_DOCKER_IMAGE})
+  GRADLE_CACHES (default: ${DEFAULT_GRADLE_CACHES})
+Arguments:
+  -h, --help: this help message
+  <task>: gradle ${pwd}/build.gradle <task>"
+### MAIN
+else
+  if [ -z "${GRADLE_CACHES}" ]; then
+    GRADLE_CACHES=$DEFAULT_GRADLE_CACHES
+  fi
+
+  if [ -z "${DOCKER_IMAGE}" ]; then
+    DOCKER_IMAGE=$DEFAULT_DOCKER_IMAGE
+  fi
+
+  echo "
+${TAGLINE}
+  [Building in Docker image ${DOCKER_IMAGE}]
+  [Gradle build caches: ${GRADLE_CACHES} => ${DOCKER_GRADLE_CACHES}]
+"
+  docker pull $DOCKER_IMAGE
+  if [ -d "${GRADLE_CACHES}" ]; then
+    docker run -t -i -v $GRADLE_CACHES:$DOCKER_GRADLE_CACHES --user gradle -v $(pwd):/docker/tmp -w /docker/tmp $DOCKER_IMAGE gradle $1
+  else
+    echo "WARNING: No Gradle build cache found."
+    docker run -t -i --user gradle -v $(pwd):/docker/tmp -w /docker/tmp $DOCKER_IMAGE gradle $1
+  fi
+fi


### PR DESCRIPTION
### Description
The following shell script is intended to make the MacOSX developer experience easier. It uses a Linux/Gradle Docker image for the build environment, thus enabling `integTest` to be run on MacOSX. The mechanics of the script as well as a pointer to the script have been provided in `CONTRIBUTING.md`.
 
### Issues Resolved
#19 Complete.
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).