### PR TITLE
Added dummy search when creating detector on the given indicies

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -173,8 +173,30 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             return;
         }
 
+        checkIndicesAndExecute(task, request, listener, user);
+    }
+
+    private void checkIndicesAndExecute(
+        Task task,
+        IndexDetectorRequest request,
+        ActionListener<IndexDetectorResponse> listener,
+        User user
+    ) {
+        String [] detectorIndices = request.getDetector().getInputs().stream().flatMap(detectorInput -> detectorInput.getIndices().stream()).toArray(String[]::new);
+        SearchRequest searchRequest =  new SearchRequest(detectorIndices).source(SearchSourceBuilder.searchSource().size(1).query(QueryBuilders.matchAllQuery()));;
+        StepListener<SearchResponse> checkIndexAccessStep = new StepListener();
+        client.search(searchRequest, checkIndexAccessStep);
         AsyncIndexDetectorsAction asyncAction = new AsyncIndexDetectorsAction(user, task, request, listener);
-        asyncAction.start();
+        // Check and execute as a step if the check was successful
+        checkIndexAccessStep.whenComplete(searchResponse -> asyncAction.start(), e -> {
+            if(e instanceof OpenSearchStatusException) {
+                listener.onFailure(SecurityAnalyticsException.wrap(
+                    new OpenSearchStatusException(String.format(Locale.getDefault(), "User doesn't have read permissions for one or more configured index %s", detectorIndices), RestStatus.FORBIDDEN)
+                ));
+            } else {
+                listener.onFailure(e);
+            }
+        });
     }
 
     private void createMonitorFromQueries(String index, List<Pair<String, Rule>> rulesById, Detector detector, ActionListener<List<IndexMonitorResponse>> listener, WriteRequest.RefreshPolicy refreshPolicy) throws SigmaError, IOException {
@@ -595,7 +617,6 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
         void start() {
             try {
-
                 TransportIndexDetectorAction.this.threadPool.getThreadContext().stashContext();
 
                 if (!detectorIndices.detectorIndexExists()) {

--- a/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
+++ b/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
@@ -72,7 +72,7 @@ import java.util.stream.Collectors;
 import static org.opensearch.action.admin.indices.create.CreateIndexRequest.MAPPINGS;
 import static org.opensearch.securityanalytics.TestHelpers.sumAggregationTestRule;
 import static org.opensearch.securityanalytics.TestHelpers.productIndexAvgAggRule;
-import static org.opensearch.securityanalytics.util.RuleTopicIndices.ruleTopicIndexMappings;
+import static org.opensearch.securityanalytics.TestHelpers.windowsIndexMapping;
 import static org.opensearch.securityanalytics.util.RuleTopicIndices.ruleTopicIndexSettings;
 
 public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
@@ -107,6 +107,22 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
             assertEquals(RestStatus.OK, restStatus(response));
         }
     }
+
+    protected final List<String> clusterPermissions = List.of(
+        "cluster:admin/opensearch/securityanalytics/detector/*",
+        "cluster:admin/opendistro/alerting/alerts/*",
+        "cluster:admin/opendistro/alerting/findings/*",
+        "cluster:admin/opensearch/securityanalytics/mapping/*",
+        "cluster:admin/opensearch/securityanalytics/rule/*"
+    );
+
+    protected final List<String> indexPermissions = List.of(
+        "indices:admin/mappings/get",
+        "indices:admin/mapping/put",
+        "indices:data/read/search"
+    );
+
+    protected static String TEST_HR_ROLE = "hr_role";
 
     protected String createTestIndex(String index, String mapping) throws IOException {
         createTestIndex(index, mapping, Settings.EMPTY);
@@ -371,6 +387,20 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
                 new NamedXContentRegistry(ClusterModule.getNamedXWriteables()),
                 DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
                 response.getEntity().getContent()
+        );
+        return SearchResponse.fromXContent(parser);
+    }
+
+    public static SearchResponse executeSearchRequest(RestClient client, String indexName, String queryJson) throws IOException {
+
+        Request request = new Request("GET", indexName + "/_search");
+        request.setJsonEntity(queryJson);
+        Response response = client.performRequest(request);
+
+        XContentParser parser = JsonXContent.jsonXContent.createParser(
+            new NamedXContentRegistry(ClusterModule.getNamedXWriteables()),
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            response.getEntity().getContent()
         );
         return SearchResponse.fromXContent(parser);
     }
@@ -997,6 +1027,41 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
 
     }
 
+    protected void createIndexRole(String name, List<String> clusterPermissions, List<String> indexPermission, List<String> indexPatterns) throws IOException {
+        Response response;
+        try {
+            response = client().performRequest(new Request("GET", String.format(Locale.getDefault(), "/_plugins/_security/api/roles/%s", name)));
+        } catch (ResponseException ex) {
+            response = ex.getResponse();
+        }
+        // Role already exists
+        if(response.getStatusLine().getStatusCode() == RestStatus.OK.getStatus()) {
+            return;
+        }
+
+        Request request = new Request("PUT", String.format(Locale.getDefault(), "/_plugins/_security/api/roles/%s", name));
+        String clusterPermissionsStr = clusterPermissions.stream().map(p -> "\"" + p + "\"").collect(Collectors.joining(","));
+        String indexPermissionsStr = indexPermission.stream().map(p -> "\"" + p + "\"").collect(Collectors.joining(","));
+        String indexPatternsStr = indexPatterns.stream().map(p -> "\"" + p + "\"").collect(Collectors.joining(","));
+
+        String entity = "{\n" +
+            "\"cluster_permissions\": [\n" +
+            "" + clusterPermissionsStr + "\n" +
+            "], \n" +
+            "\"index_permissions\": [\n" +
+                "{" +
+                    "\"fls\": [], " +
+                    "\"masked_fields\": [], " +
+                    "\"allowed_actions\": [" + indexPermissionsStr + "], " +
+                    "\"index_patterns\": [" + indexPatternsStr + "]" +
+                "}" +
+            "], " +
+            "\"tenant_permissions\": []" +
+            "}";
+
+        request.setJsonEntity(entity);
+        client().performRequest(request);
+    }
 
     protected void createCustomRole(String name, String clusterPermissions) throws IOException {
         Request request = new Request("PUT", String.format(Locale.getDefault(), "/_plugins/_security/api/roles/%s", name));
@@ -1009,7 +1074,7 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
         client().performRequest(request);
     }
 
