### PR TITLE
changes to make id not mandatory for creating custom rule

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/rules/objects/SigmaRule.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/objects/SigmaRule.java
@@ -89,11 +89,13 @@ public class SigmaRule {
     }
 
     @SuppressWarnings("unchecked")
-    protected static SigmaRule fromDict(Map<String, Object> rule, boolean collectErrors) throws SigmaError {
+    protected static SigmaRule fromDict(Map<String, Object> rule, boolean collectErrors, boolean isCustom) throws SigmaError {
         List<SigmaError> errors = new ArrayList<>();
 
         UUID ruleId;
-        if (rule.containsKey("id")) {
+        if (isCustom)
+            ruleId = null;
+        else if (rule.containsKey("id")) {
             try {
                 ruleId = UUID.fromString(rule.get("id").toString());
             } catch (IllegalArgumentException ex) {
@@ -176,7 +178,16 @@ public class SigmaRule {
 
         Yaml yaml = new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), loaderOptions);
         Map<String, Object> ruleMap = yaml.load(rule);
-        return fromDict(ruleMap, collectErrors);
+        return fromDict(ruleMap, collectErrors, false);
+    }
+
+    public static SigmaRule fromYamlCustom(String rule, boolean collectErrors) throws SigmaError {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setNestingDepthLimit(10);
+
+        Yaml yaml = new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), loaderOptions);
+        Map<String, Object> ruleMap = yaml.load(rule);
+        return fromDict(ruleMap, collectErrors, true);
     }
 
     public String getTitle() {

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
@@ -174,7 +174,8 @@ public class TransportIndexRuleAction extends HandledTransportAction<IndexRuleRe
             String category = request.getLogType().toLowerCase(Locale.ROOT);
 
             try {
-                SigmaRule parsedRule = SigmaRule.fromYaml(rule, true);
+                SigmaRule parsedRule = SigmaRule.fromYamlCustom(rule, true);
+
                 if (parsedRule.getErrors() != null && parsedRule.getErrors().size() > 0) {
                     onFailures(parsedRule.getErrors().toArray(new SigmaError[]{}));
                     return;

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -141,7 +141,6 @@ public class TestHelpers {
 
     public static String randomRule() {
         return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
                 "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
                 "references:\n" +
                 "    - https://attack.mitre.org/tactics/TA0008/\n" +
@@ -170,7 +169,6 @@ public class TestHelpers {
 
     public static String countAggregationTestRule() {
         return "            title: Test\n" +
-                "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
                 "            status: test\n" +
                 "            level: critical\n" +
                 "            description: Detects QuarksPwDump clearing access history in hive\n" +

--- a/src/test/java/org/opensearch/securityanalytics/rules/objects/SigmaRuleTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/objects/SigmaRuleTests.java
@@ -38,13 +38,14 @@ public class SigmaRuleTests extends OpenSearchTestCase {
 
     public void testSigmaRuleBadUuid() {
         Exception exception = assertThrows(SigmaIdentifierError.class, () -> {
-            SigmaRule.fromDict(Collections.singletonMap("id", "no-uuid"), false);
+            SigmaRule.fromDict(Collections.singletonMap("id", "no-uuid"), false, false);
         });
 
         String expectedMessage = "Sigma rule identifier must be an UUID";
         String actualMessage = exception.getMessage();
 
         assertTrue(actualMessage.contains(expectedMessage));
+
     }
 
     public void testSigmaRuleBadLevel() {
@@ -52,7 +53,7 @@ public class SigmaRuleTests extends OpenSearchTestCase {
         sigmaRule.put("id", java.util.UUID.randomUUID().toString());
 
         Exception exception = assertThrows(SigmaLevelError.class, () -> {
-            SigmaRule.fromDict(sigmaRule, false);
+            SigmaRule.fromDict(sigmaRule, false, true);
         });
 
         String expectedMessage = "null is no valid Sigma rule level";
@@ -67,7 +68,7 @@ public class SigmaRuleTests extends OpenSearchTestCase {
         sigmaRule.put("level", "critical");
 
         Exception exception = assertThrows(SigmaStatusError.class, () -> {
-            SigmaRule.fromDict(sigmaRule, false);
+            SigmaRule.fromDict(sigmaRule, false, true);
         });
 
         String expectedMessage = "null is no valid Sigma rule status";
@@ -84,7 +85,7 @@ public class SigmaRuleTests extends OpenSearchTestCase {
         sigmaRule.put("date", "15/05");
 
         assertThrows(SigmaDateError.class, () -> {
-            SigmaRule.fromDict(sigmaRule, false);
+            SigmaRule.fromDict(sigmaRule, false, true);
         });
     }
 
@@ -96,7 +97,7 @@ public class SigmaRuleTests extends OpenSearchTestCase {
         sigmaRule.put("date", "2017/05/15");
 
         Exception exception = assertThrows(SigmaLogsourceError.class, () -> {
-            SigmaRule.fromDict(sigmaRule, false);
+            SigmaRule.fromDict(sigmaRule, false, true);
         });
 
         String expectedMessage = "Sigma rule must have a log source";
@@ -118,7 +119,7 @@ public class SigmaRuleTests extends OpenSearchTestCase {
 
 
         Exception exception = assertThrows(SigmaDetectionError.class, () -> {
-            SigmaRule.fromDict(sigmaRule, false);
+            SigmaRule.fromDict(sigmaRule, false, true);
         });
 
         String expectedMessage = "Sigma rule must have a detection definitions";


### PR DESCRIPTION
Signed-off-by: Raj Chakravarthi <raj@icedome.ca>

### Description
Id is not required while creating custom rules. Relevant changes are done both in code and in IT/Unit tests.
 
### Issues Resolved
https://github.com/opensearch-project/security-analytics/issues/195 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
