### PR TITLE
Feature/191 multiple detector types breaking change v1

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/action/GetDetectorResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/GetDetectorResponse.java
@@ -62,7 +62,6 @@ public class GetDetectorResponse extends ActionResponse implements ToXContentObj
                 .field(_VERSION, version);
         builder.startObject("detector")
                 .field(Detector.NAME_FIELD, detector.getName())
-                .field(Detector.DETECTOR_TYPE_FIELD, detector.getDetectorType())
                 .field(Detector.ENABLED_FIELD, detector.getEnabled())
                 .field(Detector.SCHEDULE_FIELD, detector.getSchedule())
                 .field(Detector.INPUTS_FIELD, detector.getInputs())

--- a/src/main/java/org/opensearch/securityanalytics/action/IndexDetectorResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/IndexDetectorResponse.java
@@ -57,7 +57,6 @@ public class IndexDetectorResponse extends ActionResponse implements ToXContentO
             .field(_VERSION, version);
         builder.startObject("detector")
             .field(Detector.NAME_FIELD, detector.getName())
-            .field(Detector.DETECTOR_TYPE_FIELD, detector.getDetectorType())
             .field(Detector.ENABLED_FIELD, detector.getEnabled())
             .field(Detector.SCHEDULE_FIELD, detector.getSchedule())
             .field(Detector.INPUTS_FIELD, detector.getInputs())

--- a/src/main/java/org/opensearch/securityanalytics/config/monitors/DetectorMonitorConfig.java
+++ b/src/main/java/org/opensearch/securityanalytics/config/monitors/DetectorMonitorConfig.java
@@ -5,6 +5,8 @@
 package org.opensearch.securityanalytics.config.monitors;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.opensearch.securityanalytics.model.Detector;
 
