### PR TITLE
add failure logs to github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,27 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() && matrix.os == 'ubuntu-latest' }}
+        with:
+          name: logs-ubuntu
+          path: build/testclusters/integTest-*/logs/*
+
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() && matrix.os == 'macos-latest' }}
+        with:
+          name: logs-mac
+          path: build/testclusters/integTest-*/logs/*
+
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() && matrix.os == 'windows-latest' }}
+        with:
+          name: logs-windows
+          path: build\testclusters\integTest-*\logs\*
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -28,3 +28,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Run integration tests with multi node config
         run: ./gradlew integTest -PnumNodes=3
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: logs
+          path: build/testclusters/integTest-*/logs/*


### PR DESCRIPTION
Signed-off-by: Subhobrata Dey <sbcd90@gmail.com>

### Description
add failure logs to github workflows
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
