### PR TITLE
fix for running windows integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         include:
           - os: windows-latest
-            os_build_args: -x integTest -x jacocoTestReport
+            os_build_args: -x jacocoTestReport
             working_directory: X:\
             os_java_options: -Xmx4096M
           - os: macos-latest
-            os_build_args: -x integTest -x jacocoTestReport
+            os_build_args: -x jacocoTestReport
 
     name: Build and Test security-analytics with JDK ${{ matrix.java }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
@@ -253,9 +253,7 @@ public class RuleIndices {
     }
 
     private String getRuleCategory(Path folderPath) {
-        String folder = folderPath.toString();
-        int idx = folder.lastIndexOf(PathUtils.getDefaultFileSystem().getSeparator());
-        return folder.substring(idx+1);
+        return folderPath.getFileName().toString();
     }
 
     private void ingestQueries(Map<String, List<String>> logIndexToRules, WriteRequest.RefreshPolicy refreshPolicy, TimeValue indexTimeout, ActionListener<BulkResponse> listener) throws SigmaError, IOException {


### PR DESCRIPTION
Signed-off-by: Subhobrata Dey <sbcd90@gmail.com>

### Description
fix for running windows integration tests
 
### Issues Resolved
[[RELEASE] Release version 2.4.1](https://github.com/opensearch-project/opensearch-build/issues/2925)
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
