### PR TITLE
Update mapper_topics.json

### DIFF
--- a/src/main/resources/OSMapping/mapper_topics.json
+++ b/src/main/resources/OSMapping/mapper_topics.json
@@ -4,6 +4,7 @@
   "apache_access": "OSMapping/apache_access/mappings.json",
   "cloudtrail": "OSMapping/cloudtrail/mappings.json",
   "dns": "OSMapping/dns/mappings.json",
+  "linux": "OSMapping/linux/mappings.json",
   "network": "OSMapping/network/mappings.json",
   "others_application": "OSMapping/others_application/mappings.json",
   "others_apt": "OSMapping/others_apt/mappings.json",


### PR DESCRIPTION
### Description
OSMapping for linux is missing;
this is causing "Security Analytics error: No applied aliases not found" in opensearch when adding a detector for rules handling linux (tested with 2.5.0)
 
### Issues Resolved
fixed error message "Security Analytics error: No applied aliases not found"
field mappings for linux do work now

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
