### PR TITLE
Fixed SecureFindingRestApiIT. Removed uppercasing of the detector type

### DIFF
--- a/src/test/java/org/opensearch/securityanalytics/findings/SecureFindingRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/findings/SecureFindingRestApiIT.java
@@ -280,13 +280,13 @@ public class SecureFindingRestApiIT extends SecurityAnalyticsRestTestCase {
 
             // Call GetFindings API for first detector
             Map<String, String> params = new HashMap<>();
-            params.put("detectorType", detector1.getDetectorType().toUpperCase());
+            params.put("detectorType", detector1.getDetectorType());
             Response getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
             Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
             Assert.assertEquals(1, getFindingsBody.get("total_findings"));
             // Call GetFindings API for second detector
             params.clear();
-            params.put("detectorType", detector2.getDetectorType().toUpperCase());
+            params.put("detectorType", detector2.getDetectorType());
             getFindingsResponse = makeRequest(userReadOnlyClient, "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
             getFindingsBody = entityAsMap(getFindingsResponse);
             Assert.assertEquals(1, getFindingsBody.get("total_findings"));


### PR DESCRIPTION
Signed-off-by: Stevan Buzejic <buzejic.stevan@gmail.com>

### Description
Fix for SecureFindingRestApiIT -> removed upperCasing without specified locale
 
### Issues Resolved
https://github.com/opensearch-project/security-analytics/issues/246
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