@@ -15,7 +17,7 @@ import java.util.Map;
 
 
 public class DetectorMonitorConfig {
-
+    private static Pattern findingIndexRegexPattern = Pattern.compile(".opensearch-sap-(.*?)-findings");
     public static final String OPENSEARCH_DEFAULT_RULE_INDEX = ".opensearch-sap-detectors-queries-default";
     public static final String OPENSEARCH_DEFAULT_ALERT_INDEX = ".opensearch-sap-alerts-default";
     public static final String OPENSEARCH_DEFAULT_ALL_ALERT_INDICES_PATTERN = ".opensearch-sap-alerts-default*";
@@ -128,12 +130,18 @@ public class DetectorMonitorConfig {
                 OPENSEARCH_DEFAULT_FINDINGS_INDEX_PATTERN;
     }
 
-    public static Map<String, Map<String, String>> getRuleIndexMappingsByType(String detectorType) {
+    public static Map<String, Map<String, String>> getRuleIndexMappingsByType() {
         HashMap<String, String> properties = new HashMap<>();
         properties.put("analyzer", "rule_analyzer");
         HashMap<String, Map<String, String>> fieldMappingProperties = new HashMap<>();
         fieldMappingProperties.put("text", properties);
         return fieldMappingProperties;
+    }
+
+    public static String getRuleCategoryFromFindingIndexName(String findingIndex) {
+        Matcher matcher = findingIndexRegexPattern.matcher(findingIndex);
+        matcher.find();
+        return matcher.group(1);
     }
 
     public static class MonitorConfig {

--- a/src/main/java/org/opensearch/securityanalytics/findings/FindingsService.java
+++ b/src/main/java/org/opensearch/securityanalytics/findings/FindingsService.java
@@ -5,6 +5,7 @@
 package org.opensearch.securityanalytics.findings;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -14,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.client.Client;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.commons.alerting.AlertingPluginInterface;
@@ -52,7 +54,7 @@ public class FindingsService {
      * @param table group of search related parameters
      * @param listener ActionListener to get notified on response or error
      */
-    public void getFindingsByDetectorId(String detectorId, Table table, ActionListener<GetFindingsResponse> listener ) {
+    public void getFindingsByDetectorId(String detectorId, Table table, ActionListener<GetFindingsResponse> listener) {
         this.client.execute(GetDetectorAction.INSTANCE, new GetDetectorRequest(detectorId, -3L), new ActionListener<>() {
 
             @Override
@@ -60,43 +62,50 @@ public class FindingsService {
                 // Get all monitor ids from detector
                 Detector detector = getDetectorResponse.getDetector();
                 List<String> monitorIds = detector.getMonitorIds();
-                ActionListener<GetFindingsResponse> getFindingsResponseListener = new ActionListener<>() {
-                    @Override
-                    public void onResponse(GetFindingsResponse resp) {
-                        Integer totalFindings = 0;
-                        List<FindingDto> findings = new ArrayList<>();
-                        // Merge all findings into one response
-                        totalFindings += resp.getTotalFindings();
-                        findings.addAll(resp.getFindings());
-
-                        GetFindingsResponse masterResponse = new GetFindingsResponse(
-                                totalFindings,
-                                findings
-                        );
-                        // Send master response back
-                        listener.onResponse(masterResponse);
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        log.error("Failed to fetch findings for detector " + detectorId, e);
-                        listener.onFailure(SecurityAnalyticsException.wrap(e));
-                    }
-                };
 
                 // monitor --> detectorId mapping
                 Map<String, Detector> monitorToDetectorMapping = new HashMap<>();
                 detector.getMonitorIds().forEach(
                         monitorId -> monitorToDetectorMapping.put(monitorId, detector)
                 );
+
+                List<String> detectorTypes = detector.getDetectorTypes();
+
+                ActionListener<GetFindingsResponse> getFindingsResponseListener = new GroupedActionListener(
+                    new ActionListener<Collection<GetFindingsResponse>>() {
+                        @Override
+                        public void onResponse(Collection<GetFindingsResponse> findingsResponses) {
+                            List<FindingDto> findings = new ArrayList<>();
+                            // Merge all findings into one response
+                            int totalFindings = findingsResponses.stream().map(GetFindingsResponse::getTotalFindings).collect(
+                                Collectors.summingInt(Integer::intValue));
+                            findings.addAll(findingsResponses.stream().flatMap(getFindingsResponse -> getFindingsResponse.getFindings().stream()).collect(
+                                Collectors.toList()));
+
+                            GetFindingsResponse masterResponse = new GetFindingsResponse(
+                                totalFindings,
+                                findings
+                            );
+                            listener.onResponse(masterResponse);
+                        }
+                        @Override
+                        public void onFailure(Exception e) {
+                            log.error("Failed to fetch findings for detector " + detectorId, e);
+                            listener.onFailure(SecurityAnalyticsException.wrap(e));
+                        }
+                    }, detectorTypes.size());
+
                 // Get findings for all monitor ids
-                FindingsService.this.getFindingsByMonitorIds(
+                for (String detectorType: detectorTypes) {
+                    FindingsService.this.getFindingsByMonitorIds(
                         monitorToDetectorMapping,
                         monitorIds,
-                        DetectorMonitorConfig.getAllFindingsIndicesPattern(detector.getDetectorType()),
+                        DetectorMonitorConfig.getAllFindingsIndicesPattern(detectorType),
                         table,
                         getFindingsResponseListener
-                );
+                    );
+                }
+
             }
 
             @Override
@@ -136,6 +145,7 @@ public class FindingsService {
                     public void onResponse(
                             org.opensearch.commons.alerting.action.GetFindingsResponse getFindingsResponse
                     ) {
+                        log.error("alerts response size from alerting" + getFindingsResponse.getTotalFindings());
                         // Convert response to SA's GetFindingsResponse
                         listener.onResponse(new GetFindingsResponse(
                                 getFindingsResponse.getTotalFindings(),
@@ -207,7 +217,7 @@ public class FindingsService {
     public FindingDto mapFindingWithDocsToFindingDto(FindingWithDocs findingWithDocs, Detector detector) {
         List<DocLevelQuery> docLevelQueries = findingWithDocs.getFinding().getDocLevelQueries();
         if (docLevelQueries.isEmpty()) { // this is finding generated by a bucket level monitor
-            for (Map.Entry<String, String> entry : detector.getRuleIdMonitorIdMap().entrySet()) {
+            for (Map.Entry<String, String> entry : detector.getBucketRuleIdMonitorIdMap().entrySet()) {
                 if(entry.getValue().equals(findingWithDocs.getFinding().getMonitorId())) {
                     docLevelQueries = Collections.singletonList(new DocLevelQuery(entry.getKey(),"","",Collections.emptyList()));
                 }

--- a/src/main/java/org/opensearch/securityanalytics/model/Detector.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Detector.java
@@ -5,7 +5,12 @@
 package org.opensearch.securityanalytics.model;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.ParseField;
@@ -18,6 +23,7 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
+import org.opensearch.commons.alerting.action.IndexMonitorRequest;
 import org.opensearch.commons.alerting.model.CronSchedule;
 import org.opensearch.commons.alerting.model.Schedule;
 import org.opensearch.commons.authuser.User;
@@ -32,6 +38,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 import java.util.stream.Collectors;
+import org.opensearch.securityanalytics.config.monitors.DetectorMonitorConfig;
 
 public class Detector implements Writeable, ToXContentObject {
 
@@ -53,6 +60,8 @@ public class Detector implements Writeable, ToXContentObject {
     public static final String ALERTING_MONITOR_ID = "monitor_id";
 
     public static final String BUCKET_MONITOR_ID_RULE_ID = "bucket_monitor_id_rule_id";
+
+    public static final String DOC_MONITOR_ID_PER_CATEGORY = "doc_monitor_id_per_category";
     private static final String RULE_TOPIC_INDEX = "rule_topic_index";
 
     private static final String ALERTS_INDEX = "alert_index";
@@ -87,8 +96,6 @@ public class Detector implements Writeable, ToXContentObject {
 
     private Instant enabledTime;
 
-    private DetectorType detectorType;
-
     private User user;
 
     private List<DetectorInput> inputs;
@@ -97,7 +104,9 @@ public class Detector implements Writeable, ToXContentObject {
 
     private List<String> monitorIds;
 
-    private Map<String, String> ruleIdMonitorIdMap;
+    private Map<String, String> bucketRuleIdMonitorIdMap;
+
+    private Map<String, String> docLevelMonitorPerCategory;
 
     private String ruleIndex;
 
@@ -114,10 +123,10 @@ public class Detector implements Writeable, ToXContentObject {
     private final String type;
 
     public Detector(String id, Long version, String name, Boolean enabled, Schedule schedule,
-                    Instant lastUpdateTime, Instant enabledTime, DetectorType detectorType,
-                    User user, List<DetectorInput> inputs, List<DetectorTrigger> triggers, List<String> monitorIds,
-                    String ruleIndex, String alertsIndex, String alertsHistoryIndex, String alertsHistoryIndexPattern,
-                    String findingsIndex, String findingsIndexPattern, Map<String, String> rulePerMonitor) {
+        Instant lastUpdateTime, Instant enabledTime,
+        User user, List<DetectorInput> inputs, List<DetectorTrigger> triggers, List<String> monitorIds,
+        String ruleIndex, String alertsIndex, String alertsHistoryIndex, String alertsHistoryIndexPattern,
+        String findingsIndex, String findingsIndexPattern, Map<String, String> rulePerMonitor, Map<String, String> docLevelMonitorPerCategory) {
         this.type = DETECTOR_TYPE;
 
         this.id = id != null ? id : NO_ID;
@@ -127,7 +136,6 @@ public class Detector implements Writeable, ToXContentObject {
         this.schedule = schedule;
         this.lastUpdateTime = lastUpdateTime;
         this.enabledTime = enabledTime;
-        this.detectorType = detectorType;
         this.user = user;
         this.inputs = inputs;
         this.triggers = triggers;
@@ -138,7 +146,8 @@ public class Detector implements Writeable, ToXContentObject {
         this.alertsHistoryIndexPattern = alertsHistoryIndexPattern;
         this.findingsIndex = findingsIndex;
         this.findingsIndexPattern = findingsIndexPattern;
-        this.ruleIdMonitorIdMap = rulePerMonitor;
+        this.bucketRuleIdMonitorIdMap = rulePerMonitor;
+        this.docLevelMonitorPerCategory = docLevelMonitorPerCategory;
 
         if (enabled) {
             Objects.requireNonNull(enabledTime);
@@ -154,7 +163,6 @@ public class Detector implements Writeable, ToXContentObject {
                 Schedule.readFrom(sin),
                 sin.readInstant(),
                 sin.readOptionalInstant(),
-                sin.readEnum(DetectorType.class),
                 sin.readBoolean() ? new User(sin) : null,
                 sin.readList(DetectorInput::readFrom),
                 sin.readList(DetectorTrigger::readFrom),
@@ -165,6 +173,7 @@ public class Detector implements Writeable, ToXContentObject {
                 sin.readString(),
                 sin.readString(),
                 sin.readString(),
+                sin.readMap(StreamInput::readString, StreamInput::readString),
                 sin.readMap(StreamInput::readString, StreamInput::readString)
             );
     }
@@ -183,7 +192,6 @@ public class Detector implements Writeable, ToXContentObject {
         schedule.writeTo(out);
         out.writeInstant(lastUpdateTime);
         out.writeOptionalInstant(enabledTime);
-        out.writeEnum(detectorType);
         out.writeBoolean(user != null);
         if (user != null) {
             user.writeTo(out);
@@ -199,7 +207,8 @@ public class Detector implements Writeable, ToXContentObject {
         out.writeStringCollection(monitorIds);
         out.writeString(ruleIndex);
 
-        out.writeMap(ruleIdMonitorIdMap, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(bucketRuleIdMonitorIdMap, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(docLevelMonitorPerCategory, StreamOutput::writeString, StreamOutput::writeString);
     }
 
     public XContentBuilder toXContentWithUser(XContentBuilder builder, Params params) throws IOException {
@@ -247,8 +256,7 @@ public class Detector implements Writeable, ToXContentObject {
             builder.startObject(type);
         }
         builder.field(TYPE_FIELD, type)
-                .field(NAME_FIELD, name)
-                .field(DETECTOR_TYPE_FIELD, detectorType.getDetectorType());
+                .field(NAME_FIELD, name);
 
         if (!secure) {
             if (user == null) {
@@ -283,7 +291,8 @@ public class Detector implements Writeable, ToXContentObject {
         }
 
         builder.field(ALERTING_MONITOR_ID, monitorIds);
-        builder.field(BUCKET_MONITOR_ID_RULE_ID, ruleIdMonitorIdMap);
+        builder.field(BUCKET_MONITOR_ID_RULE_ID, bucketRuleIdMonitorIdMap);
+        builder.field(DOC_MONITOR_ID_PER_CATEGORY, docLevelMonitorPerCategory);
         builder.field(RULE_TOPIC_INDEX, ruleIndex);
         builder.field(ALERTS_INDEX, alertsIndex);
         builder.field(ALERTS_HISTORY_INDEX, alertsHistoryIndex);
@@ -329,6 +338,7 @@ public class Detector implements Writeable, ToXContentObject {
         List<DetectorTrigger> triggers = new ArrayList<>();
         List<String> monitorIds = new ArrayList<>();
         Map<String, String> rulePerMonitor = new HashMap<>();
+        Map<String, String> docLevelRulePerCategory = new HashMap<>();
 
         String ruleIndex = null;
         String alertsIndex = null;
@@ -336,6 +346,8 @@ public class Detector implements Writeable, ToXContentObject {
         String alertsHistoryIndexPattern = null;
         String findingsIndex = null;
         String findingsIndexPattern = null;
+
+        List<String> allowedTypes = Arrays.stream(DetectorType.values()).map(DetectorType::getDetectorType).collect(Collectors.toList());
 
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -347,11 +359,23 @@ public class Detector implements Writeable, ToXContentObject {
                     name = xcp.text();
                     break;
                 case DETECTOR_TYPE_FIELD:
-                    detectorType = xcp.text();
-                    List<String> allowedTypes = Arrays.stream(DetectorType.values()).map(DetectorType::getDetectorType).collect(Collectors.toList());
-
-                    if (!allowedTypes.contains(detectorType.toLowerCase(Locale.ROOT))) {
-                        throw new IllegalArgumentException(String.format(Locale.getDefault(), "Detector type should be one of %s", allowedTypes));
+                    if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        detectorType = xcp.text();
+                        if (!allowedTypes.contains(detectorType.toLowerCase(Locale.ROOT))) {
+                            throw new IllegalArgumentException(String.format(Locale.getDefault(),
+                                "Detector type should be one of %s",
+                                allowedTypes));
+                        }
+                        // In order to keep the existing detector types and to be backward compatible
+                        if (detectorType != null && !inputs.get(0).getDetectorTypes().contains(DetectorType.valueOf(detectorType))) {
+                            inputs.get(0).getDetectorTypes().add(DetectorType.valueOf(detectorType.toUpperCase(Locale.ROOT)));
+                        }
+                        // Added on both places since not sure if there is an order in which fields are being parsed
+                        // In order to be backward compatible - if there is doc_level_monitor key, that means that we had one detectorType supported
+                        // Re-map from { 1 : docLevelMonitorId } to { rule_category: docLevelMonitorId }
+                        if(rulePerMonitor.containsKey(DOC_LEVEL_MONITOR) && detectorType != null && !rulePerMonitor.containsKey(detectorType)) {
+                            docLevelRulePerCategory.put(detectorType, rulePerMonitor.get(DOC_LEVEL_MONITOR));
+                        }
                     }
                     break;
                 case USER_FIELD:
@@ -372,6 +396,10 @@ public class Detector implements Writeable, ToXContentObject {
                     while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
                         DetectorInput input = DetectorInput.parse(xcp);
                         inputs.add(input);
+                    }
+                    // In order to keep the existing detector types and to be backward compatible
+                    if (detectorType != null && !inputs.get(0).getDetectorTypes().contains(DetectorType.valueOf(detectorType.toUpperCase(Locale.ROOT)))) {
+                        inputs.get(0).getDetectorTypes().add(DetectorType.valueOf(detectorType.toUpperCase(Locale.ROOT)));
                     }
                     break;
                 case TRIGGERS_FIELD:
@@ -409,7 +437,22 @@ public class Detector implements Writeable, ToXContentObject {
                     }
                     break;
                 case BUCKET_MONITOR_ID_RULE_ID:
-                    rulePerMonitor= xcp.mapStrings();
+                    rulePerMonitor = xcp.mapStrings();
+                    // In order to be backward compatible - if there is doc_level_monitor key, that means that we had one detectorType supported
+                    // Re-map from { 1 : docLevelMonitorId } to { rule_category: docLevelMonitorId }
+                    if(rulePerMonitor.containsKey(DOC_LEVEL_MONITOR) && detectorType != null && !rulePerMonitor.containsKey(detectorType)) {
+                       rulePerMonitor.put(detectorType, rulePerMonitor.get(DOC_LEVEL_MONITOR));
+                    }
+
+                    break;
+                case DOC_MONITOR_ID_PER_CATEGORY:
+                    docLevelRulePerCategory = xcp.mapStrings();
+
+                    // In order to be backward compatible - if there is doc_level_monitor key, that means that we had one detectorType supported
+                    // Re-map from { 1 : docLevelMonitorId } to { rule_category: docLevelMonitorId }
+                    if(rulePerMonitor.containsKey(DOC_LEVEL_MONITOR) && detectorType != null && !rulePerMonitor.containsKey(detectorType)) {
+                        docLevelRulePerCategory.put(detectorType, rulePerMonitor.get(DOC_LEVEL_MONITOR));
+                    }
                     break;
                 case RULE_TOPIC_INDEX:
                     ruleIndex = xcp.text();
@@ -448,7 +491,6 @@ public class Detector implements Writeable, ToXContentObject {
                 Objects.requireNonNull(schedule, "Detector schedule is null"),
                 lastUpdateTime != null ? lastUpdateTime : Instant.now(),
                 enabledTime,
-                DetectorType.valueOf(detectorType.toUpperCase(Locale.ROOT)),
                 user,
                 inputs,
                 triggers,
@@ -459,7 +501,9 @@ public class Detector implements Writeable, ToXContentObject {
                 alertsHistoryIndexPattern,
                 findingsIndex,
                 findingsIndexPattern,
-                rulePerMonitor);
+                rulePerMonitor,
+                docLevelRulePerCategory
+            );
     }
 
     public static Detector readFrom(StreamInput sin) throws IOException {
@@ -494,10 +538,6 @@ public class Detector implements Writeable, ToXContentObject {
         return enabledTime;
     }
 
-    public String getDetectorType() {
-        return detectorType.getDetectorType();
-    }
-
     public User getUser() {
         return user;
     }
@@ -514,24 +554,17 @@ public class Detector implements Writeable, ToXContentObject {
         return ruleIndex;
     }
 
-    public String getAlertsIndex() {
-        return alertsIndex;
+    public List<String> getDetectorTypes() {
+        // In the case of detectors created before support of multiple detector types
+        if(inputs == null || inputs.isEmpty() || inputs.get(0).getDetectorTypes().isEmpty()) {
+            return Collections.emptyList();
+        }
+        return inputs.get(0).getDetectorTypes().stream().map(DetectorType::getDetectorType).collect(Collectors.toList());
     }
 
-    public String getAlertsHistoryIndex() {
-        return alertsHistoryIndex;
-    }
-
-    public String getAlertsHistoryIndexPattern() {
-        return alertsHistoryIndexPattern;
-    }
-
-    public String getFindingsIndex() {
-        return findingsIndex;
-    }
-
-    public String getFindingsIndexPattern() {
-        return findingsIndexPattern;
+    public List<String> getRuleIndices() {
+        return getDetectorTypes().stream().map(detectorType -> DetectorMonitorConfig.getRuleIndex(detectorType)).collect(
+            Collectors.toList());
     }
 
     public List<String> getMonitorIds() {
@@ -542,7 +575,13 @@ public class Detector implements Writeable, ToXContentObject {
         this.user = user;
     }
 
-    public Map<String, String> getRuleIdMonitorIdMap() {return ruleIdMonitorIdMap; }
+    public Map<String, String> getBucketRuleIdMonitorIdMap() {return bucketRuleIdMonitorIdMap; }
+
+    public Map<String, String> getDocLevelMonitorPerCategory() {return docLevelMonitorPerCategory;}
+
+    public String getDocLevelMonitorIdForRuleCategory (String ruleCategory) {
+        return docLevelMonitorPerCategory.get(ruleCategory);
+    }
 
     public void setId(String id) {
         this.id = id;
@@ -552,32 +591,8 @@ public class Detector implements Writeable, ToXContentObject {
         this.version = version;
     }
 
-    public void setRuleIndex(String ruleIndex) {
-        this.ruleIndex = ruleIndex;
-    }
-
-    public void setAlertsIndex(String alertsIndex) {
-        this.alertsIndex = alertsIndex;
-    }
-
-    public void setAlertsHistoryIndex(String alertsHistoryIndex) {
-        this.alertsHistoryIndex = alertsHistoryIndex;
-    }
-
-    public void setAlertsHistoryIndexPattern(String alertsHistoryIndexPattern) {
-        this.alertsHistoryIndexPattern = alertsHistoryIndexPattern;
-    }
-
     public void setEnabledTime(Instant enabledTime) {
         this.enabledTime = enabledTime;
-    }
-
-    public void setFindingsIndex(String findingsIndex) {
-        this.findingsIndex = findingsIndex;
-    }
-
-    public void setFindingsIndexPattern(String findingsIndexPattern) {
-        this.findingsIndexPattern = findingsIndexPattern;
     }
 
     public void setLastUpdateTime(Instant lastUpdateTime) {
@@ -591,12 +606,36 @@ public class Detector implements Writeable, ToXContentObject {
     public void setMonitorIds(List<String> monitorIds) {
         this.monitorIds = monitorIds;
     }
-    public void setRuleIdMonitorIdMap(Map<String, String> ruleIdMonitorIdMap) {
-        this.ruleIdMonitorIdMap = ruleIdMonitorIdMap;
+    public void setBucketRuleIdMonitorIdMap(Map<String, String> bucketRuleIdMonitorIdMap) {
+        this.bucketRuleIdMonitorIdMap = bucketRuleIdMonitorIdMap;
     }
 
-    public String getDocLevelMonitorId() {
-        return ruleIdMonitorIdMap.get(DOC_LEVEL_MONITOR);
+    public void setDocLevelMonitorPerCategory(Map<String, String> docLevelMonitorPerCategory) {
+        this.docLevelMonitorPerCategory = docLevelMonitorPerCategory;
+    }
+
+    public List<String> getMonitorIdsToBeDeleted(List<IndexMonitorRequest> monitorsToBeUpdated) {
+        List<String> monitorIdsToBeDeleted = bucketRuleIdMonitorIdMap.values().stream().collect(Collectors.toList());
+        monitorIdsToBeDeleted.addAll(docLevelMonitorPerCategory.values().stream().collect(Collectors.toList()));
+
+        List<String> monitorIds = monitorsToBeUpdated.stream().map(IndexMonitorRequest::getMonitorId).collect(
+            Collectors.toList());
+        monitorIdsToBeDeleted.removeAll(monitorIds);
+
+        return monitorIdsToBeDeleted;
+    }
+
+    public List<String> getRuleTopicsForMonitors(List<String> monitorIds) {
+        Set<String> monitorIdsSet = new HashSet<>(monitorIds);
+        List<String> ruleTopics = new ArrayList<>();
+
+        for (Entry<String, String> categoryDocMonitorId: docLevelMonitorPerCategory.entrySet()) {
+            if (monitorIdsSet.contains(categoryDocMonitorId.getValue())) {
+                String ruleCategory = categoryDocMonitorId.getKey();
+                ruleTopics.add(DetectorMonitorConfig.getRuleIndex(ruleCategory));
+            }
+        }
+        return ruleTopics;
     }
 
     @Override
@@ -604,11 +643,11 @@ public class Detector implements Writeable, ToXContentObject {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Detector detector = (Detector) o;
-        return Objects.equals(id, detector.id) && Objects.equals(version, detector.version) && Objects.equals(name, detector.name) && Objects.equals(enabled, detector.enabled) && Objects.equals(schedule, detector.schedule) && Objects.equals(lastUpdateTime, detector.lastUpdateTime) && Objects.equals(enabledTime, detector.enabledTime) && detectorType == detector.detectorType && ((user == null && detector.user == null) || Objects.equals(user, detector.user)) && Objects.equals(inputs, detector.inputs) && Objects.equals(triggers, detector.triggers) && Objects.equals(type, detector.type) && Objects.equals(monitorIds, detector.monitorIds) && Objects.equals(ruleIndex, detector.ruleIndex);
+        return Objects.equals(id, detector.id) && Objects.equals(version, detector.version) && Objects.equals(name, detector.name) && Objects.equals(enabled, detector.enabled) && Objects.equals(schedule, detector.schedule) && Objects.equals(lastUpdateTime, detector.lastUpdateTime) && Objects.equals(enabledTime, detector.enabledTime) && ((user == null && detector.user == null) || Objects.equals(user, detector.user)) && Objects.equals(inputs, detector.inputs) && Objects.equals(triggers, detector.triggers) && Objects.equals(type, detector.type) && Objects.equals(monitorIds, detector.monitorIds) && Objects.equals(ruleIndex, detector.ruleIndex);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, version, name, enabled, schedule, lastUpdateTime, enabledTime, detectorType, user, inputs, triggers, type, monitorIds, ruleIndex);
+        return Objects.hash(id, version, name, enabled, schedule, lastUpdateTime, enabledTime, user, inputs, triggers, type, monitorIds, ruleIndex);
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/model/DetectorInput.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/DetectorInput.java
@@ -4,6 +4,9 @@
  */
 package org.opensearch.securityanalytics.model;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -20,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.opensearch.securityanalytics.model.Detector.DetectorType;
 
 public class DetectorInput implements Writeable, ToXContentObject {
 
@@ -31,6 +35,8 @@ public class DetectorInput implements Writeable, ToXContentObject {
 
     private List<DetectorRule> prePackagedRules;
 
+    private List<DetectorType> detectorTypes;
+
     private static final String NO_DESCRIPTION = "";
 
     protected static final String DESCRIPTION_FIELD = "description";
@@ -39,17 +45,20 @@ public class DetectorInput implements Writeable, ToXContentObject {
     protected static final String CUSTOM_RULES_FIELD = "custom_rules";
     protected static final String PREPACKAGED_RULES_FIELD = "pre_packaged_rules";
 
+    protected static final String DETECTOR_TYPES_FIELD = "detector_types";
+
     public static final NamedXContentRegistry.Entry XCONTENT_REGISTRY = new NamedXContentRegistry.Entry(
             DetectorInput.class,
             new ParseField(DETECTOR_INPUT_FIELD),
             DetectorInput::parse
     );
 
-    public DetectorInput(String description, List<String> indices, List<DetectorRule> customRules, List<DetectorRule> prePackagedRules) {
+    public DetectorInput(String description, List<String> indices, List<DetectorRule> customRules, List<DetectorRule> prePackagedRules, List<DetectorType> detectorTypes) {
         this.description = description;
         this.indices = indices;
         this.customRules = customRules;
         this.prePackagedRules = prePackagedRules;
+        this.detectorTypes = detectorTypes;
     }
 
     public DetectorInput(StreamInput sin) throws IOException {
@@ -57,7 +66,8 @@ public class DetectorInput implements Writeable, ToXContentObject {
                 sin.readString(),
                 sin.readStringList(),
                 sin.readList(DetectorRule::new),
-                sin.readList(DetectorRule::new)
+                sin.readList(DetectorRule::new),
+                sin.readStringList().stream().map(s -> DetectorType.valueOf(s.toUpperCase(Locale.ROOT))).collect(Collectors.toList())
         );
     }
 
@@ -72,10 +82,14 @@ public class DetectorInput implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        List<String> detectorTypes = getDetectorTypes().stream().map(detectorType -> detectorType.getDetectorType()).collect(
+            Collectors.toList());
+
         out.writeString(description);
         out.writeStringCollection(indices);
         out.writeCollection(customRules);
         out.writeCollection(prePackagedRules);
+        out.writeStringCollection(detectorTypes);
     }
 
     @Override
@@ -89,12 +103,15 @@ public class DetectorInput implements Writeable, ToXContentObject {
         DetectorRule[] prePackagedRulesArray = new DetectorRule[]{};
         prePackagedRulesArray = prePackagedRules.toArray(prePackagedRulesArray);
 
+        String [] detectorTypesArray = detectorTypes.stream().map(DetectorType::getDetectorType).toArray(String[]::new);
+
         builder.startObject()
                 .startObject(DETECTOR_INPUT_FIELD)
                 .field(DESCRIPTION_FIELD, description)
                 .field(INDICES_FIELD, indicesArray)
                 .field(CUSTOM_RULES_FIELD, customRulesArray)
                 .field(PREPACKAGED_RULES_FIELD, prePackagedRulesArray)
+                .field(DETECTOR_TYPES_FIELD, detectorTypesArray)
                 .endObject()
                 .endObject();
         return builder;
@@ -105,6 +122,7 @@ public class DetectorInput implements Writeable, ToXContentObject {
         List<String> indices = new ArrayList<>();
         List<DetectorRule> customRules = new ArrayList<>();
         List<DetectorRule> prePackagedRules = new ArrayList<>();
+        List<DetectorType> detectorTypes = new ArrayList<>();
 
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, xcp.nextToken(), xcp);
@@ -131,6 +149,12 @@ public class DetectorInput implements Writeable, ToXContentObject {
                         customRules.add(DetectorRule.parse(xcp));
                     }
                     break;
+                case DETECTOR_TYPES_FIELD:
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
+                    while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
+                        detectorTypes.add(DetectorType.valueOf(xcp.text().toUpperCase(Locale.ROOT)));
+                    }
+                    break;
                 case PREPACKAGED_RULES_FIELD:
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
                     while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
@@ -139,7 +163,7 @@ public class DetectorInput implements Writeable, ToXContentObject {
             }
         }
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, xcp.nextToken(), xcp);
-        return new DetectorInput(description, indices, customRules, prePackagedRules);
+        return new DetectorInput(description, indices, customRules, prePackagedRules, detectorTypes);
     }
 
     public static DetectorInput readFrom(StreamInput sin) throws IOException {
@@ -148,6 +172,10 @@ public class DetectorInput implements Writeable, ToXContentObject {
 
     public void setCustomRules(List<DetectorRule> customRules) {
         this.customRules = customRules;
+    }
+
+    public void setDetectorTypes(List<DetectorType> detectorTypes) {
+        this.detectorTypes = detectorTypes;
     }
 
     public String getDescription() {
@@ -164,6 +192,17 @@ public class DetectorInput implements Writeable, ToXContentObject {
 
     public List<DetectorRule> getPrePackagedRules() {
         return prePackagedRules;
+    }
+
+    public List<DetectorType> getDetectorTypes () {
+        return detectorTypes;
+    }
+
+    public void addDetectorType(String detectorType) {
+        List<String> allowedTypes = Arrays.stream(DetectorType.values()).map(DetectorType::getDetectorType).collect(Collectors.toList());
+        if (!allowedTypes.contains(detectorType)) {
+            throw new IllegalArgumentException(String.format(Locale.getDefault(), "Detector type should be one of %s", allowedTypes));
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportGetAlertsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportGetAlertsAction.java
@@ -43,6 +43,8 @@ import static org.opensearch.securityanalytics.util.DetectorUtils.DETECTOR_TYPE_
 
 public class TransportGetAlertsAction extends HandledTransportAction<GetAlertsRequest, GetAlertsResponse> implements SecureTransportAction {
 
+    public static final String DETECTOR_INPUT_PATH = "detector.inputs.detector_input";
+    public static final String DETECTOR_TYPES = "detector.inputs.detector_input.detector_types";
     private final TransportSearchDetectorAction transportSearchDetectorAction;
 
     private final NamedXContentRegistry xContentRegistry;
@@ -96,10 +98,10 @@ public class TransportGetAlertsAction extends HandledTransportAction<GetAlertsRe
             // "detector" is nested type so we have to use nested query
             NestedQueryBuilder queryBuilder =
                     QueryBuilders.nestedQuery(
-                            "detector",
+                        DETECTOR_INPUT_PATH,
                             QueryBuilders.boolQuery().must(
                                     QueryBuilders.matchQuery(
-                                            DETECTOR_TYPE_PATH,
+                                        DETECTOR_TYPES,
                                             request.getDetectorType().getDetectorType()
                                     )
                             ),

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportGetFindingsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportGetFindingsAction.java
@@ -6,7 +6,6 @@ package org.opensearch.securityanalytics.transport;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.join.ScoreMode;
@@ -41,10 +40,10 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 
-import static org.opensearch.securityanalytics.util.DetectorUtils.DETECTOR_TYPE_PATH;
-
 public class TransportGetFindingsAction extends HandledTransportAction<GetFindingsRequest, GetFindingsResponse> implements SecureTransportAction {
 
+    public static final String DETECTOR_INPUT_PATH = "detector.inputs.detector_input";
+    public static final String DETECTOR_TYPES = "detector.inputs.detector_input.detector_types";
     private final TransportSearchDetectorAction transportSearchDetectorAction;
 
     private final NamedXContentRegistry xContentRegistry;
@@ -99,10 +98,10 @@ public class TransportGetFindingsAction extends HandledTransportAction<GetFindin
             // "detector" is nested type so we have to use nested query
             NestedQueryBuilder queryBuilder =
                     QueryBuilders.nestedQuery(
-                        "detector",
+                        DETECTOR_INPUT_PATH,
                         QueryBuilders.boolQuery().must(
                                 QueryBuilders.matchQuery(
-                                    DETECTOR_TYPE_PATH,
+                                    DETECTOR_TYPES,
                                     request.getDetectorType().getDetectorType()
                                 )
                         ),

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -4,6 +4,19 @@
  */
 package org.opensearch.securityanalytics.transport;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -83,6 +96,7 @@ import org.opensearch.securityanalytics.config.monitors.DetectorMonitorConfig;
 import org.opensearch.securityanalytics.mapper.MapperService;
 import org.opensearch.securityanalytics.mapper.MapperUtils;
 import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.model.Detector.DetectorType;
 import org.opensearch.securityanalytics.model.DetectorInput;
 import org.opensearch.securityanalytics.model.DetectorRule;
 import org.opensearch.securityanalytics.model.DetectorTrigger;
@@ -226,6 +240,14 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
     }
 
     private void createMonitorFromQueries(String index, List<Pair<String, Rule>> rulesById, Detector detector, ActionListener<List<IndexMonitorResponse>> listener, WriteRequest.RefreshPolicy refreshPolicy) throws SigmaError, IOException {
+        // TODO - should we check if the detector type list is the same like list of rule categories?
+        /**List<String> ruleCategories = rulesById.stream().map(ruleIdRulePair -> ruleIdRulePair.getRight().getCategory()).distinct().collect(Collectors.toList());
+            if (detector.getDetectorTypes().size() != ruleCategories.size() ||
+                detector.getDetectorTypes().containsAll(ruleCategories) == false) {
+            listener.onFailure(new IllegalArgumentException("Detector types and rule categories are not the same"));
+            return;
+        }*/
+
         List<Pair<String, Rule>> docLevelRules = rulesById.stream().filter(it -> !it.getRight().isAggregationRule()).collect(
             Collectors.toList());
         List<Pair<String, Rule>> bucketLevelRules = rulesById.stream().filter(it -> it.getRight().isAggregationRule()).collect(
@@ -234,7 +256,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         List<IndexMonitorRequest> monitorRequests = new ArrayList<>();
 
         if (!docLevelRules.isEmpty()) {
-            monitorRequests.add(createDocLevelMonitorRequest(Pair.of(index, docLevelRules), detector, refreshPolicy, Monitor.NO_ID, Method.POST));
+            monitorRequests.addAll(createDocLevelMonitorRequests(index, docLevelRules, detector, refreshPolicy, Monitor.NO_ID, Method.POST));
         }
         if (!bucketLevelRules.isEmpty()) {
             monitorRequests.addAll(buildBucketLevelMonitorRequests(Pair.of(index, bucketLevelRules), detector, refreshPolicy, Monitor.NO_ID, Method.POST));
@@ -295,14 +317,14 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             }
 
             // Pair of RuleId - MonitorId for existing monitors of the detector
-            Map<String, String> monitorPerRule = detector.getRuleIdMonitorIdMap();
+            Map<String, String> bucketRuleIdMonitorId = detector.getBucketRuleIdMonitorIdMap();
 
             for (Pair<String, Rule> query: bucketLevelRules) {
                 Rule rule = query.getRight();
                 if (rule.getAggregationQueries() != null){
                     // Detect if the monitor should be added or updated
-                    if (monitorPerRule.containsKey(rule.getId())) {
-                        String monitorId = monitorPerRule.get(rule.getId());
+                    if (bucketRuleIdMonitorId.containsKey(rule.getId())) {
+                        String monitorId = bucketRuleIdMonitorId.get(rule.getId());
                         monitorsToBeUpdated.add(createBucketLevelMonitorRequest(query.getRight(),
                             index,
                             detector,
@@ -323,24 +345,28 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             }
         }
 
-        List<Pair<String, Rule>> docLevelRules = rulesById.stream().filter(it -> !it.getRight().isAggregationRule()).collect(
-            Collectors.toList());
+        Map<String, List<Pair<String, Rule>>> docLevelRulesByCategory = rulesById.stream().filter(it -> !it.getRight().isAggregationRule()).collect(
+            Collectors.groupingBy(it -> it.getRight().getCategory()));
 
         // Process doc level monitors
-        if (!docLevelRules.isEmpty()) {
-            if (detector.getDocLevelMonitorId() == null) {
-                monitorsToBeAdded.add(createDocLevelMonitorRequest(Pair.of(index, docLevelRules), detector, refreshPolicy, Monitor.NO_ID, Method.POST));
+        for(Entry<String, List<Pair<String, Rule>>> rulesPerCategory: docLevelRulesByCategory.entrySet()) {
+            String docLevelMonitorIdForCategory = detector.getDocLevelMonitorIdForRuleCategory(rulesPerCategory.getKey());
+            List<Pair<String, Rule>> rules =  rulesPerCategory.getValue();
+
+            if(docLevelMonitorIdForCategory == null) {
+                monitorsToBeAdded.addAll(createDocLevelMonitorRequests(index, rules, detector, refreshPolicy, Monitor.NO_ID, Method.POST));
             } else {
-                monitorsToBeUpdated.add(createDocLevelMonitorRequest(Pair.of(index, docLevelRules), detector, refreshPolicy, detector.getDocLevelMonitorId(), Method.PUT));
+                monitorsToBeUpdated.addAll(createDocLevelMonitorRequests(index, rules, detector, refreshPolicy, docLevelMonitorIdForCategory, Method.PUT));
             }
         }
+        // Both bucket and doc level monitors can be deleted
+        List<String> monitorIdsToBeDeleted = detector.getMonitorIdsToBeDeleted(monitorsToBeUpdated);
+        List<String> docRuleIndicies = detector.getRuleTopicsForMonitors(monitorIdsToBeDeleted);
 
-        List<String> monitorIdsToBeDeleted = detector.getRuleIdMonitorIdMap().values().stream().collect(Collectors.toList());
-        monitorIdsToBeDeleted.removeAll(monitorsToBeUpdated.stream().map(IndexMonitorRequest::getMonitorId).collect(
-            Collectors.toList()));
-
-        updateAlertingMonitors(monitorsToBeAdded, monitorsToBeUpdated, monitorIdsToBeDeleted, refreshPolicy, listener);
+        updateAlertingMonitors(monitorsToBeAdded, monitorsToBeUpdated, monitorIdsToBeDeleted, docRuleIndicies, refreshPolicy, listener);
     }
+
+
 
     /**
      *  Update list of monitors for the given detector
@@ -359,6 +385,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         List<IndexMonitorRequest> monitorsToBeAdded,
         List<IndexMonitorRequest> monitorsToBeUpdated,
         List<String> monitorsToBeDeleted,
+        List<String> ruleIndices,
         RefreshPolicy refreshPolicy,
         ActionListener<List<IndexMonitorResponse>> listener
     ) {
@@ -382,7 +409,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                 }
 
                     StepListener<List<DeleteMonitorResponse>> deleteMonitorStep = new StepListener<>();
-                    deleteAlertingMonitors(monitorsToBeDeleted, refreshPolicy, deleteMonitorStep);
+                    deleteAlertingMonitors(monitorsToBeDeleted, ruleIndices, refreshPolicy, deleteMonitorStep);
                     // 3. Delete alerting monitors (rules that are not provided by the user)
                     deleteMonitorStep.whenComplete(deleteMonitorResponses ->
                             // Return list of all updated + newly added monitors
@@ -395,55 +422,62 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         }, listener::onFailure);
     }
 
-    private IndexMonitorRequest createDocLevelMonitorRequest(Pair<String, List<Pair<String, Rule>>> logIndexToQueries, Detector detector, WriteRequest.RefreshPolicy refreshPolicy, String monitorId, RestRequest.Method restMethod) {
-        List<DocLevelMonitorInput> docLevelMonitorInputs = new ArrayList<>();
+    private List<IndexMonitorRequest> createDocLevelMonitorRequests(String index, List<Pair<String, Rule>> logIndexToQueries, Detector detector, WriteRequest.RefreshPolicy refreshPolicy, String monitorId, RestRequest.Method restMethod) {
+        Map<String, List<Pair<String, Rule>>> rulesByCategory = logIndexToQueries.stream().collect(Collectors.groupingBy(stringRulePair -> stringRulePair.getRight().getCategory()));
+        List<IndexMonitorRequest> requests = new ArrayList<>();
 
-        List<DocLevelQuery> docLevelQueries = new ArrayList<>();
+        for(Entry<String, List<Pair<String, Rule>>> entry: rulesByCategory.entrySet()) {
 
-        for (Pair<String, Rule> query: logIndexToQueries.getRight()) {
-            String id = query.getLeft();
+            List<DocLevelMonitorInput> docLevelMonitorInputs = new ArrayList<>();
+            List<DocLevelQuery> docLevelQueries = new ArrayList<>();
 
-            Rule rule = query.getRight();
-            String name = query.getLeft();
+            for (Pair<String, Rule> query: entry.getValue()) {
+                String id = query.getLeft();
 
-            String actualQuery = rule.getQueries().get(0).getValue();
+                Rule rule = query.getRight();
+                String name = query.getLeft();
 
-            List<String> tags = new ArrayList<>();
-            tags.add(rule.getLevel());
-            tags.add(rule.getCategory());
-            tags.addAll(rule.getTags().stream().map(Value::getValue).collect(Collectors.toList()));
+                String actualQuery = rule.getQueries().get(0).getValue();
 
-            DocLevelQuery docLevelQuery = new DocLevelQuery(id, name, actualQuery, tags);
-            docLevelQueries.add(docLevelQuery);
+                List<String> tags = new ArrayList<>();
+                tags.add(rule.getLevel());
+                tags.add(rule.getCategory());
+                tags.addAll(rule.getTags().stream().map(Value::getValue).collect(Collectors.toList()));
+
+                DocLevelQuery docLevelQuery = new DocLevelQuery(id, name, actualQuery, tags);
+                docLevelQueries.add(docLevelQuery);
+            }
+            docLevelMonitorInputs.add(new DocLevelMonitorInput(detector.getName(), List.of(index), docLevelQueries));
+
+            List<DocumentLevelTrigger> triggers = new ArrayList<>();
+            List<DetectorTrigger> detectorTriggers = detector.getTriggers();
+
+            for (DetectorTrigger detectorTrigger: detectorTriggers) {
+                String id = detectorTrigger.getId();
+                String name = detectorTrigger.getName();
+                String severity = detectorTrigger.getSeverity();
+                List<Action> actions = detectorTrigger.getActions();
+                Script condition = detectorTrigger.convertToCondition();
+
+                triggers.add(new DocumentLevelTrigger(id, name, severity, actions, condition));
+            }
+
+            String category = entry.getKey();
+
+            Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), detector.getEnabled(), detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
+                Monitor.MonitorType.DOC_LEVEL_MONITOR, detector.getUser(), 1, docLevelMonitorInputs, triggers, Map.of(),
+                new DataSources(DetectorMonitorConfig.getRuleIndex(category),
+                    DetectorMonitorConfig.getFindingsIndex(category),
+                    DetectorMonitorConfig.getFindingsIndexPattern(category),
+                    DetectorMonitorConfig.getAlertsIndex(category),
+                    DetectorMonitorConfig.getAlertsHistoryIndex(category),
+                    DetectorMonitorConfig.getAlertsHistoryIndexPattern(category),
+                    DetectorMonitorConfig.getRuleIndexMappingsByType(),
+                    true), PLUGIN_OWNER_FIELD);
+
+            requests.add(new IndexMonitorRequest(monitorId, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, refreshPolicy, restMethod, monitor, null));
         }
-        DocLevelMonitorInput docLevelMonitorInput = new DocLevelMonitorInput(detector.getName(), List.of(logIndexToQueries.getKey()), docLevelQueries);
-        docLevelMonitorInputs.add(docLevelMonitorInput);
-
-        List<DocumentLevelTrigger> triggers = new ArrayList<>();
-        List<DetectorTrigger> detectorTriggers = detector.getTriggers();
-
-        for (DetectorTrigger detectorTrigger: detectorTriggers) {
-            String id = detectorTrigger.getId();
-            String name = detectorTrigger.getName();
-            String severity = detectorTrigger.getSeverity();
-            List<Action> actions = detectorTrigger.getActions();
-            Script condition = detectorTrigger.convertToCondition();
-
-            triggers.add(new DocumentLevelTrigger(id, name, severity, actions, condition));
-        }
-
-        Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), detector.getEnabled(), detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
-            Monitor.MonitorType.DOC_LEVEL_MONITOR, detector.getUser(), 1, docLevelMonitorInputs, triggers, Map.of(),
-            new DataSources(detector.getRuleIndex(),
-                detector.getFindingsIndex(),
-                detector.getFindingsIndexPattern(),
-                detector.getAlertsIndex(),
-                detector.getAlertsHistoryIndex(),
-                detector.getAlertsHistoryIndexPattern(),
-                DetectorMonitorConfig.getRuleIndexMappingsByType(detector.getDetectorType()),
-                true), PLUGIN_OWNER_FIELD);
-
-        return new IndexMonitorRequest(monitorId, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, refreshPolicy, restMethod, monitor, null);
+        return requests;
     }
 
     private List<IndexMonitorRequest> buildBucketLevelMonitorRequests(Pair<String, List<Pair<String, Rule>>> logIndexToQueries, Detector detector, WriteRequest.RefreshPolicy refreshPolicy, String monitorId, RestRequest.Method restMethod) throws IOException, SigmaError {
@@ -547,15 +581,17 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
          triggers.add(bucketLevelTrigger1);
          } **/
 
+        String ruleCategory = rule.getCategory();
+
         Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), detector.getEnabled(), detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
             MonitorType.BUCKET_LEVEL_MONITOR, detector.getUser(), 1, bucketLevelMonitorInputs, triggers, Map.of(),
-            new DataSources(detector.getRuleIndex(),
-                detector.getFindingsIndex(),
-                detector.getFindingsIndexPattern(),
-                detector.getAlertsIndex(),
-                detector.getAlertsHistoryIndex(),
-                detector.getAlertsHistoryIndexPattern(),
-                DetectorMonitorConfig.getRuleIndexMappingsByType(detector.getDetectorType()),
+            new DataSources(DetectorMonitorConfig.getRuleIndex(ruleCategory),
+                DetectorMonitorConfig.getFindingsIndex(ruleCategory),
+                DetectorMonitorConfig.getFindingsIndexPattern(ruleCategory),
+                DetectorMonitorConfig.getAlertsIndex(ruleCategory),
+                DetectorMonitorConfig.getAlertsHistoryIndex(ruleCategory),
+                DetectorMonitorConfig.getAlertsHistoryIndexPattern(ruleCategory),
+                DetectorMonitorConfig.getRuleIndexMappingsByType(),
                 true), PLUGIN_OWNER_FIELD);
 
         return new IndexMonitorRequest(monitorId, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, refreshPolicy, restMethod, monitor, null);
@@ -596,15 +632,17 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
     /**
      * Deletes the alerting monitors based on the given ids and notifies the listener that will be notified once all monitors have been deleted
+     * Beside deleting the monitors, checks and deletes the rule indices if they are empty
      * @param monitorIds monitor ids to be deleted
      * @param refreshPolicy
      * @param listener listener that will be notified once all the monitors are being deleted
      */
-    private void deleteAlertingMonitors(List<String> monitorIds, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<List<DeleteMonitorResponse>> listener){
+    private void deleteAlertingMonitors(List<String> monitorIds, List<String> ruleIndices, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<List<DeleteMonitorResponse>> listener){
         if (monitorIds == null || monitorIds.isEmpty()) {
             listener.onResponse(new ArrayList<>());
             return;
         }
+
         ActionListener<DeleteMonitorResponse> deletesListener = new GroupedActionListener<>(new ActionListener<>() {
             @Override
             public void onResponse(Collection<DeleteMonitorResponse> responses) {
@@ -734,14 +772,9 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
         void createDetector() {
             Detector detector = request.getDetector();
-            String ruleTopic = detector.getDetectorType();
 
-            request.getDetector().setAlertsIndex(DetectorMonitorConfig.getAlertsIndex(ruleTopic));
-            request.getDetector().setAlertsHistoryIndex(DetectorMonitorConfig.getAlertsHistoryIndex(ruleTopic));
-            request.getDetector().setAlertsHistoryIndexPattern(DetectorMonitorConfig.getAlertsHistoryIndexPattern(ruleTopic));
-            request.getDetector().setFindingsIndex(DetectorMonitorConfig.getFindingsIndex(ruleTopic));
-            request.getDetector().setFindingsIndexPattern(DetectorMonitorConfig.getFindingsIndexPattern(ruleTopic));
-            request.getDetector().setRuleIndex(DetectorMonitorConfig.getRuleIndex(ruleTopic));
+            // Refactored to support multiple log types
+            List<String> ruleIndices = detector.getRuleIndices();
 
             User originalContextUser = this.user;
             log.debug("user from original context is {}", originalContextUser);
@@ -757,22 +790,23 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                             initRuleIndexAndImportRules(request, new ActionListener<>() {
                                 @Override
                                 public void onResponse(List<IndexMonitorResponse> monitorResponses) {
+                                    Pair<Map<String, String>, Map<String, String>> monitorPairs = mapMonitorIds(monitorResponses);
+
                                     request.getDetector().setMonitorIds(getMonitorIds(monitorResponses));
-                                    request.getDetector().setRuleIdMonitorIdMap(mapMonitorIds(monitorResponses));
+                                    request.getDetector().setDocLevelMonitorPerCategory(monitorPairs.getLeft());
+                                    request.getDetector().setBucketRuleIdMonitorIdMap(monitorPairs.getRight());
                                     try {
                                         indexDetector();
                                     } catch (IOException e) {
                                         onFailures(e);
                                     }
                                 }
-
                                 @Override
                                 public void onFailure(Exception e) {
                                     onFailures(e);
                                 }
                             });
                         }
-
                         @Override
                         public void onFailure(Exception e) {
                             onFailures(e);
@@ -838,21 +872,15 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                 request.getDetector().setEnabledTime(currentDetector.getEnabledTime());
             }
             request.getDetector().setMonitorIds(currentDetector.getMonitorIds());
-            request.getDetector().setRuleIdMonitorIdMap(currentDetector.getRuleIdMonitorIdMap());
-            Detector detector = request.getDetector();
+            request.getDetector().setDocLevelMonitorPerCategory(currentDetector.getDocLevelMonitorPerCategory());
+            request.getDetector().setBucketRuleIdMonitorIdMap(currentDetector.getBucketRuleIdMonitorIdMap());
 
-            String ruleTopic = detector.getDetectorType();
+            Detector detector = request.getDetector();
 
             log.debug("user in update detector {}", user);
 
-
-            request.getDetector().setAlertsIndex(DetectorMonitorConfig.getAlertsIndex(ruleTopic));
-            request.getDetector().setAlertsHistoryIndex(DetectorMonitorConfig.getAlertsHistoryIndex(ruleTopic));
-            request.getDetector().setAlertsHistoryIndexPattern(DetectorMonitorConfig.getAlertsHistoryIndexPattern(ruleTopic));
-            request.getDetector().setFindingsIndex(DetectorMonitorConfig.getFindingsIndex(ruleTopic));
-            request.getDetector().setFindingsIndexPattern(DetectorMonitorConfig.getFindingsIndexPattern(ruleTopic));
-            request.getDetector().setRuleIndex(DetectorMonitorConfig.getRuleIndex(ruleTopic));
             request.getDetector().setUser(user);
+            List<String> ruleIndices = detector.getRuleIndices();
 
             if (!detector.getInputs().isEmpty()) {
                 try {
@@ -862,8 +890,10 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                             initRuleIndexAndImportRules(request, new ActionListener<>() {
                                 @Override
                                 public void onResponse(List<IndexMonitorResponse> monitorResponses) {
+                                    Pair<Map<String, String>, Map<String, String>> monitorPairs = mapMonitorIds(monitorResponses);
                                     request.getDetector().setMonitorIds(getMonitorIds(monitorResponses));
-                                    request.getDetector().setRuleIdMonitorIdMap(mapMonitorIds(monitorResponses));
+                                    request.getDetector().setDocLevelMonitorPerCategory(monitorPairs.getLeft());
+                                    request.getDetector().setBucketRuleIdMonitorIdMap(monitorPairs.getRight());
                                     try {
                                         indexDetector();
                                     } catch (IOException e) {
@@ -996,21 +1026,27 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         @SuppressWarnings("unchecked")
         public void importRules(IndexDetectorRequest request, ActionListener<List<IndexMonitorResponse>> listener) {
             final Detector detector = request.getDetector();
-            final String ruleTopic = detector.getDetectorType();
+
             final DetectorInput detectorInput = detector.getInputs().get(0);
             final String logIndex = detectorInput.getIndices().get(0);
+            // Introduced breaking change - all detector types will be stored in detectorInput
+            final List<DetectorType> detectorTypes = detector.getInputs().get(0).getDetectorTypes();
 
             List<String> ruleIds = detectorInput.getPrePackagedRules().stream().map(DetectorRule::getId).collect(Collectors.toList());
+            QueryBuilder queryBuilder;
 
-            QueryBuilder queryBuilder =
-                    QueryBuilders.nestedQuery("rule",
-                            QueryBuilders.boolQuery().must(
-                                    QueryBuilders.matchQuery("rule.category", ruleTopic)
-                            ).must(
-                                    QueryBuilders.termsQuery("_id", ruleIds.toArray(new String[]{}))
-                            ),
-                            ScoreMode.Avg
-                    );
+            BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+            for(DetectorType detectorType: detectorTypes) {
+                boolQueryBuilder = boolQueryBuilder.should(QueryBuilders.nestedQuery("rule",
+                    QueryBuilders.boolQuery().must(
+                        QueryBuilders.matchQuery("rule.category", detectorType.getDetectorType())
+                    ).must(
+                        QueryBuilders.termsQuery("_id", ruleIds.toArray(new String[]{}))
+                    ),
+                    ScoreMode.Avg
+                ));
+            }
+            queryBuilder = boolQueryBuilder;
 
             SearchRequest searchRequest = new SearchRequest(Rule.PRE_PACKAGED_RULES_INDEX)
                     .source(new SearchSourceBuilder()
@@ -1184,20 +1220,23 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
          * @param monitorResponses index monitor responses
          * @return map of monitor ids
          */
-        private Map<String, String> mapMonitorIds(List<IndexMonitorResponse> monitorResponses) {
-            return monitorResponses.stream().collect(
-                    Collectors.toMap(
-                        // In the case of bucket level monitors rule id is trigger id
-                        it -> {
+        private Pair<Map<String, String>, Map<String, String>> mapMonitorIds(List<IndexMonitorResponse> monitorResponses) {
+            Map<String, String> bucketMonitorIdPerRuleId = new HashMap<>();
+            Map<String, String> docLevelMonitorIdPerCategory = new HashMap<>();
+            monitorResponses.stream().forEach(it -> {
+                            // In the case of bucket level monitors rule id is trigger id
                             if (MonitorType.BUCKET_LEVEL_MONITOR == it.getMonitor().getMonitorType()) {
-                                return it.getMonitor().getTriggers().get(0).getId();
-                            } else {
-                                return Detector.DOC_LEVEL_MONITOR;
+                                bucketMonitorIdPerRuleId.put(it.getMonitor().getTriggers().get(0).getId(), it.getId());
                             }
-                        },
-                        IndexMonitorResponse::getId
-                    )
+                            // TODO - think something better?; In the case of doc level monitors, key is the rule category/ detector type
+                            // test_windows : abc-xyz-asd
+                            else {
+                                docLevelMonitorIdPerCategory.put(DetectorMonitorConfig.getRuleCategoryFromFindingIndexName(it.getMonitor().getDataSources().getFindingsIndex()), it.getId());
+                            }
+                        }
                 );
+
+            return Pair.of(docLevelMonitorIdPerCategory, bucketMonitorIdPerRuleId);
         }
     }
 

--- a/src/main/resources/mappings/detectors.json
+++ b/src/main/resources/mappings/detectors.json
@@ -160,6 +160,14 @@
                       "type": "text"
                     }
                   }
+                },
+                "detector_types": {
+                  "type": "text",
+                  "fields": {
+                    "keyword": {
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             }

--- a/src/test/java/org/opensearch/securityanalytics/action/IndexDetectorResponseTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/IndexDetectorResponseTests.java
@@ -11,6 +11,7 @@ import org.opensearch.commons.alerting.model.CronSchedule;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.securityanalytics.config.monitors.DetectorMonitorConfig;
 import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.model.DetectorInput;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -29,8 +30,6 @@ public class IndexDetectorResponseTests extends OpenSearchTestCase {
 
         CronSchedule cronSchedule = new CronSchedule(cronExpression, ZoneId.of("Asia/Kolkata"), testInstance);
 
-        Detector.DetectorType detectorType = Detector.DetectorType.LINUX;
-        String detectorTypeString = detectorType.getDetectorType();
         Detector detector = new Detector(
                 "123",
                 0L,
@@ -39,9 +38,8 @@ public class IndexDetectorResponseTests extends OpenSearchTestCase {
                 cronSchedule,
                 Instant.now(),
                 Instant.now(),
-                detectorType,
                 randomUser(),
-                List.of(),
+                List.of(new DetectorInput("", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), List.of(Detector.DetectorType.LINUX))),
                 List.of(),
                 List.of("1", "2", "3"),
                 DetectorMonitorConfig.getRuleIndex(Detector.DetectorType.OTHERS_APPLICATION.getDetectorType()),
@@ -50,6 +48,7 @@ public class IndexDetectorResponseTests extends OpenSearchTestCase {
                 null,
                 null,
                 DetectorMonitorConfig.getFindingsIndex(Detector.DetectorType.OTHERS_APPLICATION.getDetectorType()),
+                Collections.emptyMap(),
                 Collections.emptyMap()
         );
         IndexDetectorResponse response = new IndexDetectorResponse("1234", 1L, RestStatus.OK, detector);

--- a/src/test/java/org/opensearch/securityanalytics/alerts/AlertingServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/alerts/AlertingServiceTests.java
@@ -27,6 +27,7 @@ import org.opensearch.securityanalytics.action.GetDetectorRequest;
 import org.opensearch.securityanalytics.action.GetDetectorResponse;
 import org.opensearch.securityanalytics.config.monitors.DetectorMonitorConfig;
 import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.model.DetectorInput;
 import org.opensearch.securityanalytics.transport.TransportIndexDetectorAction;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -53,9 +54,8 @@ public class AlertingServiceTests extends OpenSearchTestCase {
                 new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
                 Instant.now(),
                 Instant.now(),
-                Detector.DetectorType.OTHERS_APPLICATION,
                 null,
-                List.of(),
+                List.of(new DetectorInput("", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), List.of( Detector.DetectorType.OTHERS_APPLICATION))),
                 List.of(),
                 List.of("monitor_id1", "monitor_id2"),
                 DetectorMonitorConfig.getRuleIndex(Detector.DetectorType.OTHERS_APPLICATION.getDetectorType()),
@@ -64,6 +64,7 @@ public class AlertingServiceTests extends OpenSearchTestCase {
                 null,
                 null,
                 DetectorMonitorConfig.getFindingsIndex(Detector.DetectorType.OTHERS_APPLICATION.getDetectorType()),
+                Collections.emptyMap(),
                 Collections.emptyMap()
         );
         GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
@@ -225,9 +226,8 @@ public class AlertingServiceTests extends OpenSearchTestCase {
                 new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
                 Instant.now(),
                 Instant.now(),
-                Detector.DetectorType.OTHERS_APPLICATION,
                 null,
-                List.of(),
+                List.of(new DetectorInput("", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), List.of(Detector.DetectorType.OTHERS_APPLICATION))),
                 List.of(),
                 List.of("monitor_id1", "monitor_id2"),
                 DetectorMonitorConfig.getRuleIndex(Detector.DetectorType.OTHERS_APPLICATION.getDetectorType()),
@@ -236,6 +236,7 @@ public class AlertingServiceTests extends OpenSearchTestCase {
                 null,
                 null,
                 DetectorMonitorConfig.getFindingsIndex(Detector.DetectorType.OTHERS_APPLICATION.getDetectorType()),
+                Collections.emptyMap(),
                 Collections.emptyMap()
         );
         GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);

--- a/src/test/java/org/opensearch/securityanalytics/alerts/SecureAlertsRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/alerts/SecureAlertsRestApiIT.java
@@ -96,7 +96,7 @@ public class SecureAlertsRestApiIT extends SecurityAnalyticsRestTestCase {
             Action triggerAction = randomAction(createDestination());
 
             Detector detector = randomDetectorWithInputsAndTriggers(List.of(new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(createdId)),
-                    getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()))),
+                    getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()), Collections.emptyList())),
                 List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(), List.of(createdId), List.of(), List.of("attack.defense_evasion"), List.of(triggerAction))));
 
             createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
@@ -208,7 +208,6 @@ public class SecureAlertsRestApiIT extends SecurityAnalyticsRestTestCase {
         } finally {
             tryDeletingRole(TEST_HR_ROLE);
         }
-
     }
 
 

--- a/src/test/java/org/opensearch/securityanalytics/findings/FindingIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/findings/FindingIT.java
@@ -6,30 +6,38 @@
 package org.opensearch.securityanalytics.findings;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
+import org.opensearch.commons.alerting.model.Monitor.MonitorType;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.search.SearchHit;
 import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
 import org.opensearch.securityanalytics.SecurityAnalyticsRestTestCase;
 import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.model.Detector.DetectorType;
 import org.opensearch.securityanalytics.model.DetectorInput;
 import org.opensearch.securityanalytics.model.DetectorRule;
 import org.opensearch.securityanalytics.model.DetectorTrigger;
 
 import static org.opensearch.securityanalytics.TestHelpers.netFlowMappings;
+import static org.opensearch.securityanalytics.TestHelpers.randomAggregationRule;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorType;
+import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputs;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithTriggers;
 import static org.opensearch.securityanalytics.TestHelpers.randomDoc;
 import static org.opensearch.securityanalytics.TestHelpers.randomIndex;
+import static org.opensearch.securityanalytics.TestHelpers.randomRule;
 import static org.opensearch.securityanalytics.TestHelpers.windowsIndexMapping;
 import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.FINDING_HISTORY_INDEX_MAX_AGE;
 import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.FINDING_HISTORY_MAX_DOCS;
@@ -147,10 +155,358 @@ public class FindingIT extends SecurityAnalyticsRestTestCase {
         Assert.assertEquals(5, noOfSigmaRuleMatches);
         // Call GetFindings API
         Map<String, String> params = new HashMap<>();
-        params.put("detectorType", detector.getDetectorType());
+        params.put("detectorType", detector.getDetectorTypes().get(0));
         Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
         Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
         Assert.assertEquals(1, getFindingsBody.get("total_findings"));
+    }
+
+    public void testGetFindings_byDetectorType_oneDetector_multipleDetectorTypes_success() throws IOException {
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        Response response = client().performRequest(createMappingRequest);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + "windows" + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        response = client().performRequest(createMappingRequest);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        // Fetching 10 rules -> 5 from test_windows and 5 from windows category
+        List<String> prepackagedRules = getRandomPrePackagedRules();
+        String randomDocRuleId = createRule(randomRule(), "windows");
+
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(randomDocRuleId)),
+            prepackagedRules.stream().map(DetectorRule::new).collect(Collectors.toList()), List.of(DetectorType.TEST_WINDOWS, DetectorType.WINDOWS));
+
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+        assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+
+        Map<String, Object> responseBody = asMap(createResponse);
+        String createdId = responseBody.get("_id").toString();
+
+        String request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + createdId + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+
+        Map<String, List> detectorMap = (HashMap<String,List>)(hit.getSourceAsMap().get("detector"));
+        List inputArr = detectorMap.get("inputs");
+
+        assertEquals("Number of custom rules not correct", 1, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
+
+        List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
+
+        assertEquals("Number of monitors not correct", 2, monitorIds.size());
+
+        Map<String, String> docLevelMonitorIdPerCategory = ((Map<String, String>)((Map<String, Object>)hit.getSourceAsMap().get("detector")).get("doc_monitor_id_per_category"));
+        // Swapping keys and values
+        Map<String, String> ruleIdRuleCategoryMap =  docLevelMonitorIdPerCategory.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+
+        String infoOpCode = "Info";
+        String testOpCode = "Test";
+        indexDoc(index, "1", randomDoc(2, 4, infoOpCode));
+        indexDoc(index, "2", randomDoc(3, 4, infoOpCode));
+        indexDoc(index, "3", randomDoc(1, 4, infoOpCode));
+        indexDoc(index, "4", randomDoc(5, 3, testOpCode));
+        indexDoc(index, "5", randomDoc(2, 3, testOpCode));
+        indexDoc(index, "6", randomDoc(4, 3, testOpCode));
+        indexDoc(index, "7", randomDoc(6, 2, testOpCode));
+        indexDoc(index, "8", randomDoc(1, 1, testOpCode));
+
+        Set<String> expectedDocIds = Set.of("1", "2", "3", "4", "5", "6", "7", "8");
+
+        for(String monitorId: monitorIds) {
+            Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+            Map<String, Object> executeResults = entityAsMap(executeResponse);
+
+            String ruleCategory = ruleIdRuleCategoryMap.get(monitorId);
+            int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+
+            if (ruleCategory.toLowerCase(Locale.ROOT).equals(DetectorType.WINDOWS.getDetectorType().toLowerCase(Locale.ROOT))) {
+                Assert.assertEquals(1, noOfSigmaRuleMatches);
+                // Call GetFindings API
+                Map<String, String> params = new HashMap<>();
+                params.put("detectorType", DetectorType.WINDOWS.getDetectorType());
+                Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+                Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+
+                assertEquals("Number of total findings for windows category not correct", 8, getFindingsBody.get("total_findings"));
+                assertFindingsPerExecutedDocLevelMonitor(getFindingsBody, expectedDocIds);
+
+            } else {
+                assertEquals("Number of doc level rules for test_windows category not correct", 5, noOfSigmaRuleMatches);
+                // Call GetFindings API
+                Map<String, String> params = new HashMap<>();
+                params.put("detectorType", DetectorType.TEST_WINDOWS.getDetectorType());
+                Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+                Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+
+                assertEquals("Number of total findings for test_windows category not correct", 8, getFindingsBody.get("total_findings"));
+                assertFindingsPerExecutedDocLevelMonitor(getFindingsBody, expectedDocIds);
+            }
+        }
+    }
+    public void testGetFindings_byDetectorType_multipleDetectorTypes_FindingForOneLogType_success() throws IOException {
+        String infoOpCode = "Info";
+        String testOpCode = "Test";
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        Response response = client().performRequest(createMappingRequest);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + "windows" + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        response = client().performRequest(createMappingRequest);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        // Fetching 6 rules -> 5 from test_windows and 1 from windows category (custom doc rule)
+        List<String> prepackagedRules = getRandomPrePackagedRules();
+        String maxRuleId = createRule(randomAggregationRule("max", " > 3", testOpCode));
+
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(maxRuleId)),
+            prepackagedRules.stream().map(DetectorRule::new).collect(Collectors.toList()), List.of(DetectorType.TEST_WINDOWS, DetectorType.WINDOWS));
+
+        Detector detector = randomDetectorWithInputs(List.of(input));
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+
+        assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+
+        Map<String, Object> responseBody = asMap(createResponse);
+
+        String detectorId = responseBody.get("_id").toString();
+
+        String request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+
+        Map<String, List> detectorMap = (HashMap<String,List>)(hit.getSourceAsMap().get("detector"));
+        List inputArr = detectorMap.get("inputs");
+        assertEquals("Number of custom rules not correct", 1, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
+        List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
+        // 2 doc level monitors - one per each category: test_windows and windows
+        // 1 bucket level monitor - for windows category
+        assertEquals("Number of monitors not correct", 2, monitorIds.size());
+
+        Map<String, String> docLevelMonitorIdPerCategory = ((Map<String, String>)((Map<String, Object>)hit.getSourceAsMap().get("detector")).get("doc_monitor_id_per_category"));
+        // Swapping keys and values
+        Map<String, String> ruleIdRuleCategoryMap =  docLevelMonitorIdPerCategory.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+
+
+        indexDoc(index, "1", randomDoc(2, 4, infoOpCode));
+        indexDoc(index, "2", randomDoc(3, 4, infoOpCode));
+        indexDoc(index, "3", randomDoc(1, 4, infoOpCode));
+        indexDoc(index, "4", randomDoc(2, 3, testOpCode));
+        indexDoc(index, "5", randomDoc(2, 3, testOpCode));
+        indexDoc(index, "6", randomDoc(1, 3, testOpCode));
+        indexDoc(index, "7", randomDoc(1, 2, testOpCode));
+        indexDoc(index, "8", randomDoc(1, 1, testOpCode));
+        Set<String> expectedDocIds = Set.of("1", "2", "3", "4", "5", "6", "7", "8");
+
+        Map<String, Integer> numberOfMonitorTypes = new HashMap<>();
+
+        for(String monitorId: monitorIds) {
+            Map<String, String> monitor  = (Map<String, String>)(entityAsMap(client().performRequest(new Request("GET", "/_plugins/_alerting/monitors/" + monitorId)))).get("monitor");
+            numberOfMonitorTypes.merge(monitor.get("monitor_type"), 1, Integer::sum);
+            Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+            Map<String, Object> executeResults = entityAsMap(executeResponse);
+
+            if (MonitorType.DOC_LEVEL_MONITOR.getValue().equals(monitor.get("monitor_type"))) {
+                int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+                assertEquals("Number of doc level rules not correct", 5, noOfSigmaRuleMatches);
+
+                // Call GetFindings API
+                Map<String, String> params = new HashMap<>();
+                params.put("detectorType", DetectorType.TEST_WINDOWS.getDetectorType());
+                Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+                Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+
+                assertEquals("Number of total findings for test_windows category not correct", 8, getFindingsBody.get("total_findings"));
+                assertFindingsPerExecutedDocLevelMonitor(getFindingsBody, expectedDocIds);
+            } else {
+                List<Map<String, Object>> buckets = ((List<Map<String, Object>>)(((Map<String, Object>)((Map<String, Object>)((Map<String, Object>)((List<Object>)((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0)).get("aggregations")).get("result_agg")).get("buckets")));
+                Integer docCount = buckets.stream().mapToInt(it -> (Integer)it.get("doc_count")).sum();
+                assertEquals("Number of bucket level monitors not correct", 5, docCount.intValue());
+                List<String> triggerResultBucketKeys = ((Map<String, Object>)((Map<String, Object>) ((Map<String, Object>)executeResults.get("trigger_results")).get(maxRuleId)).get("agg_result_buckets")).keySet().stream().collect(Collectors.toList());
+                assertEquals(Collections.emptyList(), triggerResultBucketKeys);
+
+                // Call GetFindings API
+                Map<String, String> params = new HashMap<>();
+                params.put("detectorType", DetectorType.WINDOWS.getDetectorType());
+                Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+                Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+                assertEquals("Number of total findings for windows category not correct", 0, getFindingsBody.get("total_findings"));
+            }
+        }
+        assertEquals("Number of bucket level monitors not correct", 1, numberOfMonitorTypes.get(MonitorType.BUCKET_LEVEL_MONITOR.getValue()).intValue());
+        assertEquals("Number of doc level monitors not correct", 1, numberOfMonitorTypes.get(MonitorType.DOC_LEVEL_MONITOR.getValue()).intValue());
+    }
+
+    public void testGetFindings_byDetectorId_oneDetector_multipleDetectorTypes_success() throws IOException {
+        String infoOpCode = "Info";
+        String testOpCode = "Test";
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        Response response = client().performRequest(createMappingRequest);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + "windows" + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        response = client().performRequest(createMappingRequest);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        // Fetching 6 rules -> 5 from test_windows and 1 from windows category (custom doc rule)
+        List<String> prepackagedRules = getRandomPrePackagedRules();
+        String randomDocRuleId = createRule(randomRule(), "windows");
+        String maxRuleId = createRule(randomAggregationRule("max", " > 3", testOpCode));
+
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(randomDocRuleId), new DetectorRule(maxRuleId)),
+            prepackagedRules.stream().map(DetectorRule::new).collect(Collectors.toList()), List.of(DetectorType.TEST_WINDOWS, DetectorType.WINDOWS));
+
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+
+        assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+
+        Map<String, Object> responseBody = asMap(createResponse);
+
+        String detectorId = responseBody.get("_id").toString();
+
+        String request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+
+        Map<String, List> detectorMap = (HashMap<String,List>)(hit.getSourceAsMap().get("detector"));
+        List inputArr = detectorMap.get("inputs");
+        assertEquals("Number of custom rules not correct",  2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
+        List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
+        // 2 doc level monitors - one per each category: test_windows and windows
+        // 1 bucket level monitor - for windows category
+        assertEquals("Number of monitors not correct", 3, monitorIds.size());
+
+        Map<String, String> docLevelMonitorIdPerCategory = ((Map<String, String>)((Map<String, Object>)hit.getSourceAsMap().get("detector")).get("doc_monitor_id_per_category"));
+        // Swapping keys and values
+        Map<String, String> ruleIdRuleCategoryMap =  docLevelMonitorIdPerCategory.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+
+
+        indexDoc(index, "1", randomDoc(2, 4, infoOpCode));
+        indexDoc(index, "2", randomDoc(3, 4, infoOpCode));
+        indexDoc(index, "3", randomDoc(1, 4, infoOpCode));
+        indexDoc(index, "4", randomDoc(5, 3, testOpCode));
+        indexDoc(index, "5", randomDoc(2, 3, testOpCode));
+        indexDoc(index, "6", randomDoc(4, 3, testOpCode));
+        indexDoc(index, "7", randomDoc(6, 2, testOpCode));
+        indexDoc(index, "8", randomDoc(1, 1, testOpCode));
+
+        Map<String, Integer> numberOfMonitorTypes = new HashMap<>();
+
+        for(String monitorId: monitorIds) {
+            Map<String, String> monitor  = (Map<String, String>)(entityAsMap(client().performRequest(new Request("GET", "/_plugins/_alerting/monitors/" + monitorId)))).get("monitor");
+            numberOfMonitorTypes.merge(monitor.get("monitor_type"), 1, Integer::sum);
+            Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+            Map<String, Object> executeResults = entityAsMap(executeResponse);
+
+            if (MonitorType.DOC_LEVEL_MONITOR.getValue().equals(monitor.get("monitor_type"))) {
+                String ruleCategory = ruleIdRuleCategoryMap.get(monitorId);
+                int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+                if (ruleCategory.toLowerCase(Locale.ROOT).equals(DetectorType.WINDOWS.getDetectorType().toLowerCase(Locale.ROOT))) {
+                    assertEquals("Number of doc level rules for windows category not correct", 1, noOfSigmaRuleMatches);
+                } else if(ruleCategory.toLowerCase(Locale.ROOT).equals(DetectorType.TEST_WINDOWS.getDetectorType().toLowerCase(Locale.ROOT))){
+                    assertEquals("Number of doc level rules for test_windows category not correct", 5, noOfSigmaRuleMatches);
+                }
+            } else {
+                List<Map<String, Object>> buckets = ((List<Map<String, Object>>)(((Map<String, Object>)((Map<String, Object>)((Map<String, Object>)((List<Object>)((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0)).get("aggregations")).get("result_agg")).get("buckets")));
+                Integer docCount = buckets.stream().mapToInt(it -> (Integer)it.get("doc_count")).sum();
+                assertEquals("Number of documents in buckets not correct", 5, docCount.intValue());
+                List<String> triggerResultBucketKeys = ((Map<String, Object>)((Map<String, Object>) ((Map<String, Object>)executeResults.get("trigger_results")).get(maxRuleId)).get("agg_result_buckets")).keySet().stream().collect(Collectors.toList());
+                assertEquals("Trigger result not correct", List.of("2", "3"), triggerResultBucketKeys);
+            }
+        }
+
+        assertEquals("Number of bucket level monitors not correct", 1, numberOfMonitorTypes.get(MonitorType.BUCKET_LEVEL_MONITOR.getValue()).intValue());
+        assertEquals("Number of doc level monitors not correct", 2, numberOfMonitorTypes.get(MonitorType.DOC_LEVEL_MONITOR.getValue()).intValue());
+
+        Map<String, String> params = new HashMap<>();
+        params.put("detector_id", detectorId);
+        Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+        Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+        // 8 findings from prepackaged doc rules
+        // 8 findings from custom created doc level rule
+        // 1 finding from custom aggregation rule
+        assertEquals("Number of total findings not correct", 17, getFindingsBody.get("total_findings"));
     }
 
     public void testGetFindings_byDetectorType_success() throws IOException {
@@ -205,11 +561,10 @@ public class FindingIT extends SecurityAnalyticsRestTestCase {
         String monitorId1 = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
         // Detector 2 - NETWORK
         DetectorInput inputNetflow = new DetectorInput("windows detector for security analytics", List.of("netflow_test"), Collections.emptyList(),
-                getPrePackagedRules("network").stream().map(DetectorRule::new).collect(Collectors.toList()));
+                getPrePackagedRules("network").stream().map(DetectorRule::new).collect(Collectors.toList()), List.of(Detector.DetectorType.NETWORK));
         Detector detector2 = randomDetectorWithTriggers(
                 getPrePackagedRules("network"),
                 List.of(new DetectorTrigger(null, "test-trigger", "1", List.of("network"), List.of(), List.of(), List.of(), List.of())),
-                Detector.DetectorType.NETWORK,
                 inputNetflow
         );
 
@@ -251,17 +606,18 @@ public class FindingIT extends SecurityAnalyticsRestTestCase {
 
         // Call GetFindings API for first detector
         Map<String, String> params = new HashMap<>();
-        params.put("detectorType", detector1.getDetectorType());
+        params.put("detectorType", detector1.getDetectorTypes().get(0));
         Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
         Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
         Assert.assertEquals(1, getFindingsBody.get("total_findings"));
         // Call GetFindings API for second detector
         params.clear();
-        params.put("detectorType", detector2.getDetectorType());
+        params.put("detectorType", detector2.getDetectorTypes().get(0));
         getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
         getFindingsBody = entityAsMap(getFindingsResponse);
         Assert.assertEquals(1, getFindingsBody.get("total_findings"));
     }
+
 
     public void testGetFindings_rolloverByMaxAge_success() throws IOException, InterruptedException {
 
@@ -318,9 +674,9 @@ public class FindingIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
         Assert.assertEquals(1, getFindingsBody.get("total_findings"));
 
-        List<String> findingIndices = getFindingIndices(detector.getDetectorType());
+        List<String> findingIndices = getFindingIndices(detector.getDetectorTypes().get(0));
         while(findingIndices.size() < 2) {
-            findingIndices = getFindingIndices(detector.getDetectorType());
+            findingIndices = getFindingIndices(detector.getDetectorTypes().get(0));
             Thread.sleep(1000);
         }
         assertTrue("Did not find 3 alert indices", findingIndices.size() >= 2);
@@ -381,9 +737,9 @@ public class FindingIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
         Assert.assertEquals(1, getFindingsBody.get("total_findings"));
 
-        List<String> findingIndices = getFindingIndices(detector.getDetectorType());
+        List<String> findingIndices = getFindingIndices(detector.getDetectorTypes().get(0));
         while(findingIndices.size() < 2) {
-            findingIndices = getFindingIndices(detector.getDetectorType());
+            findingIndices = getFindingIndices(detector.getDetectorTypes().get(0));
             Thread.sleep(1000);
         }
         assertTrue("Did not find 3 alert indices", findingIndices.size() >= 2);
@@ -444,9 +800,9 @@ public class FindingIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
         Assert.assertEquals(1, getFindingsBody.get("total_findings"));
 
-        List<String> findingIndices = getFindingIndices(detector.getDetectorType());
+        List<String> findingIndices = getFindingIndices(detector.getDetectorTypes().get(0));
         while(findingIndices.size() < 2) {
-            findingIndices = getFindingIndices(detector.getDetectorType());
+            findingIndices = getFindingIndices(detector.getDetectorTypes().get(0));
             Thread.sleep(1000);
         }
         assertTrue("Did not find 3 findings indices", findingIndices.size() >= 2);
@@ -454,7 +810,7 @@ public class FindingIT extends SecurityAnalyticsRestTestCase {
         updateClusterSetting(FINDING_HISTORY_RETENTION_PERIOD.getKey(), "1s");
         updateClusterSetting(FINDING_HISTORY_MAX_DOCS.getKey(), "1000");
         while(findingIndices.size() != 1) {
-            findingIndices = getFindingIndices(detector.getDetectorType());
+            findingIndices = getFindingIndices(detector.getDetectorTypes().get(0));
             Thread.sleep(1000);
         }
 
@@ -472,5 +828,14 @@ public class FindingIT extends SecurityAnalyticsRestTestCase {
         getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
         getFindingsBody = entityAsMap(getFindingsResponse);
         Assert.assertEquals(1, getFindingsBody.get("total_findings"));
+    }
+
+    private static void assertFindingsPerExecutedDocLevelMonitor(Map<String, Object> getFindingsBody, Set<String> expectedDocIds) {
+        List<Map<String, Object>> findings = (List) getFindingsBody.get("findings");
+        List<String> relatedDocFinding = new ArrayList<>();
+        for(Map<String, Object> finding : findings) {
+            relatedDocFinding.addAll((List<String>) finding.get("related_doc_ids"));
+        }
+        assertTrue(expectedDocIds.containsAll(relatedDocFinding));
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/findings/FindingServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/findings/FindingServiceTests.java
@@ -28,6 +28,7 @@ import org.opensearch.securityanalytics.action.GetDetectorResponse;
 import org.opensearch.securityanalytics.action.GetFindingsResponse;
 import org.opensearch.securityanalytics.config.monitors.DetectorMonitorConfig;
 import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.model.DetectorInput;
 import org.opensearch.test.OpenSearchTestCase;
 
 
@@ -53,9 +54,8 @@ public class FindingServiceTests extends OpenSearchTestCase {
                 new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
                 Instant.now(),
                 Instant.now(),
-                Detector.DetectorType.OTHERS_APPLICATION,
                 null,
-                List.of(),
+                List.of(new DetectorInput("", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), List.of(Detector.DetectorType.OTHERS_APPLICATION))),
                 List.of(),
                 List.of("monitor_id1", "monitor_id2"),
                 DetectorMonitorConfig.getRuleIndex(Detector.DetectorType.OTHERS_APPLICATION.getDetectorType()),
@@ -64,6 +64,7 @@ public class FindingServiceTests extends OpenSearchTestCase {
                 null,
                 null,
                 DetectorMonitorConfig.getFindingsIndex(Detector.DetectorType.OTHERS_APPLICATION.getDetectorType()),
+                Collections.emptyMap(),
                 Collections.emptyMap()
         );
         GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
@@ -169,9 +170,8 @@ public class FindingServiceTests extends OpenSearchTestCase {
                 new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
                 Instant.now(),
                 Instant.now(),
-                Detector.DetectorType.OTHERS_APPLICATION,
                 null,
-                List.of(),
+                List.of(new DetectorInput("", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), List.of(Detector.DetectorType.OTHERS_APPLICATION))),
                 List.of(),
                 List.of("monitor_id1", "monitor_id2"),
                 DetectorMonitorConfig.getRuleIndex(Detector.DetectorType.OTHERS_APPLICATION.getDetectorType()),
@@ -180,6 +180,7 @@ public class FindingServiceTests extends OpenSearchTestCase {
                 null,
                 null,
                 DetectorMonitorConfig.getFindingsIndex(Detector.DetectorType.OTHERS_APPLICATION.getDetectorType()),
+                Collections.emptyMap(),
                 Collections.emptyMap()
         );
         GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);

--- a/src/test/java/org/opensearch/securityanalytics/findings/SecureFindingRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/findings/SecureFindingRestApiIT.java
@@ -221,18 +221,16 @@ public class SecureFindingRestApiIT extends SecurityAnalyticsRestTestCase {
                 "     }\n" +
                 "   }\n" +
                 "}";
-            List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
-            SearchHit hit = hits.get(0);
-            String monitorId1 = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
-            // Detector 2 - NETWORK
-            DetectorInput inputNetflow = new DetectorInput("windows detector for security analytics", List.of("netflow_test"), Collections.emptyList(),
-                getPrePackagedRules("network").stream().map(DetectorRule::new).collect(Collectors.toList()));
-            Detector detector2 = randomDetectorWithTriggers(
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+        String monitorId1 = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
+        // Detector 2 - NETWORK
+        DetectorInput inputNetflow = new DetectorInput("windows detector for security analytics", List.of("netflow_test"), Collections.emptyList(),
+                getPrePackagedRules("network").stream().map(DetectorRule::new).collect(Collectors.toList()), List.of(Detector.DetectorType.NETWORK));
+        Detector detector2 = randomDetectorWithTriggers(
                 getPrePackagedRules("network"),
-                List.of(new DetectorTrigger(null, "test-trigger", "1", List.of("network"), List.of(), List.of(), List.of(), List.of())),
-                Detector.DetectorType.NETWORK,
-                inputNetflow
-            );
+                List.of(new DetectorTrigger(null, "test-trigger", "1", List.of("network"), List.of(), List.of(), List.of(), List.of())), inputNetflow
+        );
 
             createResponse = makeRequest(userClient, "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector2));
             Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
@@ -280,13 +278,13 @@ public class SecureFindingRestApiIT extends SecurityAnalyticsRestTestCase {
 
             // Call GetFindings API for first detector
             Map<String, String> params = new HashMap<>();
-            params.put("detectorType", detector1.getDetectorType());
+            params.put("detectorType", detector1.getDetectorTypes().get(0));
             Response getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
             Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
             Assert.assertEquals(1, getFindingsBody.get("total_findings"));
             // Call GetFindings API for second detector
             params.clear();
-            params.put("detectorType", detector2.getDetectorType());
+            params.put("detectorType", detector2.getDetectorTypes().get(0));
             getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
             getFindingsBody = entityAsMap(getFindingsResponse);
             Assert.assertEquals(1, getFindingsBody.get("total_findings"));

--- a/src/test/java/org/opensearch/securityanalytics/model/WriteableTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/WriteableTests.java
@@ -21,7 +21,7 @@ public class WriteableTests extends OpenSearchTestCase {
 
     public void testDetectorAsStream() throws IOException {
         Detector detector = randomDetector(List.of());
-        detector.setInputs(List.of(new DetectorInput("", List.of(), List.of(), List.of())));
+        detector.setInputs(List.of(new DetectorInput("", List.of(), List.of(), List.of(), List.of())));
         BytesStreamOutput out = new BytesStreamOutput();
         detector.writeTo(out);
         StreamInput sin = StreamInput.wrap(out.bytes().toBytesRef().bytes);

--- a/src/test/java/org/opensearch/securityanalytics/model/XContentTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/XContentTests.java
@@ -34,7 +34,6 @@ public class XContentTests extends OpenSearchTestCase {
     public void testDetectorParsingWithNoName() {
         String detectorStringWithoutName = "{\n" +
                 "  \"type\": \"detector\",\n" +
-                "  \"detector_type\": \"WINDOWS\",\n" +
                 "  \"user\": {\n" +
                 "    \"name\": \"JPXeGWmlMP\",\n" +
                 "    \"backend_roles\": [\n" +
@@ -66,7 +65,8 @@ public class XContentTests extends OpenSearchTestCase {
                 "          \"windows\"\n" +
                 "        ],\n" +
                 "        \"custom_rules\": [],\n" +
-                "        \"pre_packaged_rules\": []\n" +
+                "        \"pre_packaged_rules\": [],\n" +
+                "        \"detector_types\": [\"WINDOWS\"]\n" +
                 "      }\n" +
                 "    }\n" +
                 "  ],\n" +
@@ -106,7 +106,6 @@ public class XContentTests extends OpenSearchTestCase {
         String detectorStringWithoutSchedule = "{\n" +
                 "  \"type\": \"detector\",\n" +
                 "  \"name\": \"BCIocIalTX\",\n" +
-                "  \"detector_type\": \"WINDOWS\",\n" +
                 "  \"user\": {\n" +
                 "    \"name\": \"JPXeGWmlMP\",\n" +
                 "    \"backend_roles\": [\n" +
@@ -132,7 +131,8 @@ public class XContentTests extends OpenSearchTestCase {
                 "          \"windows\"\n" +
                 "        ],\n" +
                 "        \"custom_rules\": [],\n" +
-                "        \"pre_packaged_rules\": []\n" +
+                "        \"pre_packaged_rules\": [],\n" +
+                "        \"detector_types\": [\"WINDOWS\"]\n" +
                 "      }\n" +
                 "    }\n" +
                 "  ],\n" +

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/RuleRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/RuleRestApiIT.java
@@ -412,7 +412,7 @@ public class RuleRestApiIT extends SecurityAnalyticsRestTestCase {
         String createdId = responseBody.get("_id").toString();
 
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(),
-                getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()));
+                getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()), Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
 
         createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
@@ -451,7 +451,7 @@ public class RuleRestApiIT extends SecurityAnalyticsRestTestCase {
         String createdId = responseBody.get("_id").toString();
 
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(createdId)),
-                getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()));
+                getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()), Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
 
         createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
@@ -570,7 +570,7 @@ public class RuleRestApiIT extends SecurityAnalyticsRestTestCase {
         String createdId = responseBody.get("_id").toString();
 
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(),
-                getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()));
+                getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()), Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
 
         createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
@@ -607,7 +607,7 @@ public class RuleRestApiIT extends SecurityAnalyticsRestTestCase {
         String createdId = responseBody.get("_id").toString();
 
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), List.of(new DetectorRule(createdId)),
-                getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()));
+                getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()), Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
 
         createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));


### PR DESCRIPTION
### Description
Added multiple detector types as part of DetectorInput. Extended detector with new field: docLevelMonitorPerCategory used for storing the doc level category:monitorId pairs (used when detector is being updated in order to determine which monitors should be deleted and which query indices should be removed).

In order to support multiple detector types, detectorInput has been extended with List detectorTypes property. To keep the possibility of getting all alerts and findings per detector type and per detector id AlertsService and FindingsService has been extended to use the groupedListener and then they are joining/merging the search alert/finding results.

When updating the detector, if one of the doc level monitor has been deleted by deselecting rules, and the whole rule category has been removed, query index will also be deleted.

[Here](https://docs.google.com/document/d/1iFo3gBeWp37CTwWLFkGb9fkGqfCEygyRCzDOm1ohkkI/edit) is the document describing the changes from the perspective of client
 
### Issues Resolved
[https://github.com/opensearch-project/security-analytics/issues/191]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
