### PR TITLE
Fixed error message logging to consider all the indices

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -196,7 +196,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             public void onFailure(Exception e) {
                 if (e instanceof OpenSearchStatusException) {
                     listener.onFailure(SecurityAnalyticsException.wrap(
-                        new OpenSearchStatusException(String.format(Locale.getDefault(), "User doesn't have read permissions for one or more configured index %s", detectorIndices), RestStatus.FORBIDDEN)
+                        new OpenSearchStatusException(String.format(Locale.getDefault(), "User doesn't have read permissions for one or more configured index %s", String.join(", ", detectorIndices)), RestStatus.FORBIDDEN)
                     ));
                 } else if (e instanceof IndexNotFoundException) {
                     listener.onFailure(SecurityAnalyticsException.wrap(


### PR DESCRIPTION
Signed-off-by: Stevan Buzejic <buzejic.stevan@gmail.com>

### Description
Joining the list of the indices for error message if the user can't access to one or more indices. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
