### PR TITLE
WIP: Feature/191 detector types

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/alerts/AlertsService.java
+++ b/src/main/java/org/opensearch/securityanalytics/alerts/AlertsService.java
@@ -21,12 +21,15 @@ import org.opensearch.commons.alerting.model.Table;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.securityanalytics.action.AckAlertsResponse;
 import org.opensearch.securityanalytics.action.AlertDto;
+import org.opensearch.securityanalytics.action.FindingDto;
 import org.opensearch.securityanalytics.action.GetAlertsResponse;
 import org.opensearch.securityanalytics.action.GetDetectorAction;
 import org.opensearch.securityanalytics.action.GetDetectorRequest;
 import org.opensearch.securityanalytics.action.GetDetectorResponse;
+import org.opensearch.securityanalytics.action.GetFindingsResponse;
 import org.opensearch.securityanalytics.config.monitors.DetectorMonitorConfig;
 import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.model.Detector.DetectorType;
 import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
 
 import java.util.ArrayList;
@@ -78,28 +81,51 @@ public class AlertsService {
                 detector.getMonitorIds().forEach(
                         monitorId -> monitorToDetectorMapping.put(monitorId, detector.getId())
                 );
-                // Get alerts for all monitor ids
-                AlertsService.this.getAlertsByMonitorIds(
+
+                List<String> detectorTypes = detector.getInputs().get(0).getDetectorTypes().stream().map(DetectorType::getDetectorType).collect(
+                    Collectors.toList());
+
+                if (detectorTypes == null || detectorTypes.isEmpty()) {
+                    detectorTypes = List.of(detector.getDetectorType());
+                }
+
+                GroupedActionListener<GetAlertsResponse> getAlertsResponseListener = new GroupedActionListener(
+                    new ActionListener<Collection<GetAlertsResponse>>() {
+                        @Override
+                        public void onResponse(Collection<GetAlertsResponse> alertsResponses) {
+                            List<AlertDto> alerts = new ArrayList<>();
+                            // Merge all findings into one response
+                            int totalAlerts = alertsResponses.stream().map(GetAlertsResponse::getTotalAlerts).collect(
+                                Collectors.summingInt(Integer::intValue));
+                            alerts.addAll(alertsResponses.stream().flatMap(getAlertsResponse -> getAlertsResponse.getAlerts().stream()).collect(
+                                Collectors.toList()));
+
+                            GetAlertsResponse masterResponse = new GetAlertsResponse(
+                                alerts,
+                                totalAlerts
+                            );
+                            listener.onResponse(masterResponse);
+                        }
+                        @Override
+                        public void onFailure(Exception e) {
+                            log.error("Failed to fetch alerts for detectorId: " + detectorId, e);
+                            listener.onFailure(SecurityAnalyticsException.wrap(e));
+                        }
+                    }, detectorTypes.size());
+
+                for (String detectorType: detectorTypes) {
+                    // Get alerts for all monitor ids
+                    AlertsService.this.getAlertsByMonitorIds(
                         monitorToDetectorMapping,
+                        // TODO - Monitor list will contain all the monitors event those from another detector type
                         monitorIds,
-                        DetectorMonitorConfig.getAllAlertsIndicesPattern(detector.getDetectorType()),
+                        DetectorMonitorConfig.getAllAlertsIndicesPattern(detectorType),
                         table,
                         severityLevel,
                         alertState,
-                        new ActionListener<>() {
-                            @Override
-                            public void onResponse(GetAlertsResponse getAlertsResponse) {
-                                // Send response back
-                                listener.onResponse(getAlertsResponse);
-                            }
-
-                            @Override
-                            public void onFailure(Exception e) {
-                                log.error("Failed to fetch alerts for detectorId: " + detectorId, e);
-                                listener.onFailure(SecurityAnalyticsException.wrap(e));
-                            }
-                        }
-                );
+                        getAlertsResponseListener
+                    );
+                }
             }
 
             @Override

--- a/src/main/java/org/opensearch/securityanalytics/config/monitors/DetectorMonitorConfig.java
+++ b/src/main/java/org/opensearch/securityanalytics/config/monitors/DetectorMonitorConfig.java
@@ -5,6 +5,8 @@
 package org.opensearch.securityanalytics.config.monitors;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.opensearch.securityanalytics.model.Detector;
 
