### PR TITLE
fixed aliases being returned in unmapped_index_fields

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/mapper/MappingsTraverser.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MappingsTraverser.java
@@ -121,14 +121,6 @@ public class MappingsTraverser {
     }
 
     /**
-     * Sets set of property "type" values to skip during traversal.
-     * @param types Set of strings representing property "type"
-     */
-    public void setTypesToSkip(Set<String> types) {
-        this.typesToSkip = types;
-    }
-
-    /**
      * Traverses mappings tree and collects all fields that are not of type "alias".
      * Nested fields are flattened.
      * @return list of fields in mappings.
@@ -136,7 +128,7 @@ public class MappingsTraverser {
     public List<String> extractFlatNonAliasFields() {
         List<String> flatProperties = new ArrayList<>();
         // Setup
-        this.typesToSkip.add(ALIAS);
+        this.propertiesToSkip.add(Pair.of(TYPE, ALIAS));
         this.mappingsTraverserListeners.add(new MappingsTraverserListener() {
             @Override
             public void onLeafVisited(Node node) {

--- a/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
@@ -48,19 +48,18 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
                 "  \"partial\":true" +
                 "}"
         );
-        // request.addParameter("indexName", testIndexName);
-        // request.addParameter("ruleTopic", "netflow");
         Response response = client().performRequest(request);
         assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
 
         // Verify mappings
         GetMappingsResponse getMappingsResponse = SecurityAnalyticsClientUtils.executeGetMappingsRequest(testIndexName);
         MappingsTraverser mappingsTraverser = new MappingsTraverser(getMappingsResponse.getMappings().iterator().next().value);
+        // After applying netflow aliases, our index will have 4 alias mappings
         List<String> flatProperties = mappingsTraverser.extractFlatNonAliasFields();
-        assertTrue(flatProperties.contains("source.ip"));
-        assertTrue(flatProperties.contains("destination.ip"));
-        assertTrue(flatProperties.contains("source.port"));
-        assertTrue(flatProperties.contains("destination.port"));
+        assertFalse(flatProperties.contains("source.ip"));
+        assertFalse(flatProperties.contains("destination.ip"));
+        assertFalse(flatProperties.contains("source.port"));
+        assertFalse(flatProperties.contains("destination.port"));
         // Try searching by alias field
         String query = "{" +
                 "  \"query\": {" +
@@ -110,8 +109,8 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
         GetMappingsResponse getMappingsResponse = SecurityAnalyticsClientUtils.executeGetMappingsRequest(testIndexName);
         MappingsTraverser mappingsTraverser = new MappingsTraverser(getMappingsResponse.getMappings().iterator().next().value);
         List<String> flatProperties = mappingsTraverser.extractFlatNonAliasFields();
-        assertTrue(flatProperties.contains("source.ip"));
-        assertTrue(flatProperties.contains("source.port"));
+        assertFalse(flatProperties.contains("source.ip"));
+        assertFalse(flatProperties.contains("source.port"));
         // Try searching by alias field
         String query = "{" +
                 "  \"query\": {" +

--- a/src/test/java/org/opensearch/securityanalytics/mapper/MapperUtilsTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/mapper/MapperUtilsTests.java
@@ -64,6 +64,20 @@ public class MapperUtilsTests extends OpenSearchTestCase {
         assertEquals(0, missingFields.size());
     }
 
+    public void testGetAllNonAliasFieldsFromIndex_success() throws IOException {
+        // Create index mappings
+        Map<String, Object> m = new HashMap<>();
+        m.put("netflow.event_data.SourceAddress", Map.of("type", "ip"));
+        m.put("alias_123", Map.of("type", "alias", "path", "netflow.event_data.SourceAddress"));
+        Map<String, Object> properties = Map.of("properties", m);
+        Map<String, Object> root = Map.of(MapperService.SINGLE_MAPPING_NAME, properties);
+        MappingMetadata mappingMetadata = new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, root);
+
+        List<String> fields = MapperUtils.getAllNonAliasFieldsFromIndex(mappingMetadata);
+        assertEquals(1, fields.size());
+        assertEquals("netflow.event_data.SourceAddress", fields.get(0));
+    }
+
     public void testGetAllPathsFromAliasMappingsSuccess() throws IOException {
         MapperTopicStore.putAliasMappings("test123", "testValidAliasMappingsSimple.json");
 


### PR DESCRIPTION
Signed-off-by: Petar Dzepina <petar.dzepina@gmail.com>

### Description
GetMappingsView API was returning aliases in "unmapped_index_fields" due to bug in field type filtering.
 
### Issues Resolved
#171 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
