### PR TITLE
Update to Safe yaml constructor

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/rules/objects/SigmaRule.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/objects/SigmaRule.java
@@ -12,6 +12,7 @@ import org.opensearch.securityanalytics.rules.exceptions.SigmaLevelError;
 import org.opensearch.securityanalytics.rules.exceptions.SigmaLogsourceError;
 import org.opensearch.securityanalytics.rules.exceptions.SigmaStatusError;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -167,7 +168,7 @@ public class SigmaRule {
     }
 
     public static SigmaRule fromYaml(String rule, boolean collectErrors) throws SigmaError {
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor());
         Map<String, Object> ruleMap = yaml.load(rule);
         return fromDict(ruleMap, collectErrors);
     }


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Based on security best practices, changeing default to safe yaml constructor [1].

https://bitbucket.org/snakeyaml/snakeyaml/wiki/Documentation
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5576

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