@@ -15,7 +17,7 @@ import java.util.Map;
 
 
 public class DetectorMonitorConfig {
-
+    private static Pattern findingIndexRegexPattern = Pattern.compile(".opensearch-sap-(.*?)-findings");
     public static final String OPENSEARCH_DEFAULT_RULE_INDEX = ".opensearch-sap-detectors-queries-default";
     public static final String OPENSEARCH_DEFAULT_ALERT_INDEX = ".opensearch-sap-alerts-default";
     public static final String OPENSEARCH_DEFAULT_ALL_ALERT_INDICES_PATTERN = ".opensearch-sap-alerts-default*";
@@ -125,6 +127,12 @@ public class DetectorMonitorConfig {
         HashMap<String, Map<String, String>> fieldMappingProperties = new HashMap<>();
         fieldMappingProperties.put("text", properties);
         return fieldMappingProperties;
+    }
+
+    public static String getRuleCategoryFromFindingIndexName(String findingIndex) {
+        Matcher matcher = findingIndexRegexPattern.matcher(findingIndex);
+        matcher.find();
+        return matcher.group(1);
     }
 
     public static class MonitorConfig {

--- a/src/main/java/org/opensearch/securityanalytics/model/Detector.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Detector.java
@@ -544,6 +544,15 @@ public class Detector implements Writeable, ToXContentObject {
 
     public Map<String, String> getRuleIdMonitorIdMap() {return ruleIdMonitorIdMap; }
 
+    public String getDocLevelMonitorIdForRuleCategory (String ruleCategory) {
+        // TODO - check with Shubo For previous versions - if the docLevelMonitor is specified
+        if(ruleIdMonitorIdMap.get(DOC_LEVEL_MONITOR) != null && getDetectorType() == ruleCategory) {
+            String monitorId = ruleIdMonitorIdMap.get(DOC_LEVEL_MONITOR);
+            ruleIdMonitorIdMap.put(getDetectorType(), monitorId);
+        }
+        return ruleIdMonitorIdMap.get(ruleCategory);
+    }
+
     public void setId(String id) {
         this.id = id;
     }

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -68,6 +69,7 @@ import org.opensearch.commons.alerting.model.Monitor.MonitorType;
 import org.opensearch.commons.alerting.model.SearchInput;
 import org.opensearch.commons.alerting.model.action.Action;
 import org.opensearch.commons.authuser.User;
+import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.reindex.BulkByScrollResponse;
@@ -85,6 +87,7 @@ import org.opensearch.securityanalytics.action.IndexDetectorResponse;
 import org.opensearch.securityanalytics.config.monitors.DetectorMonitorConfig;
 import org.opensearch.securityanalytics.mapper.MapperService;
 import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.model.Detector.DetectorType;
 import org.opensearch.securityanalytics.model.DetectorInput;
 import org.opensearch.securityanalytics.model.DetectorRule;
 import org.opensearch.securityanalytics.model.DetectorTrigger;
@@ -186,7 +189,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         List<IndexMonitorRequest> monitorRequests = new ArrayList<>();
 
         if (!docLevelRules.isEmpty()) {
-            monitorRequests.add(createDocLevelMonitorRequest(Pair.of(index, docLevelRules), detector, refreshPolicy, Monitor.NO_ID, Method.POST));
+            monitorRequests.addAll(createDocLevelMonitorRequest(index, docLevelRules, detector, refreshPolicy, Monitor.NO_ID, Method.POST));
         }
         if (!bucketLevelRules.isEmpty()) {
             monitorRequests.addAll(buildBucketLevelMonitorRequests(Pair.of(index, bucketLevelRules), detector, refreshPolicy, Monitor.NO_ID, Method.POST));
@@ -275,15 +278,20 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             }
         }
 
-        List<Pair<String, Rule>> docLevelRules = rulesById.stream().filter(it -> !it.getRight().isAggregationRule()).collect(
-            Collectors.toList());
+        Map<String, List<Pair<String, Rule>>> docLevelRulesByCategory = rulesById.stream().filter(it -> !it.getRight().isAggregationRule()).collect(
+            Collectors.groupingBy(it -> it.getRight().getCategory()));
 
         // Process doc level monitors
-        if (!docLevelRules.isEmpty()) {
-            if (detector.getDocLevelMonitorId() == null) {
-                monitorsToBeAdded.add(createDocLevelMonitorRequest(Pair.of(index, docLevelRules), detector, refreshPolicy, Monitor.NO_ID, Method.POST));
-            } else {
-                monitorsToBeUpdated.add(createDocLevelMonitorRequest(Pair.of(index, docLevelRules), detector, refreshPolicy, detector.getDocLevelMonitorId(), Method.PUT));
+        if (!docLevelRulesByCategory.isEmpty()) {
+            for(Entry<String, List<Pair<String, Rule>>> rulesPerCategory: docLevelRulesByCategory.entrySet()) {
+                String docLevelMonitorIdForCategory = detector.getDocLevelMonitorIdForRuleCategory(rulesPerCategory.getKey());
+                List<Pair<String, Rule>> rules =  rulesPerCategory.getValue();
+
+                if(docLevelMonitorIdForCategory == null) {
+                    monitorsToBeAdded.addAll(createDocLevelMonitorRequest(index, rules, detector, refreshPolicy, Monitor.NO_ID, Method.POST));
+                } else {
+                    monitorsToBeUpdated.addAll(createDocLevelMonitorRequest(index, rules, detector, refreshPolicy, docLevelMonitorIdForCategory, Method.PUT));
+                }
             }
         }
 
@@ -347,55 +355,73 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         }, listener::onFailure);
     }
 
-    private IndexMonitorRequest createDocLevelMonitorRequest(Pair<String, List<Pair<String, Rule>>> logIndexToQueries, Detector detector, WriteRequest.RefreshPolicy refreshPolicy, String monitorId, RestRequest.Method restMethod) {
-        List<DocLevelMonitorInput> docLevelMonitorInputs = new ArrayList<>();
+    private List<IndexMonitorRequest> createDocLevelMonitorRequest(String index, List<Pair<String, Rule>> logIndexToQueries, Detector detector, WriteRequest.RefreshPolicy refreshPolicy, String monitorId, RestRequest.Method restMethod) {
+        Map<String, List<Pair<String, Rule>>> rulesByCategory = logIndexToQueries.stream().collect(Collectors.groupingBy(stringRulePair -> stringRulePair.getRight().getCategory()));
+        List<IndexMonitorRequest> requests = new ArrayList<>();
 
-        List<DocLevelQuery> docLevelQueries = new ArrayList<>();
+        for(Entry<String, List<Pair<String, Rule>>> entry: rulesByCategory.entrySet()) {
 
-        for (Pair<String, Rule> query: logIndexToQueries.getRight()) {
-            String id = query.getLeft();
+            List<DocLevelMonitorInput> docLevelMonitorInputs = new ArrayList<>();
+            List<DocLevelQuery> docLevelQueries = new ArrayList<>();
 
-            Rule rule = query.getRight();
-            String name = query.getLeft();
+            for (Pair<String, Rule> query: entry.getValue()) {
+                String id = query.getLeft();
 
-            String actualQuery = rule.getQueries().get(0).getValue();
+                Rule rule = query.getRight();
+                String name = query.getLeft();
 
-            List<String> tags = new ArrayList<>();
-            tags.add(rule.getLevel());
-            tags.add(rule.getCategory());
-            tags.addAll(rule.getTags().stream().map(Value::getValue).collect(Collectors.toList()));
+                String actualQuery = rule.getQueries().get(0).getValue();
 
-            DocLevelQuery docLevelQuery = new DocLevelQuery(id, name, actualQuery, tags);
-            docLevelQueries.add(docLevelQuery);
-        }
-        DocLevelMonitorInput docLevelMonitorInput = new DocLevelMonitorInput(detector.getName(), List.of(logIndexToQueries.getKey()), docLevelQueries);
-        docLevelMonitorInputs.add(docLevelMonitorInput);
+                List<String> tags = new ArrayList<>();
+                tags.add(rule.getLevel());
+                tags.add(rule.getCategory());
+                tags.addAll(rule.getTags().stream().map(Value::getValue).collect(Collectors.toList()));
 
-        List<DocumentLevelTrigger> triggers = new ArrayList<>();
-        List<DetectorTrigger> detectorTriggers = detector.getTriggers();
+                DocLevelQuery docLevelQuery = new DocLevelQuery(id, name, actualQuery, tags);
+                docLevelQueries.add(docLevelQuery);
+            }
+            docLevelMonitorInputs.add(new DocLevelMonitorInput(detector.getName(), List.of(index), docLevelQueries));
 
-        for (DetectorTrigger detectorTrigger: detectorTriggers) {
-            String id = detectorTrigger.getId();
-            String name = detectorTrigger.getName();
-            String severity = detectorTrigger.getSeverity();
-            List<Action> actions = detectorTrigger.getActions();
-            Script condition = detectorTrigger.convertToCondition();
+            List<DocumentLevelTrigger> triggers = new ArrayList<>();
+            List<DetectorTrigger> detectorTriggers = detector.getTriggers();
 
-            triggers.add(new DocumentLevelTrigger(id, name, severity, actions, condition));
-        }
+            for (DetectorTrigger detectorTrigger: detectorTriggers) {
+                String id = detectorTrigger.getId();
+                String name = detectorTrigger.getName();
+                String severity = detectorTrigger.getSeverity();
+                List<Action> actions = detectorTrigger.getActions();
+                Script condition = detectorTrigger.convertToCondition();
 
-        Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), detector.getEnabled(), detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
-            Monitor.MonitorType.DOC_LEVEL_MONITOR, detector.getUser(), 1, docLevelMonitorInputs, triggers, Map.of(),
-            new DataSources(detector.getRuleIndex(),
+                triggers.add(new DocumentLevelTrigger(id, name, severity, actions, condition));
+            }
+
+            String category = entry.getKey();
+
+            DataSources d1 =  new DataSources(DetectorMonitorConfig.getRuleIndex(category),
+                DetectorMonitorConfig.getFindingsIndex(category),
+                DetectorMonitorConfig.getFindingsIndexPattern(category),
+                DetectorMonitorConfig.getAlertsIndex(category),
+                DetectorMonitorConfig.getAlertsHistoryIndex(category),
+                DetectorMonitorConfig.getAlertsHistoryIndexPattern(category),
+                DetectorMonitorConfig.getRuleIndexMappingsByType(detector.getDetectorType()),
+                true);
+
+            DataSources d2 = new DataSources(detector.getRuleIndex(),
                 detector.getFindingsIndex(),
                 detector.getFindingsIndexPattern(),
                 detector.getAlertsIndex(),
                 detector.getAlertsHistoryIndex(),
                 detector.getAlertsHistoryIndexPattern(),
                 DetectorMonitorConfig.getRuleIndexMappingsByType(detector.getDetectorType()),
-                true), PLUGIN_OWNER_FIELD);
+                true);
 
-        return new IndexMonitorRequest(monitorId, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, refreshPolicy, restMethod, monitor, null);
+            Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), detector.getEnabled(), detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
+                Monitor.MonitorType.DOC_LEVEL_MONITOR, detector.getUser(), 1, docLevelMonitorInputs, triggers, Map.of(),
+                d1, PLUGIN_OWNER_FIELD);
+
+            requests.add(new IndexMonitorRequest(monitorId, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, refreshPolicy, restMethod, monitor, null));
+        }
+        return requests;
     }
 
     private List<IndexMonitorRequest> buildBucketLevelMonitorRequests(Pair<String, List<Pair<String, Rule>>> logIndexToQueries, Detector detector, WriteRequest.RefreshPolicy refreshPolicy, String monitorId, RestRequest.Method restMethod) throws IOException, SigmaError {
@@ -466,15 +492,17 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
          triggers.add(bucketLevelTrigger1);
          } **/
 
