### PR TITLE
add support for context variables in subject & message templates

### DIFF
--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -269,7 +269,9 @@ public class TestHelpers {
 
     public static Action randomAction(String destinationId) {
         String name = OpenSearchRestTestCase.randomUnicodeOfLength(10);
-        Script template = randomTemplateScript("Hello World", null);
+        Script template = randomTemplateScript("Detector {{ctx.detector.name}} just entered alert status. Please investigate the issue.\n" +
+                "  - Trigger: {{ctx.trigger.name}}\n" +
+                "  - Severity: {{ctx.trigger.severity}}", null);
         Boolean throttleEnabled = false;
         Throttle throttle = randomThrottle(null, null);
         return new Action(name, destinationId, template, template, throttleEnabled, throttle, OpenSearchRestTestCase.randomAlphaOfLength(10), null);

--- a/src/test/java/org/opensearch/securityanalytics/alerts/AlertsIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/alerts/AlertsIT.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.http.HttpStatus;
@@ -115,9 +114,11 @@ public class AlertsIT extends SecurityAnalyticsRestTestCase {
 
                 for (Map.Entry<String, Object> actionResult: actionResults.entrySet()) {
                     Map<String, String> actionOutput = ((Map<String, Map<String, String>>) actionResult.getValue()).get("output");
+                    String expectedMessage = triggerAction.getSubjectTemplate().getIdOrCode().replace("{{ctx.detector.name}}", detector.getName())
+                            .replace("{{ctx.trigger.name}}", "test-trigger").replace("{{ctx.trigger.severity}}", "1");
 
-                    Assert.assertEquals("Hello World", actionOutput.get("subject"));
-                    Assert.assertEquals("Hello World", actionOutput.get("message"));
+                    Assert.assertEquals(expectedMessage, actionOutput.get("subject"));
+                    Assert.assertEquals(expectedMessage, actionOutput.get("message"));
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Subhobrata Dey <sbcd90@gmail.com>

### Description
add support for context variables in subject & message templates
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
