### PR TITLE
search returns detector type in CAPS fix and integration tests

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/action/IndexRuleRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/IndexRuleRequest.java
@@ -64,7 +64,7 @@ public class IndexRuleRequest extends ActionRequest {
         super();
         this.ruleId = ruleId;
         this.refreshPolicy = refreshPolicy;
-        this.logType = logType;
+        this.logType = logType.toLowerCase(Locale.ROOT);
         this.method = method;
         this.rule = rule;
         this.forced = forced;

--- a/src/main/java/org/opensearch/securityanalytics/config/monitors/DetectorMonitorConfig.java
+++ b/src/main/java/org/opensearch/securityanalytics/config/monitors/DetectorMonitorConfig.java
@@ -58,32 +58,32 @@ public class DetectorMonitorConfig {
     }
 
     public static String getRuleIndex(String detectorType) {
-        return detectorTypeToIndicesMapping.containsKey(detectorType) ?
-                detectorTypeToIndicesMapping.get(detectorType).getRuleIndex() :
+        return detectorTypeToIndicesMapping.containsKey(detectorType.toLowerCase(Locale.ROOT)) ?
+                detectorTypeToIndicesMapping.get(detectorType.toLowerCase(Locale.ROOT)).getRuleIndex() :
                 OPENSEARCH_DEFAULT_RULE_INDEX;
     }
 
     public static String getAlertsIndex(String detectorType) {
-        return detectorTypeToIndicesMapping.containsKey(detectorType) ?
-                detectorTypeToIndicesMapping.get(detectorType).getAlertsIndex() :
+        return detectorTypeToIndicesMapping.containsKey(detectorType.toLowerCase(Locale.ROOT)) ?
+                detectorTypeToIndicesMapping.get(detectorType.toLowerCase(Locale.ROOT)).getAlertsIndex() :
                 OPENSEARCH_DEFAULT_ALERT_INDEX;
     }
 
     public static String getAlertsHistoryIndex(String detectorType) {
-        return detectorTypeToIndicesMapping.containsKey(detectorType) ?
-                detectorTypeToIndicesMapping.get(detectorType).getAlertsHistoryIndex() :
+        return detectorTypeToIndicesMapping.containsKey(detectorType.toLowerCase(Locale.ROOT)) ?
+                detectorTypeToIndicesMapping.get(detectorType.toLowerCase(Locale.ROOT)).getAlertsHistoryIndex() :
                 OPENSEARCH_DEFAULT_ALERT_HISTORY_INDEX;
     }
 
     public static String getAlertsHistoryIndexPattern(String detectorType) {
-        return detectorTypeToIndicesMapping.containsKey(detectorType) ?
-                detectorTypeToIndicesMapping.get(detectorType).getAlertsHistoryIndexPattern() :
+        return detectorTypeToIndicesMapping.containsKey(detectorType.toLowerCase(Locale.ROOT)) ?
+                detectorTypeToIndicesMapping.get(detectorType.toLowerCase(Locale.ROOT)).getAlertsHistoryIndexPattern() :
                 OPENSEARCH_DEFAULT_ALERT_HISTORY_INDEX_PATTERN;
     }
 
     public static String getAllAlertsIndicesPattern(String detectorType) {
-        return detectorTypeToIndicesMapping.containsKey(detectorType) ?
-                detectorTypeToIndicesMapping.get(detectorType).getAllAlertsIndicesPattern() :
+        return detectorTypeToIndicesMapping.containsKey(detectorType.toLowerCase(Locale.ROOT)) ?
+                detectorTypeToIndicesMapping.get(detectorType.toLowerCase(Locale.ROOT)).getAllAlertsIndicesPattern() :
                 OPENSEARCH_DEFAULT_ALL_ALERT_INDICES_PATTERN;
     }
 
@@ -95,14 +95,14 @@ public class DetectorMonitorConfig {
     }
 
     public static String getFindingsIndex(String detectorType) {
-        return detectorTypeToIndicesMapping.containsKey(detectorType) ?
-                detectorTypeToIndicesMapping.get(detectorType).getFindingsIndex() :
+        return detectorTypeToIndicesMapping.containsKey(detectorType.toLowerCase(Locale.ROOT)) ?
+                detectorTypeToIndicesMapping.get(detectorType.toLowerCase(Locale.ROOT)).getFindingsIndex() :
                 OPENSEARCH_DEFAULT_FINDINGS_INDEX;
     }
 
     public static String getAllFindingsIndicesPattern(String detectorType) {
-        return detectorTypeToIndicesMapping.containsKey(detectorType) ?
-                detectorTypeToIndicesMapping.get(detectorType).getAllFindingsIndicesPattern() :
+        return detectorTypeToIndicesMapping.containsKey(detectorType.toLowerCase(Locale.ROOT)) ?
+                detectorTypeToIndicesMapping.get(detectorType.toLowerCase(Locale.ROOT)).getAllFindingsIndicesPattern() :
                 OPENSEARCH_DEFAULT_ALL_FINDINGS_INDICES_PATTERN;
     }
 
@@ -114,8 +114,8 @@ public class DetectorMonitorConfig {
     }
 
     public static String getFindingsIndexPattern(String detectorType) {
-        return detectorTypeToIndicesMapping.containsKey(detectorType) ?
-                detectorTypeToIndicesMapping.get(detectorType).getFindingsIndexPattern() :
+        return detectorTypeToIndicesMapping.containsKey(detectorType.toLowerCase(Locale.ROOT)) ?
+                detectorTypeToIndicesMapping.get(detectorType.toLowerCase(Locale.ROOT)).getFindingsIndexPattern() :
                 OPENSEARCH_DEFAULT_FINDINGS_INDEX_PATTERN;
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/mapper/MapperTopicStore.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MapperTopicStore.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -54,11 +55,11 @@ public class MapperTopicStore {
     }
 
     public static String aliasMappings(String mapperTopic) throws IOException {
-        if (INSTANCE.mapperMap.containsKey(mapperTopic)) {
+        if (INSTANCE.mapperMap.containsKey(mapperTopic.toLowerCase(Locale.ROOT))) {
             return new String(Objects.requireNonNull(
 
                     INSTANCE.getClass().getClassLoader().getResourceAsStream(INSTANCE.
-                            mapperMap.get(mapperTopic))).readAllBytes(),
+                            mapperMap.get(mapperTopic.toLowerCase(Locale.ROOT)))).readAllBytes(),
                     StandardCharsets.UTF_8);
         }
         throw new IllegalArgumentException("Mapper not found: [" + mapperTopic + "]");

--- a/src/main/java/org/opensearch/securityanalytics/model/Detector.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Detector.java
@@ -248,7 +248,7 @@ public class Detector implements Writeable, ToXContentObject {
         }
         builder.field(TYPE_FIELD, type)
                 .field(NAME_FIELD, name)
-                .field(DETECTOR_TYPE_FIELD, detectorType);
+                .field(DETECTOR_TYPE_FIELD, detectorType.getDetectorType());
 
         if (!secure) {
             if (user == null) {

--- a/src/main/java/org/opensearch/securityanalytics/model/DetectorTrigger.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/DetectorTrigger.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class DetectorTrigger implements Writeable, ToXContentObject {
 
@@ -66,7 +67,9 @@ public class DetectorTrigger implements Writeable, ToXContentObject {
         this.id = id == null? UUIDs.base64UUID(): id;
         this.name = name;
         this.severity = severity;
-        this.ruleTypes = ruleTypes;
+        this.ruleTypes = ruleTypes.stream()
+                .map( e -> e.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toList());
         this.ruleIds = ruleIds;
         this.ruleSeverityLevels = ruleSeverityLevels;
         this.tags = tags;

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportGetAlertsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportGetAlertsAction.java
@@ -73,7 +73,7 @@ public class TransportGetAlertsAction extends HandledTransportAction<GetAlertsRe
                             QueryBuilders.boolQuery().must(
                                     QueryBuilders.matchQuery(
                                             DETECTOR_TYPE_PATH,
-                                            request.getDetectorType().getDetectorType().toUpperCase(Locale.ROOT)
+                                            request.getDetectorType().getDetectorType()//.toUpperCase(Locale.ROOT)
                                     )
                             ),
                             ScoreMode.None

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportGetAlertsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportGetAlertsAction.java
@@ -73,7 +73,7 @@ public class TransportGetAlertsAction extends HandledTransportAction<GetAlertsRe
                             QueryBuilders.boolQuery().must(
                                     QueryBuilders.matchQuery(
                                             DETECTOR_TYPE_PATH,
-                                            request.getDetectorType().getDetectorType()//.toUpperCase(Locale.ROOT)
+                                            request.getDetectorType().getDetectorType()
                                     )
                             ),
                             ScoreMode.None

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportGetFindingsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportGetFindingsAction.java
@@ -103,7 +103,7 @@ public class TransportGetFindingsAction extends HandledTransportAction<GetFindin
                         QueryBuilders.boolQuery().must(
                                 QueryBuilders.matchQuery(
                                     DETECTOR_TYPE_PATH,
-                                    request.getDetectorType().getDetectorType().toUpperCase(Locale.ROOT)
+                                    request.getDetectorType().getDetectorType()//.toUpperCase(Locale.ROOT)
                                 )
                         ),
                         ScoreMode.None

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportGetFindingsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportGetFindingsAction.java
@@ -103,7 +103,7 @@ public class TransportGetFindingsAction extends HandledTransportAction<GetFindin
                         QueryBuilders.boolQuery().must(
                                 QueryBuilders.matchQuery(
                                     DETECTOR_TYPE_PATH,
-                                    request.getDetectorType().getDetectorType()//.toUpperCase(Locale.ROOT)
+                                    request.getDetectorType().getDetectorType()
                                 )
                         ),
                         ScoreMode.None

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
@@ -171,7 +171,7 @@ public class TransportIndexRuleAction extends HandledTransportAction<IndexRuleRe
 
         void prepareRuleIndexing() {
             String rule = request.getRule();
-            String category = request.getLogType();
+            String category = request.getLogType().toLowerCase(Locale.ROOT);
 
             try {
                 SigmaRule parsedRule = SigmaRule.fromYaml(rule, true);

--- a/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
+++ b/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
@@ -239,7 +239,7 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
                 "      \"query\": {\n" +
                 "        \"bool\": {\n" +
                 "          \"must\": [\n" +
-                "            { \"match\": {\"rule.category\": \"" + TestHelpers.randomDetectorType() + "\"}}\n" +
+                "            { \"match\": {\"rule.category\": \"" + TestHelpers.randomDetectorType().toLowerCase(Locale.ROOT) + "\"}}\n" +
                 "          ]\n" +
                 "        }\n" +
                 "      }\n" +

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -307,7 +307,7 @@ public class TestHelpers {
     }
 
     public static String randomDetectorType() {
-        return "test_windows";
+        return "TEST_WINDOWS".toUpperCase(Locale.ROOT);
     }
 
     public static DetectorInput randomDetectorInput() {

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -307,7 +307,7 @@ public class TestHelpers {
     }
 
     public static String randomDetectorType() {
-        return "TEST_WINDOWS".toUpperCase(Locale.ROOT);
+        return "TEST_WINDOWS";
     }
 
     public static DetectorInput randomDetectorInput() {

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
@@ -86,7 +86,7 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("alert_index"));
 
         String detectorTypeInResponse = (String) ((Map<String, Object>)responseBody.get("detector")).get("detector_type");
-        Assert.assertEquals("Detector type incorrect", randomDetectorType(), detectorTypeInResponse);
+        Assert.assertEquals("Detector type incorrect", randomDetectorType().toLowerCase(Locale.ROOT), detectorTypeInResponse);
 
         String request = "{\n" +
                 "   \"query\" : {\n" +
@@ -187,7 +187,7 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertNotNull(responseBody.get("detector"));
 
         String detectorTypeInResponse = (String) ((Map<String, Object>)responseBody.get("detector")).get("detector_type");
-        Assert.assertEquals("Detector type incorrect", randomDetectorType(), detectorTypeInResponse);
+        Assert.assertEquals("Detector type incorrect", randomDetectorType().toLowerCase(Locale.ROOT), detectorTypeInResponse);
     }
 
     @SuppressWarnings("unchecked")
@@ -228,7 +228,7 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         List<Map<String, Object>> hits = ((List<Map<String, Object>>) ((Map<String, Object>) searchResponseBody.get("hits")).get("hits"));
         Map<String, Object> hit = hits.get(0);
         String detectorTypeInResponse = (String)  ((Map<String, Object>) hit.get("_source")).get("detector_type");
-        Assert.assertEquals("Detector type incorrect", detectorTypeInResponse, randomDetectorType());
+        Assert.assertEquals("Detector type incorrect", detectorTypeInResponse, randomDetectorType().toLowerCase(Locale.ROOT));
     }
 
     @SuppressWarnings("unchecked")
@@ -286,7 +286,7 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         SearchHit hit = hits.get(0);
 
         String detectorType = (String)  ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("detector_type");
-        Assert.assertEquals("Detector type incorrect", detectorType, randomDetectorType());
+        Assert.assertEquals("Detector type incorrect", detectorType, randomDetectorType().toLowerCase(Locale.ROOT));
 
         String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
 
@@ -445,7 +445,7 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertEquals("Update detector failed", RestStatus.OK, restStatus(updateResponse));
 
         String detectorTypeInResponse = (String) ((Map<String, Object>) (asMap(updateResponse).get("detector"))).get("detector_type");
-        Assert.assertEquals("Detector type incorrect", randomDetectorType(), detectorTypeInResponse);
+        Assert.assertEquals("Detector type incorrect", randomDetectorType().toLowerCase(Locale.ROOT), detectorTypeInResponse);
 
         request = "{\n" +
                 "   \"query\" : {\n" +

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
@@ -85,6 +85,9 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("findings_index"));
         Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("alert_index"));
 
+        String detectorTypeInResponse = (String) ((Map<String, Object>)responseBody.get("detector")).get("detector_type");
+        Assert.assertEquals("Detector type incorrect", randomDetectorType(), detectorTypeInResponse);
+
         String request = "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match\":{\n" +
@@ -182,6 +185,9 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> responseBody = asMap(getResponse);
         Assert.assertEquals(createdId, responseBody.get("_id"));
         Assert.assertNotNull(responseBody.get("detector"));
+
+        String detectorTypeInResponse = (String) ((Map<String, Object>)responseBody.get("detector")).get("detector_type");
+        Assert.assertEquals("Detector type incorrect", randomDetectorType(), detectorTypeInResponse);
     }
 
     @SuppressWarnings("unchecked")
@@ -218,6 +224,11 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> searchResponseHits = (Map) searchResponseBody.get("hits");
         Map<String, Object> searchResponseTotal = (Map) searchResponseHits.get("total");
         Assert.assertEquals(1, searchResponseTotal.get("value"));
+
+        List<Map<String, Object>> hits = ((List<Map<String, Object>>) ((Map<String, Object>) searchResponseBody.get("hits")).get("hits"));
+        Map<String, Object> hit = hits.get(0);
+        String detectorTypeInResponse = (String)  ((Map<String, Object>) hit.get("_source")).get("detector_type");
+        Assert.assertEquals("Detector type incorrect", detectorTypeInResponse, randomDetectorType());
     }
 
     @SuppressWarnings("unchecked")
@@ -273,6 +284,9 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
                 "}";
         List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
         SearchHit hit = hits.get(0);
+
+        String detectorType = (String)  ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("detector_type");
+        Assert.assertEquals("Detector type incorrect", detectorType, randomDetectorType());
 
         String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
 
@@ -429,6 +443,9 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
 
         Response updateResponse = makeRequest(client(), "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(updatedDetector));
         Assert.assertEquals("Update detector failed", RestStatus.OK, restStatus(updateResponse));
+
+        String detectorTypeInResponse = (String) ((Map<String, Object>) (asMap(updateResponse).get("detector"))).get("detector_type");
+        Assert.assertEquals("Detector type incorrect", randomDetectorType(), detectorTypeInResponse);
 
         request = "{\n" +
                 "   \"query\" : {\n" +

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/RuleRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/RuleRestApiIT.java
@@ -74,7 +74,7 @@ public class RuleRestApiIT extends SecurityAnalyticsRestTestCase {
                 "      \"query\": {\n" +
                 "        \"bool\": {\n" +
                 "          \"must\": [\n" +
-                "            { \"match\": {\"rule.category\": \"" + randomDetectorType() + "\"}}\n" +
+                "            { \"match\": {\"rule.category\": \"" + randomDetectorType().toLowerCase(Locale.ROOT) + "\"}}\n" +
                 "          ]\n" +
                 "        }\n" +
                 "      }\n" +
@@ -180,7 +180,7 @@ public class RuleRestApiIT extends SecurityAnalyticsRestTestCase {
                 "      \"query\": {\n" +
                 "        \"bool\": {\n" +
                 "          \"must\": [\n" +
-                "            { \"match\": {\"rule.category\": \"" + randomDetectorType() + "\"}}\n" +
+                "            { \"match\": {\"rule.category\": \"" + randomDetectorType().toLowerCase(Locale.ROOT) + "\"}}\n" +
                 "          ]\n" +
                 "        }\n" +
                 "      }\n" +
@@ -288,7 +288,7 @@ public class RuleRestApiIT extends SecurityAnalyticsRestTestCase {
                 "      \"query\": {\n" +
                 "        \"bool\": {\n" +
                 "          \"must\": [\n" +
-                "            { \"match\": {\"rule.category\": \"" + randomDetectorType() + "\"}}\n" +
+                "            { \"match\": {\"rule.category\": \"" + randomDetectorType().toLowerCase(Locale.ROOT) + "\"}}\n" +
                 "          ]\n" +
                 "        }\n" +
                 "      }\n" +


### PR DESCRIPTION
Signed-off-by: Raj Chakravarthi <raj@icedome.ca>

### Description
After this change, the detector type will be returned in small case during search.
Also, integration tests are written to ensure that happens in create, update, get , search detector.
 
### Issues Resolved
(https://github.com/opensearch-project/security-analytics/issues/173) 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