+        String ruleCategory = rule.getCategory();
+
         Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), detector.getEnabled(), detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
             MonitorType.BUCKET_LEVEL_MONITOR, detector.getUser(), 1, bucketLevelMonitorInputs, triggers, Map.of(),
-            new DataSources(detector.getRuleIndex(),
-                detector.getFindingsIndex(),
-                detector.getFindingsIndexPattern(),
-                detector.getAlertsIndex(),
-                detector.getAlertsHistoryIndex(),
-                detector.getAlertsHistoryIndexPattern(),
-                DetectorMonitorConfig.getRuleIndexMappingsByType(detector.getDetectorType()),
+            new DataSources(DetectorMonitorConfig.getRuleIndex(ruleCategory),
+                DetectorMonitorConfig.getFindingsIndex(ruleCategory),
+                DetectorMonitorConfig.getFindingsIndexPattern(ruleCategory),
+                DetectorMonitorConfig.getAlertsIndex(ruleCategory),
+                DetectorMonitorConfig.getAlertsHistoryIndex(ruleCategory),
+                DetectorMonitorConfig.getAlertsHistoryIndexPattern(ruleCategory),
+                DetectorMonitorConfig.getRuleIndexMappingsByType(ruleCategory),
                 true), PLUGIN_OWNER_FIELD);
 
         return new IndexMonitorRequest(monitorId, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, refreshPolicy, restMethod, monitor, null);
