### PR TITLE
Added integration test that verifies acking the bucket level alerts v…

### DIFF
--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -64,6 +64,11 @@ public class TestHelpers {
                 rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
         return randomDetector(null, null, null, List.of(input), triggers, null, null, null, null);
     }
+
+    public static Detector randomDetectorWithTriggers(List<DetectorTrigger> triggers, DetectorInput input) {
+        return randomDetector(null, null, null, List.of(input), triggers, null, null, null, null);
+    }
+
     public static Detector randomDetectorWithTriggers(List<String> rules, List<DetectorTrigger> triggers, List<String> inputIndices) {
         DetectorInput input = new DetectorInput("windows detector for security analytics", inputIndices, Collections.emptyList(),
                 rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
@@ -120,7 +125,6 @@ public class TestHelpers {
         }
         if (triggers.size() == 0) {
             triggers = new ArrayList<>();
-
             DetectorTrigger trigger = new DetectorTrigger(null, "windows-trigger", "1", List.of(randomDetectorType()), List.of("QuarksPwDump Clearing Access History"), List.of("high"), List.of("T0008"), List.of());
             triggers.add(trigger);
         }


### PR DESCRIPTION
…ia SA plugin

Signed-off-by: Stevan Buzejic <buzejic.stevan@gmail.com>

### Description
Added integration test that will fail until the alerting is merged. This integration test tries to ack the bucket level alerts together with the doc level rules. In order to achieve acking, first alerts are being retrieved by their ids. For the bucket level alerts ids are missing - that's why [this PR](https://github.com/opensearch-project/alerting/pull/753) needs to be merged in order to pass the integration test.
 
### Issues Resolved
(https://github.com/opensearch-project/alerting/issues/748)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