-    protected void  createUser(String name, String passwd, String[] backendRoles) throws IOException {
+    public void  createUser(String name, String passwd, String[] backendRoles) throws IOException {
         Request request = new Request("PUT", String.format(Locale.getDefault(), "/_plugins/_security/api/internalusers/%s", name));
         String broles = String.join(",", backendRoles);
         //String roles = String.join(",", customRoles);
@@ -1048,17 +1113,44 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
         createUserRolesMapping(roleName, users);
     }
 
+    protected void  createUserWithDataAndCustomRole(String userName, String userPasswd, String roleName, String[] backendRoles, List<String> clusterPermissions, List<String> indexPermissions, List<String> indexPatterns) throws IOException {
+        String[] users = {userName};
+        createUser(userName, userPasswd, backendRoles);
+        createIndexRole(roleName, clusterPermissions, indexPermissions, indexPatterns);
+        createUserRolesMapping(roleName, users);
+    }
+
     protected void  createUserWithData(String userName, String userPasswd, String roleName, String[] backendRoles ) throws IOException {
         String[] users = {userName};
         createUser(userName, userPasswd, backendRoles);
         createUserRolesMapping(roleName, users);
     }
 
-
+    public void createUserWithTestData(String user, String index, String role, String [] backendRoles, List<String> indexPermissions) throws IOException{
+        String[] users = {user};
+        createUser(user, user, backendRoles);
+        createTestIndex(client(), index, windowsIndexMapping(), Settings.EMPTY);
+        createIndexRole(role, Collections.emptyList(), indexPermissions, List.of(index));
+        createUserRolesMapping(role, users);
+    }
 
     protected void deleteUser(String name) throws IOException {
         Request request = new Request("DELETE", String.format(Locale.getDefault(), "/_plugins/_security/api/internalusers/%s", name));
         client().performRequest(request);
+    }
+
+    protected void tryDeletingRole(String name) throws IOException{
+        Response response;
+        try {
+            response = client().performRequest(new Request("GET", String.format(Locale.getDefault(), "/_plugins/_security/api/roles/%s", name)));
+        } catch (ResponseException ex) {
+            response = ex.getResponse();
+        }
+        // Role already exists
+        if(response.getStatusLine().getStatusCode() == RestStatus.OK.getStatus()) {
+            Request request = new Request("DELETE", String.format(Locale.getDefault(), "/_plugins/_security/api/roles/%s", name));
+            client().performRequest(request);
+        }
     }
 
     @Override

--- a/src/test/java/org/opensearch/securityanalytics/alerts/SecureAlertsRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/alerts/SecureAlertsRestApiIT.java
@@ -22,7 +22,6 @@ import org.opensearch.rest.RestStatus;
 import org.opensearch.search.SearchHit;
 import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
 import org.opensearch.securityanalytics.SecurityAnalyticsRestTestCase;
-import org.opensearch.securityanalytics.action.AlertDto;
 import org.opensearch.securityanalytics.config.monitors.DetectorMonitorConfig;
 import org.opensearch.securityanalytics.model.Detector;
 import org.opensearch.securityanalytics.model.DetectorInput;
@@ -34,7 +33,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.opensearch.securityanalytics.TestHelpers.*;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.*;
 
 public class SecureAlertsRestApiIT extends SecurityAnalyticsRestTestCase {
 
@@ -63,252 +61,271 @@ public class SecureAlertsRestApiIT extends SecurityAnalyticsRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testGetAlerts_byDetectorId_success() throws IOException {
-        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+        try {
+            String index = createTestIndex(randomIndex(), windowsIndexMapping());
+            // Assign a role to the index
+            createIndexRole(TEST_HR_ROLE, Collections.emptyList(), indexPermissions, List.of(index));
+            String[] users = {user};
+            // Assign a role to existing user
+            createUserRolesMapping(TEST_HR_ROLE, users);
 
-        String rule = randomRule();
+            String rule = randomRule();
 
-        Response createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.RULE_BASE_URI, Collections.singletonMap("category", randomDetectorType()),
+            Response createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.RULE_BASE_URI, Collections.singletonMap("category", randomDetectorType()),
                 new StringEntity(rule), new BasicHeader("Content-Type", "application/json"));
-        Assert.assertEquals("Create rule failed", RestStatus.CREATED, restStatus(createResponse));
+            Assert.assertEquals("Create rule failed", RestStatus.CREATED, restStatus(createResponse));
 
-        Map<String, Object> responseBody = asMap(createResponse);
+            Map<String, Object> responseBody = asMap(createResponse);
 
-        String createdId = responseBody.get("_id").toString();
+            String createdId = responseBody.get("_id").toString();
 
-        // Execute CreateMappingsAction to add alias mapping for index
-        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
-        // both req params and req body are supported
-        createMappingRequest.setJsonEntity(
+            // Execute CreateMappingsAction to add alias mapping for index
+            Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+            // both req params and req body are supported
+            createMappingRequest.setJsonEntity(
                 "{ \"index_name\":\"" + index + "\"," +
-                        "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
-                        "  \"partial\":true" +
-                        "}"
-        );
+                    "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                    "  \"partial\":true" +
+                    "}"
+            );
 
-        Response response = userClient.performRequest(createMappingRequest);
-        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+            Response response = userClient.performRequest(createMappingRequest);
+            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
 
-        createAlertingMonitorConfigIndex(null);
-        Action triggerAction = randomAction(createDestination());
+            createAlertingMonitorConfigIndex(null);
+            Action triggerAction = randomAction(createDestination());
 
-        Detector detector = randomDetectorWithInputsAndTriggers(List.of(new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(createdId)),
-                        getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()))),
+            Detector detector = randomDetectorWithInputsAndTriggers(List.of(new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(createdId)),
+                    getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()))),
                 List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(), List.of(createdId), List.of(), List.of("attack.defense_evasion"), List.of(triggerAction))));
 
-        createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
-        Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+            createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+            Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
 
-        responseBody = asMap(createResponse);
+            responseBody = asMap(createResponse);
 
-        createdId = responseBody.get("_id").toString();
+            createdId = responseBody.get("_id").toString();
 
-        String request = "{\n" +
+            String request = "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match\":{\n" +
                 "        \"_id\": \"" + createdId + "\"\n" +
                 "     }\n" +
                 "   }\n" +
                 "}";
-        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
-        SearchHit hit = hits.get(0);
+            List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+            SearchHit hit = hits.get(0);
 
-        String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
+            String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
 
-        indexDoc(index, "1", randomDoc());
+            indexDoc(index, "1", randomDoc());
 
-        Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
-        Map<String, Object> executeResults = entityAsMap(executeResponse);
+            Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+            Map<String, Object> executeResults = entityAsMap(executeResponse);
 
-        int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
-        Assert.assertEquals(6, noOfSigmaRuleMatches);
+            int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+            Assert.assertEquals(6, noOfSigmaRuleMatches);
 
-        Assert.assertEquals(1, ((Map<String, Object>) executeResults.get("trigger_results")).values().size());
+            Assert.assertEquals(1, ((Map<String, Object>) executeResults.get("trigger_results")).values().size());
 