@@ -663,6 +691,16 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             request.getDetector().setFindingsIndexPattern(DetectorMonitorConfig.getFindingsIndexPattern(ruleTopic));
             request.getDetector().setRuleIndex(DetectorMonitorConfig.getRuleIndex(ruleTopic));
 
+            List<DetectorType> detectorTypes = detector.getInputs().get(0).getDetectorTypes();
+            List<String> ruleIndices;
+
+            if (detectorTypes == null || detectorTypes.isEmpty()) {
+                ruleIndices = List.of(DetectorMonitorConfig.getRuleIndex(ruleTopic));
+            } else {
+                ruleIndices = detectorTypes.stream().map(detectorType -> DetectorMonitorConfig.getRuleIndex(detectorType.getDetectorType())).collect(
+                    Collectors.toList());
+            }
+
             User originalContextUser = this.user;
             log.debug("user from original context is {}", originalContextUser);
             request.getDetector().setUser(originalContextUser);
@@ -670,10 +708,10 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
             if (!detector.getInputs().isEmpty()) {
                 try {
-                    ruleTopicIndices.initRuleTopicIndex(detector.getRuleIndex(), new ActionListener<>() {
+                    // Create rule indices for all rule categories
+                    ruleTopicIndices.initRuleTopicIndices(ruleIndices, new ActionListener<>() {
                         @Override
-                        public void onResponse(CreateIndexResponse createIndexResponse) {
-
+                        public void onResponse(List<CreateIndexResponse> createIndexResponse) {
                             initRuleIndexAndImportRules(request, new ActionListener<>() {
                                 @Override
                                 public void onResponse(List<IndexMonitorResponse> monitorResponses) {
@@ -774,11 +812,21 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             request.getDetector().setRuleIndex(DetectorMonitorConfig.getRuleIndex(ruleTopic));
             request.getDetector().setUser(user);
 
+            List<DetectorType> detectorTypes = detector.getInputs().get(0).getDetectorTypes();
+
+            List<String> ruleIndices;
+            if (detectorTypes == null || detectorTypes.isEmpty()) {
+                ruleIndices = List.of(DetectorMonitorConfig.getRuleIndex(ruleTopic));
+            } else {
+                ruleIndices = detectorTypes.stream().map(detectorType -> DetectorMonitorConfig.getRuleIndex(detectorType.getDetectorType())).collect(
+                    Collectors.toList());
+            }
+
             if (!detector.getInputs().isEmpty()) {
                 try {
-                    ruleTopicIndices.initRuleTopicIndex(detector.getRuleIndex(), new ActionListener<>() {
+                    ruleTopicIndices.initRuleTopicIndices(ruleIndices, new ActionListener<>() {
                         @Override
-                        public void onResponse(CreateIndexResponse createIndexResponse) {
+                        public void onResponse(List<CreateIndexResponse> createIndexResponse) {
                             initRuleIndexAndImportRules(request, new ActionListener<>() {
                                 @Override
                                 public void onResponse(List<IndexMonitorResponse> monitorResponses) {
@@ -917,21 +965,40 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         public void importRules(IndexDetectorRequest request, ActionListener<List<IndexMonitorResponse>> listener) {
             final Detector detector = request.getDetector();
             final String ruleTopic = detector.getDetectorType();
+
+            // TODO - replace the request model with detector.getInputs().get(0).getDetectorTypes();
+            final List<DetectorType> detectorTypes = detector.getInputs().get(0).getDetectorTypes();
+
             final DetectorInput detectorInput = detector.getInputs().get(0);
             final String logIndex = detectorInput.getIndices().get(0);
 
             List<String> ruleIds = detectorInput.getPrePackagedRules().stream().map(DetectorRule::getId).collect(Collectors.toList());
+            QueryBuilder queryBuilder;
 
-            QueryBuilder queryBuilder =
-                    QueryBuilders.nestedQuery("rule",
-                            QueryBuilders.boolQuery().must(
-                                    QueryBuilders.matchQuery("rule.category", ruleTopic)
-                            ).must(
-                                    QueryBuilders.termsQuery("_id", ruleIds.toArray(new String[]{}))
-                            ),
-                            ScoreMode.Avg
-                    );
+            if (detectorTypes.isEmpty()) {
+                queryBuilder = QueryBuilders.nestedQuery("rule",
+                    QueryBuilders.boolQuery().must(
+                        QueryBuilders.matchQuery("rule.category", ruleTopic)
+                    ).must(
+                        QueryBuilders.termsQuery("_id", ruleIds.toArray(new String[]{}))
+                    ),
+                    ScoreMode.Avg
+                );
+            } else {
+                BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
 
+                for(DetectorType detectorType: detectorTypes) {
+                    boolQueryBuilder = boolQueryBuilder.should(QueryBuilders.nestedQuery("rule",
+                        QueryBuilders.boolQuery().must(
+                            QueryBuilders.matchQuery("rule.category", detectorType.getDetectorType())
+                        ).must(
+                            QueryBuilders.termsQuery("_id", ruleIds.toArray(new String[]{}))
+                        ),
+                        ScoreMode.Avg
+                    ));
+                }
+                queryBuilder = boolQueryBuilder;
+            }
             SearchRequest searchRequest = new SearchRequest(Rule.PRE_PACKAGED_RULES_INDEX)
                     .source(new SearchSourceBuilder()
                             .seqNoAndPrimaryTerm(true)
@@ -1101,15 +1168,19 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
          * @param monitorResponses index monitor responses
          * @return map of monitor ids
          */
+        int counterStevan = 0;
         private Map<String, String> mapMonitorIds(List<IndexMonitorResponse> monitorResponses) {
+            counterStevan++;
             return monitorResponses.stream().collect(
                     Collectors.toMap(
-                        // In the case of bucket level monitors rule id is trigger id
                         it -> {
+                            // In the case of bucket level monitors rule id is trigger id
                             if (MonitorType.BUCKET_LEVEL_MONITOR == it.getMonitor().getMonitorType()) {
                                 return it.getMonitor().getTriggers().get(0).getId();
-                            } else {
-                                return Detector.DOC_LEVEL_MONITOR;
+                            }
+                            // TODO - think something better?; In the case of doc level monitors, key is the rule category/ detector type
+                            else {
+                                return DetectorMonitorConfig.getRuleCategoryFromFindingIndexName(it.getMonitor().getDataSources().getFindingsIndex());
                             }
                         },
                         IndexMonitorResponse::getId

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -397,27 +397,16 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
             String category = entry.getKey();
 
-            DataSources d1 =  new DataSources(DetectorMonitorConfig.getRuleIndex(category),
-                DetectorMonitorConfig.getFindingsIndex(category),
-                DetectorMonitorConfig.getFindingsIndexPattern(category),
-                DetectorMonitorConfig.getAlertsIndex(category),
-                DetectorMonitorConfig.getAlertsHistoryIndex(category),
-                DetectorMonitorConfig.getAlertsHistoryIndexPattern(category),
-                DetectorMonitorConfig.getRuleIndexMappingsByType(detector.getDetectorType()),
-                true);
-
-            DataSources d2 = new DataSources(detector.getRuleIndex(),
-                detector.getFindingsIndex(),
-                detector.getFindingsIndexPattern(),
-                detector.getAlertsIndex(),
-                detector.getAlertsHistoryIndex(),
-                detector.getAlertsHistoryIndexPattern(),
-                DetectorMonitorConfig.getRuleIndexMappingsByType(detector.getDetectorType()),
-                true);
-
             Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), detector.getEnabled(), detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
                 Monitor.MonitorType.DOC_LEVEL_MONITOR, detector.getUser(), 1, docLevelMonitorInputs, triggers, Map.of(),
-                d1, PLUGIN_OWNER_FIELD);
+                new DataSources(DetectorMonitorConfig.getRuleIndex(category),
+                    DetectorMonitorConfig.getFindingsIndex(category),
+                    DetectorMonitorConfig.getFindingsIndexPattern(category),
+                    DetectorMonitorConfig.getAlertsIndex(category),
+                    DetectorMonitorConfig.getAlertsHistoryIndex(category),
+                    DetectorMonitorConfig.getAlertsHistoryIndexPattern(category),
+                    DetectorMonitorConfig.getRuleIndexMappingsByType(detector.getDetectorType()),
+                    true), PLUGIN_OWNER_FIELD);
 
             requests.add(new IndexMonitorRequest(monitorId, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, refreshPolicy, restMethod, monitor, null));
         }

--- a/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
+++ b/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
@@ -78,7 +78,7 @@ import static org.opensearch.securityanalytics.util.RuleTopicIndices.ruleTopicIn
 import static org.opensearch.securityanalytics.util.RuleTopicIndices.ruleTopicIndexSettings;
 
 public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
-    @Before
+    // Uncomment to support debug level of logs @Before
     void setDebugLogLevel() throws IOException {
 
 

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
@@ -35,6 +35,7 @@ import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
 import org.opensearch.securityanalytics.SecurityAnalyticsRestTestCase;
 import org.opensearch.securityanalytics.config.monitors.DetectorMonitorConfig;
 import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.model.Detector.DetectorType;
 import org.opensearch.securityanalytics.model.DetectorInput;
 import org.opensearch.securityanalytics.model.DetectorRule;
 import org.opensearch.securityanalytics.model.Rule;
@@ -104,11 +105,11 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(MonitorType.DOC_LEVEL_MONITOR.getValue(), monitorType);
 
         // Create aggregation rules
-        String sumRuleId = createRule(randomAggregationRule( "sum", " > 2"));
-        String avgTermRuleId = createRule(randomAggregationRule( "avg", " > 1"));
+        String sumRuleId = createRule(randomAggregationRule( "sum", " > 2"), "test_windows");
+        String avgTermRuleId = createRule(randomAggregationRule( "avg", " > 1"), "test_windows");
         // Update detector and empty doc level rules so detector contains only one aggregation rule
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(sumRuleId), new DetectorRule(avgTermRuleId)),
-            Collections.emptyList());
+            Collections.emptyList(), Collections.emptyList());
         Detector updatedDetector = randomDetectorWithInputs(List.of(input));
 
         Response updateResponse = makeRequest(client(), "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(updatedDetector));
@@ -190,10 +191,10 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
 
         assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
 
-        String maxRuleId = createRule(randomAggregationRule( "max", " > 2"));
+        String maxRuleId = createRule(randomAggregationRule( "max", " > 2"), "test_windows");
         List<DetectorRule> detectorRules = List.of(new DetectorRule(maxRuleId));
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
-            Collections.emptyList());
+            Collections.emptyList(), Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
         Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
 
@@ -229,10 +230,10 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(MonitorType.BUCKET_LEVEL_MONITOR.getValue(), monitorType);
 
         // Create random doc rule and 5 pre-packed rules and assign to detector
-        String randomDocRuleId = createRule(randomRule());
+        String randomDocRuleId = createRule(randomRule(), "test_windows");
         List<String> prepackagedRules = getRandomPrePackagedRules();
         input = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(randomDocRuleId)),
-            prepackagedRules.stream().map(DetectorRule::new).collect(Collectors.toList()));
+            prepackagedRules.stream().map(DetectorRule::new).collect(Collectors.toList()), Collections.emptyList());
         Detector updatedDetector = randomDetectorWithInputs(List.of(input));
 
         Response updateResponse = makeRequest(client(), "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(updatedDetector));
@@ -406,10 +407,10 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
 
         assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
 
-        String sumRuleId = createRule(randomAggregationRule("sum", " > 1"));
+        String sumRuleId = createRule(randomAggregationRule("sum", " > 1"), "test_windows");
         List<DetectorRule> detectorRules = List.of(new DetectorRule(sumRuleId));
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
-            Collections.emptyList());
+            Collections.emptyList(), Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
         Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
 
@@ -433,9 +434,9 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(1, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
 
         // Test adding the new max monitor and updating the existing sum monitor
-        String maxRuleId =  createRule(randomAggregationRule("max", " > 3"));
+        String maxRuleId =  createRule(randomAggregationRule("max", " > 3"), "test_windows");
         DetectorInput newInput = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(maxRuleId), new DetectorRule(sumRuleId)),
-            Collections.emptyList());
+            Collections.emptyList(), Collections.emptyList());
         Detector updatedDetector = randomDetectorWithInputs(List.of(newInput));
         Response updateResponse = makeRequest(client(), "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(updatedDetector));
 
@@ -514,14 +515,14 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
 
         List<String> aggRuleIds = new ArrayList<>();
-        String avgRuleId = createRule(randomAggregationRule("avg", " > 1"));
+        String avgRuleId = createRule(randomAggregationRule("avg", " > 1"), "test_windows");
         aggRuleIds.add(avgRuleId);
-        String countRuleId = createRule(randomAggregationRule("count", " > 1"));
+        String countRuleId = createRule(randomAggregationRule("count", " > 1"), "test_windows");
         aggRuleIds.add(countRuleId);
 
         List<DetectorRule> detectorRules = aggRuleIds.stream().map(DetectorRule::new).collect(Collectors.toList());
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
-            Collections.emptyList());
+            Collections.emptyList(), Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
         Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
 
@@ -546,7 +547,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
 
         // Test deleting the aggregation rule
         DetectorInput newInput = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(avgRuleId)),
-            Collections.emptyList());
+            Collections.emptyList(), Collections.emptyList());
         detector = randomDetectorWithInputs(List.of(newInput));
         Response updateResponse = makeRequest(client(), "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(detector));
 
@@ -628,16 +629,16 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
 
         List<String> aggRuleIds = new ArrayList<>();
-        String avgRuleId = createRule(randomAggregationRule("avg", " > 1"));
+        String avgRuleId = createRule(randomAggregationRule("avg", " > 1"), "test_windows");
         aggRuleIds.add(avgRuleId);
-        String minRuleId = createRule(randomAggregationRule("min", " > 1"));
+        String minRuleId = createRule(randomAggregationRule("min", " > 1"), "test_windows");
         aggRuleIds.add(minRuleId);
 
         List<DetectorRule> detectorRules = aggRuleIds.stream().map(DetectorRule::new).collect(Collectors.toList());
         List<String> prepackagedDocRules = getRandomPrePackagedRules();
 
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
-            prepackagedDocRules.stream().map(DetectorRule::new).collect(Collectors.toList()));
+            prepackagedDocRules.stream().map(DetectorRule::new).collect(Collectors.toList()), Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
         Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
 
@@ -660,10 +661,10 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
 
         assertEquals(2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
 
-        String maxRuleId = createRule(randomAggregationRule("max", " > 2"));
+        String maxRuleId = createRule(randomAggregationRule("max", " > 2"), "test_windows");
         DetectorInput newInput = new DetectorInput("windows detector for security analytics", List.of("windows"),
             List.of(new DetectorRule(avgRuleId), new DetectorRule(maxRuleId)),
-            getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()));
+            getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()), Collections.emptyList());
         detector = randomDetectorWithInputs(List.of(newInput));
         createResponse = makeRequest(client(), "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(detector));
 
@@ -747,10 +748,10 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
 
         List<String> aggRuleIds = new ArrayList<>();
         String testOpCode = "Test";
-        aggRuleIds.add(createRule(randomAggregationRule("min", " > 3", testOpCode)));
+        aggRuleIds.add(createRule(randomAggregationRule("min", " > 3", testOpCode), "test_windows"));
         List<DetectorRule> detectorRules = aggRuleIds.stream().map(DetectorRule::new).collect(Collectors.toList());
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
-            Collections.emptyList());
+            Collections.emptyList(), Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
         Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
 
@@ -837,20 +838,20 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         String testOpCode = "Test";
 
         // 5 custom aggregation rules
-        String sumRuleId = createRule(randomAggregationRule("sum", " > 1", infoOpCode));
-        String maxRuleId =  createRule(randomAggregationRule("max", " > 3", testOpCode));
-        String minRuleId =  createRule(randomAggregationRule("min", " > 3", testOpCode));
-        String avgRuleId =  createRule(randomAggregationRule("avg", " > 3", infoOpCode));
-        String cntRuleId =  createRule(randomAggregationRule("count", " > 3", "randomTestCode"));
+        String sumRuleId = createRule(randomAggregationRule("sum", " > 1", infoOpCode), "test_windows");
+        String maxRuleId =  createRule(randomAggregationRule("max", " > 3", testOpCode), "test_windows");
+        String minRuleId =  createRule(randomAggregationRule("min", " > 3", testOpCode), "test_windows");
+        String avgRuleId =  createRule(randomAggregationRule("avg", " > 3", infoOpCode), "test_windows");
+        String cntRuleId =  createRule(randomAggregationRule("count", " > 3", "randomTestCode"), "test_windows");
         List<String> aggRuleIds = List.of(sumRuleId, maxRuleId);
-        String randomDocRuleId = createRule(randomRule());
+        String randomDocRuleId = createRule(randomRule(), "test_windows");
         List<String> prepackagedRules = getRandomPrePackagedRules();
 
         List<DetectorRule> detectorRules = List.of(new DetectorRule(sumRuleId), new DetectorRule(maxRuleId), new DetectorRule(minRuleId),
             new DetectorRule(avgRuleId), new DetectorRule(cntRuleId), new DetectorRule(randomDocRuleId));
 
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
-            prepackagedRules.stream().map(DetectorRule::new).collect(Collectors.toList()));
+            prepackagedRules.stream().map(DetectorRule::new).collect(Collectors.toList()), Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
 
         Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
@@ -937,6 +938,191 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertNotNull(getFindingsBody);
         // 8 findings from doc level rules, and 3 findings for aggregation (sum, max and min)
         assertEquals(11, getFindingsBody.get("total_findings"));
+
+        String findingDetectorId = ((Map<String, Object>)((List)getFindingsBody.get("findings")).get(0)).get("detectorId").toString();
+        assertEquals(detectorId, findingDetectorId);
+
+        String findingIndex = ((Map<String, Object>)((List)getFindingsBody.get("findings")).get(0)).get("index").toString();
+        assertEquals(index, findingIndex);
+
+        List<String> docLevelFinding = new ArrayList<>();
+        List<Map<String, Object>> findings = (List) getFindingsBody.get("findings");
+
+        Set<String> docLevelRules = new HashSet<>(prepackagedRules);
+        docLevelRules.add(randomDocRuleId);
+
+        for(Map<String, Object> finding : findings) {
+            List<Map<String, Object>> queries = (List<Map<String, Object>>)finding.get("queries");
+            Set<String> findingRuleIds = queries.stream().map(it -> it.get("id").toString()).collect(Collectors.toSet());
+            // Doc level finding matches all doc level rules (including the custom one) in this test case
+            if(docLevelRules.containsAll(findingRuleIds)) {
+                docLevelFinding.addAll((List<String>)finding.get("related_doc_ids"));
+            } else {
+                // In the case of bucket level monitors, queries will always contain one value
+                String aggRuleId = findingRuleIds.iterator().next();
+                List<String> findingDocs = (List<String>)finding.get("related_doc_ids");
+
+                if(aggRuleId.equals(sumRuleId)) {
+                    assertTrue(List.of("1", "2", "3").containsAll(findingDocs));
+                } else if(aggRuleId.equals(maxRuleId)) {
+                    assertTrue(List.of("4", "5", "6", "7").containsAll(findingDocs));
+                } else if(aggRuleId.equals( minRuleId)) {
+                    assertTrue(List.of("7").containsAll(findingDocs));
+                }
+            }
+        }
+
+        assertTrue(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8").containsAll(docLevelFinding));
+    }
+
+
+    public void testMultipleAggregationAndDocRulesForMultipleDetectorTypes_findingSuccess() throws IOException {
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        Response createMappingResponse = client().performRequest(createMappingRequest);
+
+        assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
+
+        String lin = "s3";
+
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + lin + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        createMappingResponse = client().performRequest(createMappingRequest);
+
+        assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
+
+        String infoOpCode = "Info";
+        String testOpCode = "Test";
+
+        // 5 custom aggregation rules
+        String sumRuleId = createRule(randomAggregationRule("sum", " > 1", infoOpCode));
+        String maxRuleId =  createRule(randomAggregationRule("max", " > 3", testOpCode));
+        String minRuleId =  createRule(randomAggregationRule("min", " > 3", testOpCode));
+        String avgRuleId =  createRule(randomAggregationRule("avg", " > 3", infoOpCode));
+        String cntRuleId =  createRule(randomAggregationRule("count", " > 3", "randomTestCode"));
+        List<String> aggRuleIds = List.of(sumRuleId, maxRuleId);
+        String randomDocRuleId = createRule(randomRule());
+        List<String> prepackagedRules = getRandomPrePackagedRules();
+
+        List<DetectorRule> detectorRules = List.of(new DetectorRule(sumRuleId), new DetectorRule(maxRuleId), new DetectorRule(minRuleId),
+            new DetectorRule(avgRuleId), new DetectorRule(cntRuleId), new DetectorRule(randomDocRuleId));
+
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
+            prepackagedRules.stream().map(DetectorRule::new).collect(Collectors.toList()), List.of(DetectorType.TEST_WINDOWS, DetectorType.WINDOWS));
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+
+        String request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match_all\":{\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex("test_windows"), request, true);
+        assertEquals(5, response.getHits().getTotalHits().value);
+
+        response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex("windows"), request, true);
+        assertEquals(1, response.getHits().getTotalHits().value);
+
+        assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+        Map<String, Object> responseBody = asMap(createResponse);
+        String detectorId = responseBody.get("_id").toString();
+        request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+        Map<String, List> updatedDetectorMap = (HashMap<String,List>)(hit.getSourceAsMap().get("detector"));
+        List inputArr = updatedDetectorMap.get("inputs");
+
+        assertEquals(6, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
+
+        List<String> monitorIds = ((List<String>) (updatedDetectorMap).get("monitor_id"));
+
+        assertEquals(7, monitorIds.size());
+
+        indexDoc(index, "1", randomDoc(2, 4, infoOpCode));
+        indexDoc(index, "2", randomDoc(3, 4, infoOpCode));
+        indexDoc(index, "3", randomDoc(1, 4, infoOpCode));
+        indexDoc(index, "4", randomDoc(5, 3, testOpCode));
+        indexDoc(index, "5", randomDoc(2, 3, testOpCode));
+        indexDoc(index, "6", randomDoc(4, 3, testOpCode));
+        indexDoc(index, "7", randomDoc(6, 2, testOpCode));
+        indexDoc(index, "8", randomDoc(1, 1, testOpCode));
+
+        Map<String, Integer> numberOfMonitorTypes = new HashMap<>();
+
+        String windowsMonitorId = (String)((Map<String, Object>)updatedDetectorMap.get("bucket_monitor_id_rule_id")).get("windows");
+        String testWindowsMonitorId = (String)((Map<String, Object>)updatedDetectorMap.get("bucket_monitor_id_rule_id")).get("test_windows");
+
+        for (String monitorId: monitorIds) {
+            Map<String, String> monitor  = (Map<String, String>)(entityAsMap(client().performRequest(new Request("GET", "/_plugins/_alerting/monitors/" + monitorId)))).get("monitor");
+            numberOfMonitorTypes.merge(monitor.get("monitor_type"), 1, Integer::sum);
+            Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+
+            // Assert monitor executions
+            Map<String, Object> executeResults = entityAsMap(executeResponse);
+            if (MonitorType.DOC_LEVEL_MONITOR.getValue().equals(monitor.get("monitor_type"))) {
+                int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+                // 5 prepackaged and 1 custom doc level rule
+                if (monitorId.equals(windowsMonitorId)) {
+                    assertEquals(1, noOfSigmaRuleMatches);
+                }
+                if (monitorId.equals(testWindowsMonitorId)) {
+                    assertEquals(5, noOfSigmaRuleMatches);
+                }
+
+            } else {
+                for(String ruleId: aggRuleIds) {
+                    Object rule = (((Map<String,Object>)((Map<String, Object>)((List<Object>)((Map<String, Object>)executeResults.get("input_results")).get("results")).get(0)).get("aggregations")).get(ruleId));
+                    if(rule != null) {
+                        if(ruleId == sumRuleId) {
+                            assertRuleMonitorFinding(executeResults, ruleId,3, List.of("4"));
+                        } else if (ruleId == maxRuleId) {
+                            assertRuleMonitorFinding(executeResults, ruleId,5, List.of("2", "3"));
+                        }
+                        else if (ruleId == minRuleId) {
+                            assertRuleMonitorFinding(executeResults, ruleId,1,  List.of("2"));
+                        }
+                    }
+                }
+            }
+        }
+
+        assertEquals(5, numberOfMonitorTypes.get(MonitorType.BUCKET_LEVEL_MONITOR.getValue()).intValue());
+        assertEquals(2, numberOfMonitorTypes.get(MonitorType.DOC_LEVEL_MONITOR.getValue()).intValue());
+
+        Map<String, String> params = new HashMap<>();
+        params.put("detector_id", detectorId);
+        Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+        Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+
+        // Assert findings
+        assertNotNull(getFindingsBody);
+        // 8 findings for 5 prepackaged doc level rules for test_windows category
+        // 8 findings for 1 custom doc level rule for windows category
+        // 3 findings for bucket level monitors
+        assertEquals(19, getFindingsBody.get("total_findings"));
 
         String findingDetectorId = ((Map<String, Object>)((List)getFindingsBody.get("findings")).get(0)).get("detectorId").toString();
         assertEquals(detectorId, findingDetectorId);


### PR DESCRIPTION
### Description
Supporting multiple detector types.
Added creation of multiple rule indices at same time. Getting the findings and alerts from different indices depending of the detector type and joining them.
 
### Issues Resolved
https://github.com/opensearch-project/security-analytics/issues/191
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
