### PR TITLE
Publish snapshots to maven via GHA

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,39 @@
+name: Publish snapshots to maven
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [
+        main
+          1.*
+          2.*
+    ]
+
+jobs:
+  build-and-publish-snapshots:
+    strategy:
+      fail-fast: false
+    if: github.repository == 'opensearch-project/security-analytics'
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: 17
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+      - name: publish snapshots to maven
+        run: |
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,17 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven {
+            name = "Snapshots"
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
+    }
 }
 
 repositories {


### PR DESCRIPTION
### Description
Publish snapshots to maven via GHA
 
### Issues Resolved
#334

### Tests
```
find snapshots | sort
snapshots
snapshots/org
snapshots/org/opensearch
snapshots/org/opensearch/plugin
snapshots/org/opensearch/plugin/opensearch-security-analytics
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/maven-metadata.xml
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/maven-metadata.xml.md5
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/maven-metadata.xml.sha1
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/maven-metadata.xml.sha256
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/maven-metadata.xml.sha512
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/opensearch-security-analytics-2.5.0.0-20230221.202401-1.pom
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/opensearch-security-analytics-2.5.0.0-20230221.202401-1.pom.md5
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/opensearch-security-analytics-2.5.0.0-20230221.202401-1.pom.sha1
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/opensearch-security-analytics-2.5.0.0-20230221.202401-1.pom.sha256
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/opensearch-security-analytics-2.5.0.0-20230221.202401-1.pom.sha512
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/opensearch-security-analytics-2.5.0.0-20230221.202401-1.zip
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/opensearch-security-analytics-2.5.0.0-20230221.202401-1.zip.md5
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/opensearch-security-analytics-2.5.0.0-20230221.202401-1.zip.sha1
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/opensearch-security-analytics-2.5.0.0-20230221.202401-1.zip.sha256
snapshots/org/opensearch/plugin/opensearch-security-analytics/2.5.0.0-SNAPSHOT/opensearch-security-analytics-2.5.0.0-20230221.202401-1.zip.sha512
snapshots/org/opensearch/plugin/opensearch-security-analytics/maven-metadata.xml
snapshots/org/opensearch/plugin/opensearch-security-analytics/maven-metadata.xml.md5
snapshots/org/opensearch/plugin/opensearch-security-analytics/maven-metadata.xml.sha1
snapshots/org/opensearch/plugin/opensearch-security-analytics/maven-metadata.xml.sha256
snapshots/org/opensearch/plugin/opensearch-security-analytics/maven-metadata.xml.sha512

```
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