-        for (Map.Entry<String, Map<String, Object>> triggerResult: ((Map<String, Map<String, Object>>) executeResults.get("trigger_results")).entrySet()) {
-            Assert.assertEquals(1, ((Map<String, Object>) triggerResult.getValue().get("action_results")).values().size());
+            for (Map.Entry<String, Map<String, Object>> triggerResult: ((Map<String, Map<String, Object>>) executeResults.get("trigger_results")).entrySet()) {
+                Assert.assertEquals(1, ((Map<String, Object>) triggerResult.getValue().get("action_results")).values().size());
 
-            for (Map.Entry<String, Map<String, Object>> alertActionResult: ((Map<String, Map<String, Object>>) triggerResult.getValue().get("action_results")).entrySet()) {
-                Map<String, Object> actionResults = alertActionResult.getValue();
+                for (Map.Entry<String, Map<String, Object>> alertActionResult: ((Map<String, Map<String, Object>>) triggerResult.getValue().get("action_results")).entrySet()) {
+                    Map<String, Object> actionResults = alertActionResult.getValue();
 
-                for (Map.Entry<String, Object> actionResult: actionResults.entrySet()) {
-                    Map<String, String> actionOutput = ((Map<String, Map<String, String>>) actionResult.getValue()).get("output");
-                    String expectedMessage = triggerAction.getSubjectTemplate().getIdOrCode().replace("{{ctx.detector.name}}", detector.getName())
+                    for (Map.Entry<String, Object> actionResult: actionResults.entrySet()) {
+                        Map<String, String> actionOutput = ((Map<String, Map<String, String>>) actionResult.getValue()).get("output");
+                        String expectedMessage = triggerAction.getSubjectTemplate().getIdOrCode().replace("{{ctx.detector.name}}", detector.getName())
                             .replace("{{ctx.trigger.name}}", "test-trigger").replace("{{ctx.trigger.severity}}", "1");
 
-                    Assert.assertEquals(expectedMessage, actionOutput.get("subject"));
-                    Assert.assertEquals(expectedMessage, actionOutput.get("message"));
+                        Assert.assertEquals(expectedMessage, actionOutput.get("subject"));
+                        Assert.assertEquals(expectedMessage, actionOutput.get("message"));
+                    }
                 }
             }
-        }
 
-        request = "{\n" +
+            request = "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match_all\":{\n" +
                 "     }\n" +
                 "   }\n" +
                 "}";
-        hits = new ArrayList<>();
+            hits = new ArrayList<>();
 
-        while (hits.size() == 0) {
-            hits = executeSearch(DetectorMonitorConfig.getAlertsIndex(randomDetectorType()), request);
-        }
+            while (hits.size() == 0) {
+                hits = executeSearch(DetectorMonitorConfig.getAlertsIndex(randomDetectorType()), request);
+            }
 
-        // try to do get finding as a user with read access
-        String userRead = "userReadAlert";
-        String[] backendRoles = { TEST_IT_BACKEND_ROLE };
-        createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, backendRoles );
-        RestClient userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
+            // try to do get finding as a user with read access
+            String userRead = "userReadAlert";
+            String[] backendRoles = { TEST_IT_BACKEND_ROLE };
+            createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, backendRoles );
+            RestClient userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
 
-        // Call GetAlerts API
-        Map<String, String> params = new HashMap<>();
-        params.put("detector_id", createdId);
-        Response getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
-        Map<String, Object> getAlertsBody = asMap(getAlertsResponse);
-        Assert.assertEquals(1, getAlertsBody.get("total_alerts"));
+            // Call GetAlerts API
+            Map<String, String> params = new HashMap<>();
+            params.put("detector_id", createdId);
+            Response getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
+            Map<String, Object> getAlertsBody = asMap(getAlertsResponse);
+            Assert.assertEquals(1, getAlertsBody.get("total_alerts"));
 
-        // Enable backend filtering and try to read finding as a user with no backend roles matching the user who created the detector
-        enableOrDisableFilterBy("true");
-        try {
+            // Enable backend filtering and try to read finding as a user with no backend roles matching the user who created the detector
+            enableOrDisableFilterBy("true");
+            try {
+                getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
+            } catch (ResponseException e)
+            {
+                assertEquals("Get alert failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
+            }
+            finally {
+                userReadOnlyClient.close();
+                deleteUser(userRead);
+            }
+
+            // recreate user with matching backend roles and try again
+            String[] newBackendRoles = { TEST_HR_BACKEND_ROLE };
+            createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, newBackendRoles );
+            userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
             getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
-        } catch (ResponseException e)
-        {
-            assertEquals("Get alert failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
-        }
-        finally {
+            getAlertsBody = asMap(getAlertsResponse);
+            Assert.assertEquals(1, getAlertsBody.get("total_alerts"));
             userReadOnlyClient.close();
-            deleteUser(userRead);
+
+            // update user with no backend roles and try again
+            createUser(userRead, userRead, EMPTY_ARRAY);
+            userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
+            try {
+                getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
+            } catch (ResponseException e)
+            {
+                assertEquals("Get alert failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
+            }
+            finally {
+                userReadOnlyClient.close();
+                deleteUser(userRead);
+            }
+        } finally {
+            tryDeletingRole(TEST_HR_ROLE);
         }
 
-        // recreate user with matching backend roles and try again
-        String[] newBackendRoles = { TEST_HR_BACKEND_ROLE };
-        createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, newBackendRoles );
-        userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
-        getAlertsBody = asMap(getAlertsResponse);
-        Assert.assertEquals(1, getAlertsBody.get("total_alerts"));
-        userReadOnlyClient.close();
-
-        // update user with no backend roles and try again
-        createUser(userRead, userRead, EMPTY_ARRAY);
-        userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        try {
-            getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
-        } catch (ResponseException e)
-        {
-            assertEquals("Get alert failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
-        }
-        finally {
-            userReadOnlyClient.close();
-            deleteUser(userRead);
-        }
     }
 
 
     public void testGetAlerts_byDetectorType_success() throws IOException, InterruptedException {
-        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+        try {
+            String index = createTestIndex(randomIndex(), windowsIndexMapping());
+            // Assign a role to the index
+            createIndexRole(TEST_HR_ROLE, Collections.emptyList(), indexPermissions, List.of(index));
+            String[] users = {user};
+            // Assign a role to existing user
+            createUserRolesMapping(TEST_HR_ROLE, users);
 
-        // Execute CreateMappingsAction to add alias mapping for index
-        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
-        // both req params and req body are supported
-        createMappingRequest.setJsonEntity(
+            // Execute CreateMappingsAction to add alias mapping for index
+            Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+            // both req params and req body are supported
+            createMappingRequest.setJsonEntity(
                 "{ \"index_name\":\"" + index + "\"," +
-                        "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
-                        "  \"partial\":true" +
-                        "}"
-        );
+                    "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                    "  \"partial\":true" +
+                    "}"
+            );
 
-        Response response = userClient.performRequest(createMappingRequest);
-        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+            Response response = userClient.performRequest(createMappingRequest);
+            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
 
-        Detector detector = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of())));
+            Detector detector = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of())));
 
-        Response createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
-        Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+            Response createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+            Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
 
-        Map<String, Object> responseBody = asMap(createResponse);
+            Map<String, Object> responseBody = asMap(createResponse);
 
-        String createdId = responseBody.get("_id").toString();
+            String createdId = responseBody.get("_id").toString();
 
-        String request = "{\n" +
+            String request = "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match\":{\n" +
                 "        \"_id\": \"" + createdId + "\"\n" +
                 "     }\n" +
                 "   }\n" +
                 "}";
-        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
-        SearchHit hit = hits.get(0);
+            List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+            SearchHit hit = hits.get(0);
 
