### PR TITLE
Match maintainer account username.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | ---------------- | ----------------------------------------------------- | ----------- |
 | Ashish Agrawal   | [lezzago](https://github.com/lezzago)                 | Amazon      |
 | Subhobrata Dey   | [sbcd90](https://github.com/sbcd90)                   | Amazon      |
-| Thomas Hurney    | [awshurneyt](https://github.com/AWSHurneyt)       | Amazon      |
+| Thomas Hurney    | [AWSHurneyt](https://github.com/AWSHurneyt)       | Amazon      |
 | Surya Sashank Nistala    | [eirsep](https://github.com/eirsep)       | Amazon      |
 | Praveen Sameneni | [praveensameneni](https://github.com/praveensameneni) | Amazon      |
 | Amardeepsingh Siglani    | [amsiglan](https://github.com/amsiglan)       | Amazon      |


### PR DESCRIPTION
### Description

Spell the username as chosen by the person on GitHub. While GitHub is not case-sensitive, it does redirect to the correct spelling and we kept maintainer audit tools in https://github.com/opensearch-project/project-tools case-sensitive on those to avoid eLiTe type re-spelling and such.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
