### PR TITLE
Enabled creation detector without rules

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -193,6 +193,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         }
         // Do nothing if detector doesn't have any monitor
         if(monitorRequests.isEmpty()){
+            listener.onResponse(Collections.emptyList());
             return;
         }
 


### PR DESCRIPTION
Signed-off-by: Stevan Buzejic <stevan.buzejic@htecgroup.com>

### Description
Enabled empty detector (detector without rules) creation.
Added response handling on detector create request when the list of rules is empty.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