-        String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
+            String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
 
-        indexDoc(index, "1", randomDoc());
+            indexDoc(index, "1", randomDoc());
 
-        client().performRequest(new Request("POST", "_refresh"));
+            client().performRequest(new Request("POST", "_refresh"));
 
-        Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
-        Map<String, Object> executeResults = entityAsMap(executeResponse);
-        int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
-        Assert.assertEquals(5, noOfSigmaRuleMatches);
+            Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+            Map<String, Object> executeResults = entityAsMap(executeResponse);
+            int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+            Assert.assertEquals(5, noOfSigmaRuleMatches);
 
-        request = "{\n" +
+            request = "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match_all\":{\n" +
                 "     }\n" +
                 "   }\n" +
                 "}";
-        hits = new ArrayList<>();
+            hits = new ArrayList<>();
 
-        while (hits.size() == 0) {
-            hits = executeSearch(DetectorMonitorConfig.getAlertsIndex(randomDetectorType()), request);
-        }
+            while (hits.size() == 0) {
+                hits = executeSearch(DetectorMonitorConfig.getAlertsIndex(randomDetectorType()), request);
+            }
 
-        // try to do get finding as a user with read access
-        String userRead = "userReadAlert";
-        String[] backendRoles = { TEST_IT_BACKEND_ROLE };
-        createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, backendRoles );
-        RestClient userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
+            // try to do get finding as a user with read access
+            String userRead = "userReadAlert";
+            String[] backendRoles = { TEST_IT_BACKEND_ROLE };
+            createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, backendRoles );
+            RestClient userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
 
-        // Call GetAlerts API
-        Map<String, String> params = new HashMap<>();
-        params.put("detectorType", randomDetectorType());
-        Response getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
-        Map<String, Object> getAlertsBody = asMap(getAlertsResponse);
-        Assert.assertEquals(1, getAlertsBody.get("total_alerts"));
+            // Call GetAlerts API
+            Map<String, String> params = new HashMap<>();
+            params.put("detectorType", randomDetectorType());
+            Response getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
+            Map<String, Object> getAlertsBody = asMap(getAlertsResponse);
+            Assert.assertEquals(1, getAlertsBody.get("total_alerts"));
 
-        // Enable backend filtering and try to read finding as a user with no backend roles matching the user who created the detector
-        enableOrDisableFilterBy("true");
-        try {
+            // Enable backend filtering and try to read finding as a user with no backend roles matching the user who created the detector
+            enableOrDisableFilterBy("true");
+            try {
+                getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
+            } catch (ResponseException e)
+            {
+                assertEquals("Get alert failed", RestStatus.NOT_FOUND, restStatus(e.getResponse()));
+            }
+            finally {
+                userReadOnlyClient.close();
+                deleteUser(userRead);
+            }
+
+            // recreate user with matching backend roles and try again
+            String[] newBackendRoles = { TEST_HR_BACKEND_ROLE };
+            createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, newBackendRoles );
+            userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
             getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
-        } catch (ResponseException e)
-        {
-            assertEquals("Get alert failed", RestStatus.NOT_FOUND, restStatus(e.getResponse()));
-        }
-        finally {
+            getAlertsBody = asMap(getAlertsResponse);
+            Assert.assertEquals(1, getAlertsBody.get("total_alerts"));
             userReadOnlyClient.close();
-            deleteUser(userRead);
-        }
 
-        // recreate user with matching backend roles and try again
-        String[] newBackendRoles = { TEST_HR_BACKEND_ROLE };
-        createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, newBackendRoles );
-        userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
-        getAlertsBody = asMap(getAlertsResponse);
-        Assert.assertEquals(1, getAlertsBody.get("total_alerts"));
-        userReadOnlyClient.close();
-
-        // update user with no backend roles and try again
-        createUser(userRead, userRead, EMPTY_ARRAY);
-        userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        try {
-            getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
-        } catch (ResponseException e)
-        {
-            assertEquals("Get alert failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
-        }
-        finally {
-            userReadOnlyClient.close();
-            deleteUser(userRead);
+            // update user with no backend roles and try again
+            createUser(userRead, userRead, EMPTY_ARRAY);
+            userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
+            try {
+                getAlertsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params, null);
+            } catch (ResponseException e)
+            {
+                assertEquals("Get alert failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
+            }
+            finally {
+                userReadOnlyClient.close();
+                deleteUser(userRead);
+            }
+        } finally {
+            tryDeletingRole(TEST_HR_ROLE);
         }
     }
 

--- a/src/test/java/org/opensearch/securityanalytics/findings/SecureFindingRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/findings/SecureFindingRestApiIT.java
@@ -66,248 +66,269 @@ public class SecureFindingRestApiIT extends SecurityAnalyticsRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testGetFindings_byDetectorId_success() throws IOException {
-        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+        try {
+            String index = createTestIndex(randomIndex(), windowsIndexMapping());
+            // Assign a role to the index
+            createIndexRole(TEST_HR_ROLE, Collections.emptyList(), indexPermissions, List.of(index));
+            String[] users = {user};
+            // Assign a role to existing user
+            createUserRolesMapping(TEST_HR_ROLE, users);
 
-        // Execute CreateMappingsAction to add alias mapping for index
-        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
-        // both req params and req body are supported
-        createMappingRequest.setJsonEntity(
+            // Execute CreateMappingsAction to add alias mapping for index
+            Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+            // both req params and req body are supported
+            createMappingRequest.setJsonEntity(
                 "{ \"index_name\":\"" + index + "\"," +
-                        "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
-                        "  \"partial\":true" +
-                        "}"
-        );
+                    "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                    "  \"partial\":true" +
+                    "}"
+            );
 
-        Response response = userClient.performRequest(createMappingRequest);
-        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+            Response response = userClient.performRequest(createMappingRequest);
+            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
 
-        Detector detector = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of())));
+            Detector detector = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of())));
 
-        Response createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
-        Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+            Response createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+            Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
 
-        Map<String, Object> responseBody = asMap(createResponse);
+            Map<String, Object> responseBody = asMap(createResponse);
 
-        String createdId = responseBody.get("_id").toString();
+            String createdId = responseBody.get("_id").toString();
 
-        String request = "{\n" +
+            String request = "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match\":{\n" +
                 "        \"_id\": \"" + createdId + "\"\n" +
                 "     }\n" +
                 "   }\n" +
                 "}";
-        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
-        SearchHit hit = hits.get(0);
+            List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+            SearchHit hit = hits.get(0);
 
-        String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
+            String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
 
-        indexDoc(index, "1", randomDoc());
+            indexDoc(index, "1", randomDoc());
 
-        Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
-        Map<String, Object> executeResults = entityAsMap(executeResponse);
+            Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+            Map<String, Object> executeResults = entityAsMap(executeResponse);
 
-        int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
-        Assert.assertEquals(5, noOfSigmaRuleMatches);
+            int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+            Assert.assertEquals(5, noOfSigmaRuleMatches);
 
