### PR TITLE
Correct rule description in web_apache_segfault.yml

### DIFF
--- a/src/main/resources/rules/apache_access/web_apache_segfault.yml
+++ b/src/main/resources/rules/apache_access/web_apache_segfault.yml
@@ -1,7 +1,7 @@
 title: Apache Segmentation Fault
 id: 1da8ce0b-855d-4004-8860-7d64d42063b1
 status: test
-description: Detects a segmentation fault error message caused by a creashing apache worker process
+description: Detects a segmentation fault error message caused by a crashing apache worker process
 author: Florian Roth
 references:
   - http://www.securityfocus.com/infocus/1633


### PR DESCRIPTION
### Description
Rule description was "Detects a segmentation fault error message caused by a creashing apache worker process" and is now "Detects a segmentation fault error message caused by a crashing apache worker process"
 
### Issues Resolved
Misspelling in rule description has been corrected. 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
