### PR TITLE
Handle index not exists for detector search and delete

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportSearchDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportSearchDetectorAction.java
@@ -7,9 +7,13 @@ package org.opensearch.securityanalytics.transport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.search.SearchResponse;
 
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.commons.authuser.User;
@@ -20,6 +24,12 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.rest.RestStatus;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.search.profile.SearchProfileShardResults;
+import org.opensearch.search.suggest.Suggest;
 import org.opensearch.securityanalytics.action.SearchDetectorAction;
 import org.opensearch.securityanalytics.action.SearchDetectorRequest;
 import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
@@ -30,7 +40,11 @@ import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
 
+import java.util.Collections;
+import java.util.Locale;
+
 import static org.opensearch.rest.RestStatus.OK;
+import static org.opensearch.securityanalytics.util.DetectorUtils.getEmptySearchResponse;
 
 public class TransportSearchDetectorAction extends HandledTransportAction<SearchDetectorRequest, SearchResponse> implements SecureTransportAction {
 
@@ -78,7 +92,10 @@ public class TransportSearchDetectorAction extends HandledTransportAction<Search
         }
 
         this.threadPool.getThreadContext().stashContext();
-
+        if (!detectorIndices.detectorIndexExists()) {
+            actionListener.onResponse(getEmptySearchResponse());
+            return;
+        }
         client.search(searchDetectorRequest.searchRequest(), new ActionListener<>() {
             @Override
             public void onResponse(SearchResponse response) {

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorUtils.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorUtils.java
@@ -4,29 +4,48 @@
  */
 package org.opensearch.securityanalytics.util;
 
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import org.apache.lucene.search.TotalHits;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
+import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.search.profile.SearchProfileShardResults;
+import org.opensearch.search.suggest.Suggest;
 import org.opensearch.securityanalytics.model.Detector;
 import org.opensearch.securityanalytics.model.DetectorInput;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 
 public class DetectorUtils {
 
     public static final String DETECTOR_TYPE_PATH = "detector.detector_type";
     public static final String DETECTOR_ID_FIELD = "detector_id";
+
+    public static SearchResponse getEmptySearchResponse() {
+        return new SearchResponse(new InternalSearchResponse(
+                new SearchHits(new SearchHit[0], new TotalHits(0L, TotalHits.Relation.EQUAL_TO), 0.0f),
+                InternalAggregations.from(Collections.emptyList()),
+                new Suggest(Collections.emptyList()),
+                new SearchProfileShardResults(Collections.emptyMap()), false, false, 0),
+                "", 0, 0, 0, 0,
+                ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+    }
 
     public static List<Detector> getDetectors(SearchResponse response, NamedXContentRegistry xContentRegistry) throws IOException {
         List<Detector> detectors = new LinkedList<>();

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
@@ -122,6 +122,30 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertEquals(5, noOfSigmaRuleMatches);
     }
 
+    @SuppressWarnings("unchecked")
+    public void test_searchDetectors_detectorsIndexNotExists() throws IOException {
+        try {
+            makeRequest(client(), "DELETE", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + "d1", Collections.emptyMap(), null);
+            fail("delete detector call should have failed");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("not found"));
+        }
+        String request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match_all\":{\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+        HttpEntity requestEntity = new StringEntity(request, ContentType.APPLICATION_JSON);
+        Response searchResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + "_search", Collections.emptyMap(), requestEntity);
+        Map<String, Object> searchResponseBody = asMap(searchResponse);
+        Assert.assertNotNull("response is not null", searchResponseBody);
+        Map<String, Object> searchResponseHits = (Map) searchResponseBody.get("hits");
+        Map<String, Object> searchResponseTotal = (Map) searchResponseHits.get("total");
+        Assert.assertEquals(0, searchResponseTotal.get("value"));
+    }
+
+
     public void testCreatingADetectorWithMultipleIndices() throws IOException {
         String index1 = createTestIndex("windows-1", windowsIndexMapping());
         String index2 = createTestIndex("windows-2", windowsIndexMapping());


### PR DESCRIPTION
### Description
Detector search api throws 404 when detector config index doesn't exist. this PR fixes that scenario to return a 0 hits search response.

Detector deletion API returns message that index is not found when index doesnt exist. Fixed it to return "detector not found" message.
 
### Issues Resolved
#206 #370
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