-        // try to do get finding as a user with read access
-        String userRead = "userReadFinding";
-        String[] backendRoles = { TEST_IT_BACKEND_ROLE };
-        createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, backendRoles );
-        RestClient userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        // Call GetFindings API
-        Map<String, String> params = new HashMap<>();
-        params.put("detector_id", createdId);
-        Response getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
-        Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
-        Assert.assertEquals(1, getFindingsBody.get("total_findings"));
+            // try to do get finding as a user with read access
+            String userRead = "userReadFinding";
+            String[] backendRoles = { TEST_IT_BACKEND_ROLE };
+            createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, backendRoles );
+            RestClient userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
+            // Call GetFindings API
+            Map<String, String> params = new HashMap<>();
+            params.put("detector_id", createdId);
+            Response getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+            Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+            Assert.assertEquals(1, getFindingsBody.get("total_findings"));
 
-        // Enable backend filtering and try to read finding as a user with no backend roles matching the user who created the detector
-        enableOrDisableFilterBy("true");
-        try {
+            // Enable backend filtering and try to read finding as a user with no backend roles matching the user who created the detector
+            enableOrDisableFilterBy("true");
+            try {
+                getFindingsResponse =  makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+            } catch (ResponseException e)
+            {
+                assertEquals("Get finding failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
+            }
+            finally {
+                userReadOnlyClient.close();
+                deleteUser(userRead);
+            }
+
+            // recreate user with matching backend roles and try again
+            String[] newBackendRoles = { TEST_HR_BACKEND_ROLE };
+            createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, newBackendRoles );
+            userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
             getFindingsResponse =  makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
-        } catch (ResponseException e)
-        {
-            assertEquals("Get finding failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
-        }
-        finally {
+            getFindingsBody = entityAsMap(getFindingsResponse);
+            Assert.assertEquals(1, getFindingsBody.get("total_findings"));
             userReadOnlyClient.close();
-            deleteUser(userRead);
-        }
 
-        // recreate user with matching backend roles and try again
-        String[] newBackendRoles = { TEST_HR_BACKEND_ROLE };
-        createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, newBackendRoles );
-        userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        getFindingsResponse =  makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
-        getFindingsBody = entityAsMap(getFindingsResponse);
-        Assert.assertEquals(1, getFindingsBody.get("total_findings"));
-        userReadOnlyClient.close();
+            // update user with no backend roles and try again
+            createUser(userRead, userRead, EMPTY_ARRAY);
+            userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
+            try {
+                getFindingsResponse =  makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+            } catch (ResponseException e)
+            {
+                assertEquals("Get finding failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
+            }
+            finally {
+                userReadOnlyClient.close();
+                deleteUser(userRead);
+            }
 
-        // update user with no backend roles and try again
-        createUser(userRead, userRead, EMPTY_ARRAY);
-        userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        try {
-            getFindingsResponse =  makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
-        } catch (ResponseException e)
-        {
-            assertEquals("Get finding failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
+        } finally {
+            tryDeletingRole(TEST_HR_ROLE);
         }
-        finally {
-            userReadOnlyClient.close();
-            deleteUser(userRead);
-        }
-
     }
-    
+
     public void testGetFindings_byDetectorType_success() throws IOException {
-        String index1 = createTestIndex(randomIndex(), windowsIndexMapping());
+        try {
+            String index1 = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        // Execute CreateMappingsAction to add alias mapping for index
-        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
-        // both req params and req body are supported
-        createMappingRequest.setJsonEntity(
+            // Execute CreateMappingsAction to add alias mapping for index
+            Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+            // both req params and req body are supported
+            createMappingRequest.setJsonEntity(
                 "{ \"index_name\":\"" + index1 + "\"," +
-                        "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
-                        "  \"partial\":true" +
-                        "}"
-        );
-        // index 2
-        String index2 = createTestIndex("netflow_test", netFlowMappings());
+                    "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                    "  \"partial\":true" +
+                    "}"
+            );
+            Response response = userClient.performRequest(createMappingRequest);
+            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
 
-        // Execute CreateMappingsAction to add alias mapping for index
-        createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
-        // both req params and req body are supported
-        createMappingRequest.setJsonEntity(
+            // index 2
+            String index2 = createTestIndex("netflow_test", netFlowMappings());
+
+            // Execute CreateMappingsAction to add alias mapping for index
+            createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+            // both req params and req body are supported
+            createMappingRequest.setJsonEntity(
                 "{ \"index_name\":\"" + index2 + "\"," +
-                        "  \"rule_topic\":\"netflow\", " +
-                        "  \"partial\":true" +
-                        "}"
-        );
+                    "  \"rule_topic\":\"netflow\", " +
+                    "  \"partial\":true" +
+                    "}"
+            );
 
-        Response response = userClient.performRequest(createMappingRequest);
-        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
-        // Detector 1 - WINDOWS
-        Detector detector1 = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of())));
-        Response createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector1));
-        Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+            response = userClient.performRequest(createMappingRequest);
+            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
 
-        Map<String, Object> responseBody = asMap(createResponse);
+            createIndexRole(TEST_HR_ROLE, Collections.emptyList(), indexPermissions, List.of(index1, index2));
+            String[] users = {user};
+            createUserRolesMapping(TEST_HR_ROLE, users);
 
-        String createdId = responseBody.get("_id").toString();
+            // Detector 1 - WINDOWS
+            Detector detector1 = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of())));
+            Response createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector1));
+            Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
 
-        String request = "{\n" +
+            Map<String, Object> responseBody = asMap(createResponse);
+
+            String createdId = responseBody.get("_id").toString();
+
+            String request = "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match\":{\n" +
                 "        \"_id\": \"" + createdId + "\"\n" +
                 "     }\n" +
                 "   }\n" +
                 "}";
-        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
-        SearchHit hit = hits.get(0);
-        String monitorId1 = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
-        // Detector 2 - NETWORK
-        DetectorInput inputNetflow = new DetectorInput("windows detector for security analytics", List.of("netflow_test"), Collections.emptyList(),
+            List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+            SearchHit hit = hits.get(0);
+            String monitorId1 = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
+            // Detector 2 - NETWORK
+            DetectorInput inputNetflow = new DetectorInput("windows detector for security analytics", List.of("netflow_test"), Collections.emptyList(),
                 getPrePackagedRules("network").stream().map(DetectorRule::new).collect(Collectors.toList()));
-        Detector detector2 = randomDetectorWithTriggers(
+            Detector detector2 = randomDetectorWithTriggers(
                 getPrePackagedRules("network"),
                 List.of(new DetectorTrigger(null, "test-trigger", "1", List.of("network"), List.of(), List.of(), List.of(), List.of())),
                 Detector.DetectorType.NETWORK,
                 inputNetflow
-        );
+            );
 
-        createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector2));
-        Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+            createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector2));
+            Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
 
-        responseBody = asMap(createResponse);
+            responseBody = asMap(createResponse);
 
-        createdId = responseBody.get("_id").toString();
+            createdId = responseBody.get("_id").toString();
 
-        request = "{\n" +
+            request = "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match\":{\n" +
                 "        \"_id\": \"" + createdId + "\"\n" +
                 "     }\n" +
                 "   }\n" +
                 "}";
