### PR TITLE
[CVE-2023-2976] Fix google-java-format-1.17.0.jar: 1 vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,9 +159,10 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'notifications', version: "${opensearch_build}"
 
     //spotless
-    implementation('com.google.googlejavaformat:google-java-format:32.0.1') {
+    implementation('com.google.googlejavaformat:google-java-format:1.17.0') {
         exclude group: 'com.google.guava'
     }
+    implementation 'com.google.guava:guava:32.0.1-jre'
 }
 
 // RPM & Debian build

--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'notifications', version: "${opensearch_build}"
 
     //spotless
-    implementation('com.google.googlejavaformat:google-java-format:1.17.0') {
+    implementation('com.google.googlejavaformat:google-java-format:32.0.1') {
         exclude group: 'com.google.guava'
     }
 }


### PR DESCRIPTION
### Description
Fix google-java-format-1.17.0.jar: 1 vulnerabilities

### Issues Resolved
CVE: https://www.mend.io/vulnerability-database/CVE-2023-2976
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
