### PR TITLE
changes to return empty search response for custom rules

### DIFF
--- a/src/test/java/org/opensearch/securityanalytics/resthandler/RuleRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/RuleRestApiIT.java
@@ -273,6 +273,19 @@ public class RuleRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertEquals(17, ((Map<String, Object>) ((Map<String, Object>) responseBody.get("hits")).get("total")).get("value"));
     }
 
+    public void testSearchingCustomRulesWhenNoneExist() throws IOException {
+        String request = "{\n" +
+                "  \"query\": {\n" +
+                "        \"match_all\": {}\n" +
+                "    }\n" +
+                "}";
+
+        Response searchResponse = makeRequest(client(), "POST", String.format(Locale.getDefault(), "%s/_search", SecurityAnalyticsPlugin.RULE_BASE_URI), Collections.singletonMap("pre_packaged", "false"),
+                new StringEntity(request), new BasicHeader("Content-Type", "application/json"));
+        Assert.assertEquals("Searching rules failed", RestStatus.OK, restStatus(searchResponse));
+        Map<String, Object> responseBody = asMap(searchResponse);
+        Assert.assertEquals(0, ((Map<String, Object>) ((Map<String, Object>) responseBody.get("hits")).get("total")).get("value"));
+    }
     @SuppressWarnings("unchecked")
     public void testSearchingCustomRules() throws IOException {
         String rule = randomRule();


### PR DESCRIPTION
Signed-off-by: Raj Chakravarthi <raj@icedome.ca>

### Description
This returns an empty search response (status 200) when there are no custom rules configured instead of throwing an exception. Integration test also written.
 
### Issues Resolved
https://github.com/opensearch-project/security-analytics/issues/205 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