-        hits = executeSearch(Detector.DETECTORS_INDEX, request);
-        hit = hits.get(0);
-        String monitorId2 = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
+            hits = executeSearch(Detector.DETECTORS_INDEX, request);
+            hit = hits.get(0);
+            String monitorId2 = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
 
-        indexDoc(index1, "1", randomDoc());
-        indexDoc(index2, "1", randomDoc());
-        // execute monitor 1
-        Response executeResponse = executeAlertingMonitor(monitorId1, Collections.emptyMap());
-        Map<String, Object> executeResults = entityAsMap(executeResponse);
+            indexDoc(index1, "1", randomDoc());
+            indexDoc(index2, "1", randomDoc());
+            // execute monitor 1
+            Response executeResponse = executeAlertingMonitor(monitorId1, Collections.emptyMap());
+            Map<String, Object> executeResults = entityAsMap(executeResponse);
 
-        int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
-        Assert.assertEquals(3, noOfSigmaRuleMatches);
+            int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+            Assert.assertEquals(5, noOfSigmaRuleMatches);
 
-        // execute monitor 2
-        executeResponse = executeAlertingMonitor(monitorId2, Collections.emptyMap());
-        executeResults = entityAsMap(executeResponse);
+            // execute monitor 2
+            executeResponse = executeAlertingMonitor(monitorId2, Collections.emptyMap());
+            executeResults = entityAsMap(executeResponse);
 
-        noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
-        Assert.assertEquals(1, noOfSigmaRuleMatches);
+            noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+            Assert.assertEquals(1, noOfSigmaRuleMatches);
 
-        client().performRequest(new Request("POST", "_refresh"));
-
-
-        // try to do get finding as a user with read access
-        String userRead = "userReadFinding";
-        String[] backendRoles = { TEST_IT_BACKEND_ROLE };
-        createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, backendRoles );
-        RestClient userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
+            client().performRequest(new Request("POST", "_refresh"));
 
 
-        // Call GetFindings API for first detector
-        Map<String, String> params = new HashMap<>();
-        params.put("detectorType", detector1.getDetectorType().toUpperCase());
-        Response getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
-        Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
-        Assert.assertEquals(1, getFindingsBody.get("total_findings"));
-        // Call GetFindings API for second detector
-        params.clear();
-        params.put("detectorType", detector2.getDetectorType().toUpperCase());
-        getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
-        getFindingsBody = entityAsMap(getFindingsResponse);
-        Assert.assertEquals(1, getFindingsBody.get("total_findings"));
+            // try to do get finding as a user with read access
+            String userRead = "userReadFinding";
+            String[] backendRoles = { TEST_IT_BACKEND_ROLE };
+            createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, backendRoles );
+            RestClient userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
 
-        // Enable backend filtering and try to read finding as a user with no backend roles matching the user who created the detector
-        enableOrDisableFilterBy("true");
-        try {
+
+            // Call GetFindings API for first detector
+            Map<String, String> params = new HashMap<>();
+            params.put("detectorType", detector1.getDetectorType().toUpperCase());
+            Response getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+            Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+            Assert.assertEquals(1, getFindingsBody.get("total_findings"));
+            // Call GetFindings API for second detector
+            params.clear();
+            params.put("detectorType", detector2.getDetectorType().toUpperCase());
             getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
-        } catch (ResponseException e)
-        {
-            assertEquals("Get finding failed", RestStatus.NOT_FOUND, restStatus(e.getResponse()));
-        }
-        finally {
+            getFindingsBody = entityAsMap(getFindingsResponse);
+            Assert.assertEquals(1, getFindingsBody.get("total_findings"));
+
+            // Enable backend filtering and try to read finding as a user with no backend roles matching the user who created the detector
+            enableOrDisableFilterBy("true");
+            try {
+                getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+            } catch (ResponseException e)
+            {
+                assertEquals("Get finding failed", RestStatus.NOT_FOUND, restStatus(e.getResponse()));
+            }
+            finally {
+                userReadOnlyClient.close();
+                deleteUser(userRead);
+            }
+
+            // recreate user with matching backend roles and try again
+            String[] newBackendRoles = { TEST_HR_BACKEND_ROLE };
+            createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, newBackendRoles );
+            userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
+            getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+            getFindingsBody = entityAsMap(getFindingsResponse);
+            Assert.assertEquals(1, getFindingsBody.get("total_findings"));
             userReadOnlyClient.close();
-            deleteUser(userRead);
-        }
-
-        // recreate user with matching backend roles and try again
-        String[] newBackendRoles = { TEST_HR_BACKEND_ROLE };
-        createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, newBackendRoles );
-        userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
-        getFindingsBody = entityAsMap(getFindingsResponse);
-        Assert.assertEquals(1, getFindingsBody.get("total_findings"));
-        userReadOnlyClient.close();
 
 
-        // update user with no backend roles and try again
-        createUser(userRead, userRead, EMPTY_ARRAY);
-        userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        try {
-            getFindingsResponse =  makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
-        } catch (ResponseException e)
-        {
-            assertEquals("Get finding failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
-        }
-        finally {
-            userReadOnlyClient.close();
-            deleteUser(userRead);
+            // update user with no backend roles and try again
+            createUser(userRead, userRead, EMPTY_ARRAY);
+            userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
+            try {
+                getFindingsResponse =  makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+            } catch (ResponseException e)
+            {
+                assertEquals("Get finding failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
+            }
+            finally {
+                userReadOnlyClient.close();
+                deleteUser(userRead);
+            }
+        } finally {
+            tryDeletingRole(TEST_HR_ROLE);
         }
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SecureDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SecureDetectorRestApiIT.java
@@ -38,11 +38,8 @@ public class SecureDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
     static String SECURITY_ANALYTICS_FULL_ACCESS_ROLE = "security_analytics_full_access";
     static String SECURITY_ANALYTICS_READ_ACCESS_ROLE = "security_analytics_read_access";
     static String TEST_HR_BACKEND_ROLE = "HR";
-    static String CUSTOM_HR_ROLE = "HR";
 
     static String TEST_IT_BACKEND_ROLE = "IT";
-
-
 
     static Map<String, String> roleToPermissionsMap = Map.ofEntries(
             Map.entry(SECURITY_ANALYTICS_FULL_ACCESS_ROLE, "cluster:admin/opendistro/securityanalytics/detector/*"),
@@ -70,102 +67,109 @@ public class SecureDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testCreateDetectorWithFullAccess() throws IOException {
-        String[] users = {user};
-        //createUserRolesMapping("alerting_full_access", users);
-        String index = createTestIndex(client(), randomIndex(), windowsIndexMapping(), Settings.EMPTY);
+        try {
+            String index = createTestIndex(randomIndex(), windowsIndexMapping());
+            // Assign a role to the index
+            createIndexRole(TEST_HR_ROLE, Collections.emptyList(), indexPermissions, List.of(index));
+            String[] users = {user};
+            // Assign a role to existing user
+            createUserRolesMapping(TEST_HR_ROLE, users);
 
-        // Execute CreateMappingsAction to add alias mapping for index
-        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
-        // both req params and req body are supported
-        createMappingRequest.setJsonEntity(
+            // Execute CreateMappingsAction to add alias mapping for index
+            Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+            // both req params and req body are supported
+            createMappingRequest.setJsonEntity(
                 "{ \"index_name\":\"" + index + "\"," +
-                        "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
-                        "  \"partial\":true" +
-                        "}"
-        );
+                    "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                    "  \"partial\":true" +
+                    "}"
+            );
 
-        Response response = userClient.performRequest(createMappingRequest);
-        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+            Response response = userClient.performRequest(createMappingRequest);
+            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
 
-        Detector detector = randomDetector(getRandomPrePackagedRules());
+            Detector detector = randomDetector(getRandomPrePackagedRules());
 
-        Response createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
-        Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+            Response createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+            Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
 
-        Map<String, Object> responseBody = asMap(createResponse);
+            Map<String, Object> responseBody = asMap(createResponse);
 
-        String createdId = responseBody.get("_id").toString();
-        int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
-        Assert.assertNotEquals("response is missing Id", Detector.NO_ID, createdId);
-        Assert.assertTrue("incorrect version", createdVersion > 0);
-        Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, createdId), createResponse.getHeader("Location"));
-        Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("rule_topic_index"));
-        Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("findings_index"));
-        Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("alert_index"));
+            String createdId = responseBody.get("_id").toString();
+            int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+            Assert.assertNotEquals("response is missing Id", Detector.NO_ID, createdId);
+            Assert.assertTrue("incorrect version", createdVersion > 0);
+            Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, createdId), createResponse.getHeader("Location"));
+            Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("rule_topic_index"));
+            Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("findings_index"));
+            Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("alert_index"));
 
-        String request = "{\n" +
+            String request = "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match\":{\n" +
                 "        \"_id\": \"" + createdId + "\"\n" +
                 "     }\n" +
                 "   }\n" +
                 "}";
-        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
-        SearchHit hit = hits.get(0);
+            List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+            SearchHit hit = hits.get(0);
 
-        String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
+            String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
 
-        indexDoc(index, "1", randomDoc());
+            indexDoc(index, "1", randomDoc());
 
-        Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
-        Map<String, Object> executeResults = entityAsMap(executeResponse);
+            Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+            Map<String, Object> executeResults = entityAsMap(executeResponse);
 
-        int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
-        Assert.assertEquals(5, noOfSigmaRuleMatches);
+            int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+            Assert.assertEquals(5, noOfSigmaRuleMatches);
 
-        // try to do get detector as a user with read access
-        String userRead = "userRead";
-        String[] backendRoles = { TEST_IT_BACKEND_ROLE };
-        createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, backendRoles );
-        RestClient userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        Response getResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + createdId, Collections.emptyMap(), null);
-        Map<String, Object> getResponseBody = asMap(getResponse);
-        Assert.assertEquals(createdId, getResponseBody.get("_id"));
+            // try to do get detector as a user with read access
+            String userRead = "userRead";
+            String[] backendRoles = { TEST_IT_BACKEND_ROLE };
+            createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, backendRoles );
+            RestClient userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
+            Response getResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + createdId, Collections.emptyMap(), null);
+            Map<String, Object> getResponseBody = asMap(getResponse);
+            Assert.assertEquals(createdId, getResponseBody.get("_id"));
 
 
-        // Enable backend filtering and try to read detector as a user with no backend roles matching the user who created the detector
-        enableOrDisableFilterBy("true");
-        try {
+            // Enable backend filtering and try to read detector as a user with no backend roles matching the user who created the detector
+            enableOrDisableFilterBy("true");
+            try {
+                getResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + createdId, Collections.emptyMap(), null);
+            } catch (ResponseException e)
+            {
+                assertEquals("Get detector failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
+            }
+            finally {
+                userReadOnlyClient.close();
+                deleteUser(userRead);
+            }
+
+            // recreate user with matching backend roles and try again
+            String[] newBackendRoles = { TEST_HR_BACKEND_ROLE };
+            createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, newBackendRoles );
+            userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
             getResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + createdId, Collections.emptyMap(), null);
-        } catch (ResponseException e)
-        {
-            assertEquals("Get detector failed", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
-        }
-        finally {
-            userReadOnlyClient.close();
-            deleteUser(userRead);
-        }
-
-        // recreate user with matching backend roles and try again
-        String[] newBackendRoles = { TEST_HR_BACKEND_ROLE };
-        createUserWithData( userRead, userRead, SECURITY_ANALYTICS_READ_ACCESS_ROLE, newBackendRoles );
-        userReadOnlyClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userRead, userRead).setSocketTimeout(60000).build();
-        getResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + createdId, Collections.emptyMap(), null);
-        getResponseBody = asMap(getResponse);
-        Assert.assertEquals(createdId, getResponseBody.get("_id"));
+            getResponseBody = asMap(getResponse);
+            Assert.assertEquals(createdId, getResponseBody.get("_id"));
 
         //Search on id should give one result
-        String queryJson = "{ \"query\": { \"match\": { \"_id\" : \"" + createdId + "\"} } }";
-        HttpEntity requestEntity = new NStringEntity(queryJson, ContentType.APPLICATION_JSON);
-        Response searchResponse = makeRequest(userReadOnlyClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + "_search", Collections.emptyMap(), requestEntity);
-        Map<String, Object> searchResponseBody = asMap(searchResponse);
-        Assert.assertNotNull("response is not null", searchResponseBody);
-        Map<String, Object> searchResponseHits = (Map) searchResponseBody.get("hits");
-        Map<String, Object> searchResponseTotal = (Map) searchResponseHits.get("total");
-        Assert.assertEquals(1, searchResponseTotal.get("value"));
+            String queryJson = "{ \"query\": { \"match\": { \"_id\" : \"" + createdId + "\"} } }";
+            HttpEntity requestEntity = new NStringEntity(queryJson, ContentType.APPLICATION_JSON);
+            Response searchResponse = makeRequest(userReadOnlyClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + "_search", Collections.emptyMap(), requestEntity);
+            Map<String, Object> searchResponseBody = asMap(searchResponse);
+            Assert.assertNotNull("response is not null", searchResponseBody);
+            Map<String, Object> searchResponseHits = (Map) searchResponseBody.get("hits");
+            Map<String, Object> searchResponseTotal = (Map) searchResponseHits.get("total");
+            Assert.assertEquals(1, searchResponseTotal.get("value"));
 
-        userReadOnlyClient.close();
-        deleteUser(userRead);
+            userReadOnlyClient.close();
+            deleteUser(userRead);
+        }  finally {
+            tryDeletingRole(TEST_HR_ROLE);
+        }
     }
 
     public void testCreateDetectorWithNoBackendRoles() throws IOException {
@@ -202,6 +206,152 @@ public class SecureDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         finally {
             userFullClient.close();
             deleteUser(userFull);
+        }
+    }
+
+    /**
+     * 1. Tries to create a detector as a user without access to the given index pattern and verifies that it is forbidden
+     * 2. Creates a detector as a user with access to a given index
+     * @throws IOException
+     */
+    public void testCreateDetectorIndexAccess() throws IOException {
+        String[] backendRoles = { TEST_IT_BACKEND_ROLE };
+
+        String userWithoutAccess = "user";
+        String roleNameWithoutIndexPatternAccess = "test-role";
+        String testIndexPattern = "test*";
+        createUserWithDataAndCustomRole(userWithoutAccess, userWithoutAccess, roleNameWithoutIndexPatternAccess, backendRoles, clusterPermissions, indexPermissions, List.of(testIndexPattern));
+        RestClient clientWithoutAccess = null;
+
+        String userWithAccess = "user1";
+        String roleNameWithIndexPatternAccess = "test-role-1";
+        String windowsIndexPattern = "windows*";
+        createUserWithDataAndCustomRole(userWithAccess, userWithAccess, roleNameWithIndexPatternAccess, backendRoles, clusterPermissions, indexPermissions, List.of(windowsIndexPattern));
+        RestClient clientWithAccess = null;
+        try {
+            clientWithoutAccess =  new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userWithoutAccess, userWithoutAccess).setSocketTimeout(60000).build();
+            clientWithAccess = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userWithAccess, userWithAccess).setSocketTimeout(60000).build();
+            //createUserRolesMapping("alerting_full_access", users);
+            String index = createTestIndex(client(), randomIndex(), windowsIndexMapping(), Settings.EMPTY);
+
+            // Execute CreateMappingsAction to add alias mapping for index
+            Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+            // both req params and req body are supported
+            createMappingRequest.setJsonEntity(
+                "{ \"index_name\":\"" + index + "\"," +
+                    "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                    "  \"partial\":true" +
+                    "}"
+            );
+            Response response = userClient.performRequest(createMappingRequest);
+            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+            Detector detector = randomDetector(getRandomPrePackagedRules());
+
+            try {
+                makeRequest(clientWithoutAccess, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+            } catch (ResponseException e) {
+                assertEquals("Create detector error status", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
+            }
+
+            Response createResponse = makeRequest(clientWithAccess, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+            assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+
+            Map<String, Object> responseBody = asMap(createResponse);
+
+            String createdId = responseBody.get("_id").toString();
+            int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+
+            assertNotEquals("response is missing Id", Detector.NO_ID, createdId);
+            assertTrue("incorrect version", createdVersion > 0);
+            assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, createdId), createResponse.getHeader("Location"));
+            assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("rule_topic_index"));
+            assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("findings_index"));
+            assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("alert_index"));
+        } finally {
+            if(clientWithoutAccess!= null) clientWithoutAccess.close();
+            deleteUser(userWithoutAccess);
+            tryDeletingRole(roleNameWithoutIndexPatternAccess);
+
+            if (clientWithAccess != null) clientWithAccess.close();
+            deleteUser(userWithAccess);
+            tryDeletingRole(roleNameWithIndexPatternAccess);
+        }
+    }
+
+    /**
+     * 1. Tries to update a detector as a user without access to the given index pattern and verifies that it is forbidden
+     * 2. Updates a detector as a user with access to a given index
+     * @throws IOException
+     */
+    public void testUpdateDetectorIndexAccess() throws IOException {
+        String[] backendRoles = { TEST_IT_BACKEND_ROLE };
+
+        String userWithoutAccess = "user";
+        String roleNameWithoutIndexPatternAccess = "test-role";
+        String testIndexPattern = "test*";
+        createUserWithDataAndCustomRole(userWithoutAccess, userWithoutAccess, roleNameWithoutIndexPatternAccess, backendRoles, clusterPermissions, indexPermissions, List.of(testIndexPattern));
+        RestClient clientWithoutAccess = null;
+
+
+        String userWithAccess = "user1";
+        String roleNameWithIndexPatternAccess = "test-role-1";
+        String windowsIndexPattern = "windows*";
+        createUserWithDataAndCustomRole(userWithAccess, userWithAccess, roleNameWithIndexPatternAccess, backendRoles, clusterPermissions, indexPermissions, List.of(windowsIndexPattern));
+        RestClient clientWithAccess =  null;
+        try {
+            clientWithoutAccess = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userWithoutAccess, userWithoutAccess).setSocketTimeout(60000).build();
+            clientWithAccess = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[]{}), isHttps(), userWithAccess, userWithAccess).setSocketTimeout(60000).build();
+            //createUserRolesMapping("alerting_full_access", users);
+            String index = createTestIndex(client(), randomIndex(), windowsIndexMapping(), Settings.EMPTY);
+
+            // Execute CreateMappingsAction to add alias mapping for index
+            Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+            // both req params and req body are supported
+            createMappingRequest.setJsonEntity(
+                "{ \"index_name\":\"" + index + "\"," +
+                    "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                    "  \"partial\":true" +
+                    "}"
+            );
+            Response response = clientWithAccess.performRequest(createMappingRequest);
+            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+            Detector detector = randomDetector(getRandomPrePackagedRules());
+
+            Response createResponse = makeRequest(clientWithAccess, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+            assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+
+            Map<String, Object> responseBody = asMap(createResponse);
+
+            String createdId = responseBody.get("_id").toString();
+            int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+
+            assertNotEquals("response is missing Id", Detector.NO_ID, createdId);
+            assertTrue("incorrect version", createdVersion > 0);
+            assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, createdId), createResponse.getHeader("Location"));
+            assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("rule_topic_index"));
+            assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("findings_index"));
+            assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("alert_index"));
+
+            String detectorId = responseBody.get("_id").toString();
+
+            try {
+                makeRequest(clientWithoutAccess, "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(detector));
+            } catch (ResponseException e) {
+                assertEquals("Update detector error status", RestStatus.FORBIDDEN, restStatus(e.getResponse()));
+            }
+
+            Response updateResponse = makeRequest(clientWithAccess, "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(detector));
+            assertEquals("Update detector failed", RestStatus.OK, restStatus(updateResponse));
+        } finally {
+            if (clientWithoutAccess != null) clientWithoutAccess.close();
+            deleteUser(userWithoutAccess);
+            tryDeletingRole(roleNameWithoutIndexPatternAccess);
+
+            if (clientWithAccess != null) clientWithAccess.close();
+            deleteUser(userWithAccess);
+            tryDeletingRole(roleNameWithIndexPatternAccess);
         }
     }
 }


### PR DESCRIPTION
### Description
[Describe what this change achieves]
Checks if user can access the given indices when creating detector

Implemented approach 2 from the issue listed below. Introduced dummy index search before detector creation happens, since once the detector is being created the context is stashed and from that point, the program continues the execution as a super user (which has an access to resources on altering and security analytics side). 
That's why, the check has been introduced before the context is being stashed and follows the approach used in alerting.

 One general note - security tests will fail because the index privilege action is not introduced for the security_analytics_full_access role
### Issues Resolved
[List any issues this PR will resolve]
https://github.com/opensearch-project/security-analytics/issues/182
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
