### PR TITLE
Using alerting workflows in detectors  (#394)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ configurations {
 
 dependencies {
     javaRestTestImplementation project.sourceSets.main.runtimeClasspath
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.13.0'
     implementation "org.antlr:antlr4-runtime:4.10.1"
     implementation "com.cronutils:cron-utils:9.1.6"
     api "org.opensearch:common-utils:${common_utils_version}@jar"

--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -242,7 +242,8 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
                 SecurityAnalyticsSettings.FINDING_HISTORY_RETENTION_PERIOD,
                 SecurityAnalyticsSettings.IS_CORRELATION_INDEX_SETTING,
                 SecurityAnalyticsSettings.CORRELATION_TIME_WINDOW,
-                SecurityAnalyticsSettings.DEFAULT_MAPPING_SCHEMA
+                SecurityAnalyticsSettings.DEFAULT_MAPPING_SCHEMA,
+                SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE
         );
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/model/Detector.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Detector.java
@@ -53,6 +53,8 @@ public class Detector implements Writeable, ToXContentObject {
     public static final String ENABLED_TIME_FIELD = "enabled_time";
     public static final String ALERTING_MONITOR_ID = "monitor_id";
 
+    public static final String ALERTING_WORKFLOW_ID = "workflow_ids";
+
     public static final String BUCKET_MONITOR_ID_RULE_ID = "bucket_monitor_id_rule_id";
     private static final String RULE_TOPIC_INDEX = "rule_topic_index";
 
@@ -100,6 +102,8 @@ public class Detector implements Writeable, ToXContentObject {
 
     private Map<String, String> ruleIdMonitorIdMap;
 
+    private List<String> workflowIds;
+
     private String ruleIndex;
 
     private String alertsIndex;
@@ -118,7 +122,7 @@ public class Detector implements Writeable, ToXContentObject {
                     Instant lastUpdateTime, Instant enabledTime, String logType,
                     User user, List<DetectorInput> inputs, List<DetectorTrigger> triggers, List<String> monitorIds,
                     String ruleIndex, String alertsIndex, String alertsHistoryIndex, String alertsHistoryIndexPattern,
-                    String findingsIndex, String findingsIndexPattern, Map<String, String> rulePerMonitor) {
+                    String findingsIndex, String findingsIndexPattern, Map<String, String> rulePerMonitor, List<String> workflowIds) {
         this.type = DETECTOR_TYPE;
 
         this.id = id != null ? id : NO_ID;
@@ -140,6 +144,7 @@ public class Detector implements Writeable, ToXContentObject {
         this.findingsIndexPattern = findingsIndexPattern;
         this.ruleIdMonitorIdMap = rulePerMonitor;
         this.logType = logType;
+        this.workflowIds = workflowIds != null ? workflowIds : null;
 
         if (enabled) {
             Objects.requireNonNull(enabledTime);
@@ -166,7 +171,8 @@ public class Detector implements Writeable, ToXContentObject {
                 sin.readString(),
                 sin.readString(),
                 sin.readString(),
-                sin.readMap(StreamInput::readString, StreamInput::readString)
+                sin.readMap(StreamInput::readString, StreamInput::readString),
+                sin.readStringList()
             );
     }
 
@@ -201,6 +207,10 @@ public class Detector implements Writeable, ToXContentObject {
         out.writeString(ruleIndex);
 
         out.writeMap(ruleIdMonitorIdMap, StreamOutput::writeString, StreamOutput::writeString);
+
+        if (workflowIds != null) {
+            out.writeStringCollection(workflowIds);
+        }
     }
 
     public XContentBuilder toXContentWithUser(XContentBuilder builder, Params params) throws IOException {
@@ -254,6 +264,14 @@ public class Detector implements Writeable, ToXContentObject {
         }
 
         builder.field(ALERTING_MONITOR_ID, monitorIds);
+
+        if (workflowIds == null) {
+            builder.nullField(ALERTING_WORKFLOW_ID);
+        } else {
+            builder.field(ALERTING_WORKFLOW_ID, workflowIds);
+        }
+
+
         builder.field(BUCKET_MONITOR_ID_RULE_ID, ruleIdMonitorIdMap);
         builder.field(RULE_TOPIC_INDEX, ruleIndex);
         builder.field(ALERTS_INDEX, alertsIndex);
@@ -300,6 +318,7 @@ public class Detector implements Writeable, ToXContentObject {
         List<DetectorInput> inputs = new ArrayList<>();
         List<DetectorTrigger> triggers = new ArrayList<>();
         List<String> monitorIds = new ArrayList<>();
+        List<String> workflowIds = new ArrayList<>();
         Map<String, String> rulePerMonitor = new HashMap<>();
 
         String ruleIndex = null;
@@ -375,6 +394,15 @@ public class Detector implements Writeable, ToXContentObject {
                         monitorIds.add(monitorId);
                     }
                     break;
+                case ALERTING_WORKFLOW_ID:
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
+                    while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
+                        String workflowId = xcp.textOrNull();
+                        if (workflowId != null) {
+                            workflowIds.add(workflowId);
+                        }
+                    }
+                    break;
                 case BUCKET_MONITOR_ID_RULE_ID:
                     rulePerMonitor= xcp.mapStrings();
                     break;
@@ -430,7 +458,8 @@ public class Detector implements Writeable, ToXContentObject {
                 alertsHistoryIndexPattern,
                 findingsIndex,
                 findingsIndexPattern,
-                rulePerMonitor
+                rulePerMonitor,
+                workflowIds
                 );
     }
 
@@ -567,8 +596,20 @@ public class Detector implements Writeable, ToXContentObject {
         this.ruleIdMonitorIdMap = ruleIdMonitorIdMap;
     }
 
+    public void setWorkflowIds(List<String> workflowIds) {
+        this.workflowIds = workflowIds;
+    }
+
+    public List<String> getWorkflowIds() {
+        return workflowIds;
+    }
+
     public String getDocLevelMonitorId() {
         return ruleIdMonitorIdMap.get(DOC_LEVEL_MONITOR);
+    }
+
+    public boolean isWorkflowSupported() {
+        return workflowIds != null && !workflowIds.isEmpty();
     }
 
     @Override

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -98,6 +98,12 @@ public class SecurityAnalyticsSettings {
             Setting.Property.NodeScope, Setting.Property.Dynamic
     );
 
+    public static final Setting<Boolean> ENABLE_WORKFLOW_USAGE = Setting.boolSetting(
+        "plugins.security_analytics.enable_workflow_usage",
+        false,
+        Setting.Property.NodeScope, Setting.Property.Dynamic
+    );
+
     public static final Setting<Boolean> IS_CORRELATION_INDEX_SETTING = Setting.boolSetting(CORRELATION_INDEX, false, Setting.Property.IndexScope);
 
     public static final Setting<TimeValue> CORRELATION_TIME_WINDOW = Setting.positiveTimeSetting(

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteDetectorAction.java
@@ -4,16 +4,11 @@
  */
 package org.opensearch.securityanalytics.transport;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.ActionRunnable;
+import org.opensearch.action.StepListener;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
@@ -24,29 +19,42 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.alerting.AlertingPluginInterface;
 import org.opensearch.commons.alerting.action.DeleteMonitorRequest;
 import org.opensearch.commons.alerting.action.DeleteMonitorResponse;
+import org.opensearch.commons.alerting.action.DeleteWorkflowResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.core.rest.RestStatus;
+import org.opensearch.extensions.AcknowledgedResponse;
 import org.opensearch.securityanalytics.action.DeleteDetectorAction;
 import org.opensearch.securityanalytics.action.DeleteDetectorRequest;
 import org.opensearch.securityanalytics.action.DeleteDetectorResponse;
 import org.opensearch.securityanalytics.mapper.IndexTemplateManager;
 import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.securityanalytics.util.DetectorIndices;
+import org.opensearch.securityanalytics.util.MonitorService;
 import org.opensearch.securityanalytics.util.RuleTopicIndices;
 import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
+import org.opensearch.securityanalytics.util.WorkflowService;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.opensearch.securityanalytics.model.Detector.NO_VERSION;
 
@@ -60,14 +68,24 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
 
     private final NamedXContentRegistry xContentRegistry;
 
+    private final WorkflowService workflowService;
+
+    private final MonitorService monitorService;
+
     private final ThreadPool threadPool;
+
+    private final Settings settings;
+
+    private final ClusterService clusterService;
+    private volatile Boolean enabledWorkflowUsage;
 
     private final IndexTemplateManager indexTemplateManager;
 
     private final DetectorIndices detectorIndices;
 
     @Inject
-    public TransportDeleteDetectorAction(TransportService transportService, IndexTemplateManager indexTemplateManager, Client client, ActionFilters actionFilters, NamedXContentRegistry xContentRegistry, RuleTopicIndices ruleTopicIndices, DetectorIndices detectorIndices) {
+    public TransportDeleteDetectorAction(TransportService transportService, IndexTemplateManager indexTemplateManager, Client client, ActionFilters actionFilters, NamedXContentRegistry xContentRegistry, RuleTopicIndices ruleTopicIndices, DetectorIndices detectorIndices, ClusterService clusterService,
+                                         Settings settings) {
         super(DeleteDetectorAction.NAME, transportService, actionFilters, DeleteDetectorRequest::new);
         this.client = client;
         this.ruleTopicIndices = ruleTopicIndices;
@@ -75,6 +93,13 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
         this.threadPool = client.threadPool();
         this.indexTemplateManager = indexTemplateManager;
         this.detectorIndices = detectorIndices;
+        this.monitorService = new MonitorService(client);
+        this.workflowService = new WorkflowService(client, monitorService);
+        this.clusterService = clusterService;
+        this.settings = settings;
+
+        this.enabledWorkflowUsage = SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE.get(this.settings);
+        this.clusterService.getClusterSettings().addSettingsUpdateConsumer(SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE, this::setEnabledWorkflowUsage);
     }
 
     @Override
@@ -155,39 +180,63 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
         }
 
         private void onGetResponse(Detector detector) {
-            List<String> monitorIds = detector.getMonitorIds();
-            ActionListener<DeleteMonitorResponse> deletesListener = new GroupedActionListener<>(new ActionListener<>() {
-                @Override
-                public void onResponse(Collection<DeleteMonitorResponse> responses) {
-                    SetOnce<RestStatus> errorStatusSupplier = new SetOnce<>();
-                    if (responses.stream().filter(response -> {
-                        if (response.getStatus() != RestStatus.OK) {
-                            log.error("Detector not being deleted because monitor [{}] could not be deleted. Status [{}]", response.getId(), response.getStatus());
-                            errorStatusSupplier.trySet(response.getStatus());
-                            return true;
+            StepListener<AcknowledgedResponse> onDeleteWorkflowStep = new StepListener<>();
+            // 1. Delete the workflow if the workflow is supported
+            deleteWorkflow(detector, onDeleteWorkflowStep);
+            onDeleteWorkflowStep.whenComplete(acknowledgedResponse -> {
+                List<String> monitorIds = detector.getMonitorIds();
+                ActionListener<DeleteMonitorResponse> deletesListener = new GroupedActionListener<>(new ActionListener<>() {
+                    @Override
+                    public void onResponse(Collection<DeleteMonitorResponse> responses) {
+                        SetOnce<RestStatus> errorStatusSupplier = new SetOnce<>();
+                        if (responses.stream().filter(response -> {
+                            if (response.getStatus() != RestStatus.OK) {
+                                log.error("Detector not being deleted because monitor [{}] could not be deleted. Status [{}]", response.getId(), response.getStatus());
+                                errorStatusSupplier.trySet(response.getStatus());
+                                return true;
+                            }
+                            return false;
+                        }).count() > 0) {
+                            onFailures(new OpenSearchStatusException("Monitor associated with detected could not be deleted", errorStatusSupplier.get()));
                         }
-                        return false;
-                    }).count() > 0) {
-                        onFailures(new OpenSearchStatusException("Monitor associated with detected could not be deleted", errorStatusSupplier.get()));
-                    }
-                    deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    if(isOnlyMonitorOrIndexMissingExceptionThrownByGroupedActionListener(e, detector.getId())) {
                         deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
-                    } else {
-                        log.error(String.format(Locale.ROOT, "Failed to delete detector %s", detector.getId()), e);
-                        if (counter.compareAndSet(false, true)) {
-                            finishHim(null, e);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        if (isOnlyMonitorOrIndexMissingExceptionThrownByGroupedActionListener(e, detector.getId())) {
+                            deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
+                        } else {
+                            log.error(String.format(Locale.ROOT, "Failed to delete detector %s", detector.getId()), e);
+                            if (counter.compareAndSet(false, true)) {
+                                finishHim(null, e);
+                            }
                         }
                     }
+                }, monitorIds.size());
+                for (String monitorId : monitorIds) {
+                    deleteAlertingMonitor(monitorId, request.getRefreshPolicy(),
+                            deletesListener);
                 }
-            }, monitorIds.size());
-            for (String monitorId : monitorIds) {
-                deleteAlertingMonitor(monitorId, request.getRefreshPolicy(),
-                        deletesListener);
+            }, e -> {
+                if (counter.compareAndSet(false, true)) {
+                    finishHim(null, e);
+                }
+            });
+        }
+
+        private void deleteWorkflow(Detector detector, ActionListener<AcknowledgedResponse> actionListener) {
+            if (detector.isWorkflowSupported() && enabledWorkflowUsage) {
+                var workflowId = detector.getWorkflowIds().get(0);
+                log.debug(String.format("Deleting the workflow %s before deleting the detector", workflowId));
+                StepListener<DeleteWorkflowResponse> onDeleteWorkflowStep = new StepListener<>();
+                workflowService.deleteWorkflow(workflowId, onDeleteWorkflowStep);
+                onDeleteWorkflowStep.whenComplete(deleteWorkflowResponse -> {
+                    actionListener.onResponse(new AcknowledgedResponse(true));
+                }, actionListener::onFailure);
+            } else {
+                // If detector doesn't have the workflows it means that older version of the plugin is used and just skip the step
+                actionListener.onResponse(new AcknowledgedResponse(true));
             }
         }
 
@@ -211,6 +260,7 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
                             });
 
                         }
+
                         @Override
                         public void onFailure(Exception t) {
                             onFailures(t);
@@ -235,7 +285,7 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
         private void finishHim(String detectorId, Exception t) {
             threadPool.executor(ThreadPool.Names.GENERIC).execute(ActionRunnable.supply(listener, () -> {
                 if (t != null) {
-                    log.error(String.format(Locale.ROOT, "Failed to delete detector %s",detectorId), t);
+                    log.error(String.format(Locale.ROOT, "Failed to delete detector %s", detectorId), t);
                     if (t instanceof OpenSearchStatusException) {
                         throw t;
                     }
@@ -256,8 +306,8 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
             for (int i = 0; i <= len; i++) {
                 Throwable e = i == len ? ex : ex.getSuppressed()[i];
                 if (e.getMessage().matches("(.*)Monitor(.*) is not found(.*)")
-                                || e.getMessage().contains(
-                                        "Configured indices are not found: [.opendistro-alerting-config]")
+                        || e.getMessage().contains(
+                        "Configured indices are not found: [.opendistro-alerting-config]")
                 ) {
                     log.error(
                             String.format(Locale.ROOT, "Monitor or jobs index already deleted." +
@@ -269,5 +319,9 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
             }
             return true;
         }
+    }
+
+    private void setEnabledWorkflowUsage(boolean enabledWorkflowUsage) {
+        this.enabledWorkflowUsage = enabledWorkflowUsage;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportGetFindingsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportGetFindingsAction.java
@@ -111,7 +111,7 @@ public class TransportGetFindingsAction extends HandledTransportAction<GetFindin
                     actionListener
                     );
         } else {
-            // "detector" is nested type so we have to use nested query
+            // "detector" is nested type, so we have to use nested query
             NestedQueryBuilder queryBuilder =
                     QueryBuilders.nestedQuery(
                         "detector",

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -653,7 +653,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             triggers.add(new DocumentLevelTrigger(id, name, severity, actions, condition));
         }
 
-        Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), false, detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
+        Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), false, detector.getSchedule(), detector.getLastUpdateTime(), null,
                 Monitor.MonitorType.DOC_LEVEL_MONITOR, detector.getUser(), 1, docLevelMonitorInputs, triggers, Map.of(),
                 new DataSources(detector.getRuleIndex(),
                         detector.getFindingsIndex(),

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -9,8 +9,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.cluster.routing.Preference;
-import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.ActionRunnable;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
@@ -31,22 +29,21 @@ import org.opensearch.client.Client;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.routing.Preference;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.SetOnce;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
-import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.alerting.AlertingPluginInterface;
-import org.opensearch.commons.alerting.action.DeleteMonitorRequest;
 import org.opensearch.commons.alerting.action.DeleteMonitorResponse;
+import org.opensearch.commons.alerting.action.DeleteWorkflowResponse;
 import org.opensearch.commons.alerting.action.IndexMonitorRequest;
 import org.opensearch.commons.alerting.action.IndexMonitorResponse;
+import org.opensearch.commons.alerting.action.IndexWorkflowResponse;
 import org.opensearch.commons.alerting.model.BucketLevelTrigger;
 import org.opensearch.commons.alerting.model.DataSources;
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput;
@@ -55,8 +52,13 @@ import org.opensearch.commons.alerting.model.DocumentLevelTrigger;
 import org.opensearch.commons.alerting.model.Monitor;
 import org.opensearch.commons.alerting.model.Monitor.MonitorType;
 import org.opensearch.commons.alerting.model.SearchInput;
+import org.opensearch.commons.alerting.model.Workflow;
 import org.opensearch.commons.alerting.model.action.Action;
 import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
@@ -68,7 +70,6 @@ import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.script.Script;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -96,9 +97,11 @@ import org.opensearch.securityanalytics.rules.exceptions.SigmaError;
 import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.securityanalytics.util.DetectorIndices;
 import org.opensearch.securityanalytics.util.IndexUtils;
+import org.opensearch.securityanalytics.util.MonitorService;
 import org.opensearch.securityanalytics.util.RuleIndices;
 import org.opensearch.securityanalytics.util.RuleTopicIndices;
 import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
+import org.opensearch.securityanalytics.util.WorkflowService;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -141,11 +144,15 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
     private volatile Boolean filterByEnabled;
 
+    private volatile Boolean enabledWorkflowUsage;
 
     private final Settings settings;
 
     private final NamedWriteableRegistry namedWriteableRegistry;
 
+    private final WorkflowService workflowService;
+
+    private final MonitorService monitorService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
 
     private volatile TimeValue indexTimeout;
@@ -178,9 +185,12 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         this.threadPool = this.detectorIndices.getThreadPool();
         this.indexTimeout = SecurityAnalyticsSettings.INDEX_TIMEOUT.get(this.settings);
         this.filterByEnabled = SecurityAnalyticsSettings.FILTER_BY_BACKEND_ROLES.get(this.settings);
+        this.enabledWorkflowUsage = SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE.get(this.settings);
+        this.monitorService = new MonitorService(client);
+        this.workflowService = new WorkflowService(client, monitorService);
 
         this.clusterService.getClusterSettings().addSettingsUpdateConsumer(SecurityAnalyticsSettings.FILTER_BY_BACKEND_ROLES, this::setFilterByEnabled);
-
+        this.clusterService.getClusterSettings().addSettingsUpdateConsumer(SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE, this::setEnabledWorkflowUsage);
     }
 
     @Override
@@ -221,7 +231,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                     ));
                 } else if (e instanceof IndexNotFoundException) {
                     listener.onFailure(SecurityAnalyticsException.wrap(
-                            new OpenSearchStatusException(String.format(Locale.getDefault(), "Indices not found %s", String.join(", ", detectorIndices)), RestStatus.NOT_FOUND)
+                        new OpenSearchStatusException(String.format(Locale.getDefault(), "Indices not found %s", String.join(", ", detectorIndices)), RestStatus.NOT_FOUND)
                     ));
                 }
                 else {
@@ -231,7 +241,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         });
     }
 
-    private void createMonitorFromQueries(String index, List<Pair<String, Rule>> rulesById, Detector detector, ActionListener<List<IndexMonitorResponse>> listener, WriteRequest.RefreshPolicy refreshPolicy) throws SigmaError, IOException {
+    private void createMonitorFromQueries(List<Pair<String, Rule>> rulesById, Detector detector, ActionListener<List<IndexMonitorResponse>> listener, WriteRequest.RefreshPolicy refreshPolicy) throws SigmaError, IOException {
         List<Pair<String, Rule>> docLevelRules = rulesById.stream().filter(it -> !it.getRight().isAggregationRule()).collect(
             Collectors.toList());
         List<Pair<String, Rule>> bucketLevelRules = rulesById.stream().filter(it -> it.getRight().isAggregationRule()).collect(
@@ -262,27 +272,26 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                 AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, monitorRequests.get(0), namedWriteableRegistry, addFirstMonitorStep);
                 addFirstMonitorStep.whenComplete(addedFirstMonitorResponse -> {
                             monitorResponses.add(addedFirstMonitorResponse);
+
+                            StepListener<List<IndexMonitorResponse>> indexMonitorsStep = new StepListener<>();
+                            indexMonitorsStep.whenComplete(
+                                    indexMonitorResponses -> saveWorkflow(detector, indexMonitorResponses, refreshPolicy, listener),
+                                    e -> {
+                                        log.error("Failed to index the workflow", e);
+                                        listener.onFailure(e);
+                                    });
+
                             int numberOfUnprocessedResponses = monitorRequests.size() - 1;
                             if (numberOfUnprocessedResponses == 0) {
-                                listener.onResponse(monitorResponses);
+                                saveWorkflow(detector, monitorResponses, refreshPolicy, listener);
                             } else {
-                                GroupedActionListener<IndexMonitorResponse> monitorResponseListener = new GroupedActionListener(
-                                        new ActionListener<Collection<IndexMonitorResponse>>() {
-                                            @Override
-                                            public void onResponse(Collection<IndexMonitorResponse> indexMonitorResponse) {
-                                                monitorResponses.addAll(indexMonitorResponse.stream().collect(Collectors.toList()));
-                                                listener.onResponse(monitorResponses);
-                                            }
-
-                                            @Override
-                                            public void onFailure(Exception e) {
-                                                listener.onFailure(e);
-                                            }
-                                        }, numberOfUnprocessedResponses);
-
-                                for (int i = 1; i < monitorRequests.size(); i++) {
-                                    AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, monitorRequests.get(i), namedWriteableRegistry, monitorResponseListener);
-                                }
+                                // Saves the rest of the monitors and saves the workflow if supported
+                                saveMonitors(
+                                        monitorRequests,
+                                        monitorResponses,
+                                        numberOfUnprocessedResponses,
+                                        indexMonitorsStep
+                                );
                             }
                         },
                         listener::onFailure
@@ -296,38 +305,82 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             }
 
             List<IndexMonitorResponse> monitorResponses = new ArrayList<>();
-            StepListener<IndexMonitorResponse> addFirstMonitorStep = new StepListener();
+            StepListener<IndexMonitorResponse> indexDocLevelMonitorStep = new StepListener();
 
             // Indexing monitors in two steps in order to prevent all shards failed error from alerting
             // https://github.com/opensearch-project/alerting/issues/646
-            AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, monitorRequests.get(0), namedWriteableRegistry, addFirstMonitorStep);
-            addFirstMonitorStep.whenComplete(addedFirstMonitorResponse -> {
+            AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, monitorRequests.get(0), namedWriteableRegistry, indexDocLevelMonitorStep);
+            indexDocLevelMonitorStep.whenComplete(addedFirstMonitorResponse -> {
                         monitorResponses.add(addedFirstMonitorResponse);
-                        int numberOfUnprocessedResponses = monitorRequests.size() - 1;
-                        if (numberOfUnprocessedResponses == 0) {
-                            listener.onResponse(monitorResponses);
-                        } else {
-                            GroupedActionListener<IndexMonitorResponse> monitorResponseListener = new GroupedActionListener(
-                                    new ActionListener<Collection<IndexMonitorResponse>>() {
-                                        @Override
-                                        public void onResponse(Collection<IndexMonitorResponse> indexMonitorResponse) {
-                                            monitorResponses.addAll(indexMonitorResponse.stream().collect(Collectors.toList()));
-                                            listener.onResponse(monitorResponses);
-                                        }
-
-                                        @Override
-                                        public void onFailure(Exception e) {
-                                            listener.onFailure(e);
-                                        }
-                                    }, numberOfUnprocessedResponses);
-
-                            for (int i = 1; i < monitorRequests.size(); i++) {
-                                AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, monitorRequests.get(i), namedWriteableRegistry, monitorResponseListener);
-                            }
-                        }
+                        saveWorkflow(detector, monitorResponses, refreshPolicy, listener);
                     },
                     listener::onFailure
             );
+        }
+    }
+
+    private void saveMonitors(
+        List<IndexMonitorRequest> monitorRequests,
+        List<IndexMonitorResponse> monitorResponses,
+        int numberOfUnprocessedResponses,
+        ActionListener<List<IndexMonitorResponse>> listener
+    ) {
+        GroupedActionListener<IndexMonitorResponse> monitorResponseListener = new GroupedActionListener(
+            new ActionListener<Collection<IndexMonitorResponse>>() {
+                @Override
+                public void onResponse(Collection<IndexMonitorResponse> indexMonitorResponses) {
+                    monitorResponses.addAll(indexMonitorResponses.stream().collect(Collectors.toList()));
+                    listener.onResponse(monitorResponses);
+                }
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            }, numberOfUnprocessedResponses);
+
+        for (int i = 1; i < monitorRequests.size(); i++) {
+            AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, monitorRequests.get(i), namedWriteableRegistry, monitorResponseListener);
+        }
+    }
+
+    /**
+     * If the workflow is enabled, saves the workflow, updates the detector and returns the saved monitors
+     * if not, returns the saved monitors
+     * @param detector
+     * @param monitorResponses
+     * @param refreshPolicy
+     * @param actionListener
+     */
+    private void saveWorkflow(
+        Detector detector,
+        List<IndexMonitorResponse> monitorResponses,
+        RefreshPolicy refreshPolicy,
+        ActionListener<List<IndexMonitorResponse>> actionListener
+    ) {
+        if (enabledWorkflowUsage) {
+            workflowService.upsertWorkflow(
+                monitorResponses.stream().map(IndexMonitorResponse::getId).collect(Collectors.toList()),
+                null,
+                detector,
+                refreshPolicy,
+                Workflow.NO_ID,
+                Method.POST,
+                    new ActionListener<>() {
+                        @Override
+                        public void onResponse(IndexWorkflowResponse workflowResponse) {
+                            // Update passed detector with the workflowId
+                            detector.setWorkflowIds(List.of(workflowResponse.getId()));
+                            actionListener.onResponse(monitorResponses);
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            log.error("Error saving workflow", e);
+                            actionListener.onFailure(e);
+                        }
+                    });
+        } else {
+            actionListener.onResponse(monitorResponses);
         }
     }
 
@@ -393,7 +446,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                         monitorIdsToBeDeleted.removeAll(monitorsToBeUpdated.stream().map(IndexMonitorRequest::getMonitorId).collect(
                                 Collectors.toList()));
 
-                        updateAlertingMonitors(monitorsToBeAdded, monitorsToBeUpdated, monitorIdsToBeDeleted, refreshPolicy, listener);
+                        updateAlertingMonitors(detector, monitorsToBeAdded, monitorsToBeUpdated, monitorIdsToBeDeleted, refreshPolicy, listener);
                     } catch (IOException | SigmaError ex) {
                         listener.onFailure(ex);
                     }
@@ -421,7 +474,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             monitorIdsToBeDeleted.removeAll(monitorsToBeUpdated.stream().map(IndexMonitorRequest::getMonitorId).collect(
                     Collectors.toList()));
 
-            updateAlertingMonitors(monitorsToBeAdded, monitorsToBeUpdated, monitorIdsToBeDeleted, refreshPolicy, listener);
+            updateAlertingMonitors(detector, monitorsToBeAdded, monitorsToBeUpdated, monitorIdsToBeDeleted, refreshPolicy, listener);
         }
     }
 
@@ -430,8 +483,9 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
      *  Executed in a steps:
      *  1. Add new monitors;
      *  2. Update existing monitors;
-     *  3. Delete the monitors omitted from request
-     *  4. Respond with updated list of monitors
+     *  3. Updates the workflow
+     *  4. Delete the monitors omitted from request
+     *  5. Respond with updated list of monitors
      * @param monitorsToBeAdded Newly added monitors by the user
      * @param monitorsToBeUpdated Existing monitors that will be updated
      * @param monitorsToBeDeleted Monitors omitted by the user
@@ -439,6 +493,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
      * @param listener Listener that accepts the list of updated monitors if the action was successful
      */
     private void updateAlertingMonitors(
+        Detector detector,
         List<IndexMonitorRequest> monitorsToBeAdded,
         List<IndexMonitorRequest> monitorsToBeUpdated,
         List<String> monitorsToBeDeleted,
@@ -455,27 +510,110 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             if (addNewMonitorsResponse != null && !addNewMonitorsResponse.isEmpty()) {
                 updatedMonitors.addAll(addNewMonitorsResponse);
             }
-
             StepListener<List<IndexMonitorResponse>> updateMonitorsStep = new StepListener<>();
             executeMonitorActionRequest(monitorsToBeUpdated, updateMonitorsStep);
             // 2. Update existing alerting monitors (based on the common rules)
             updateMonitorsStep.whenComplete(updateMonitorResponse -> {
-                if (updateMonitorResponse!=null && !updateMonitorResponse.isEmpty()) {
-                    updatedMonitors.addAll(updateMonitorResponse);
-                }
-
-                    StepListener<List<DeleteMonitorResponse>> deleteMonitorStep = new StepListener<>();
-                    deleteAlertingMonitors(monitorsToBeDeleted, refreshPolicy, deleteMonitorStep);
-                    // 3. Delete alerting monitors (rules that are not provided by the user)
-                    deleteMonitorStep.whenComplete(deleteMonitorResponses ->
-                            // Return list of all updated + newly added monitors
-                            listener.onResponse(updatedMonitors),
-                        // Handle delete monitors (step 3)
-                        listener::onFailure);
-                }, // Handle update monitor failed (step 2)
+                    if (updateMonitorResponse != null && !updateMonitorResponse.isEmpty()) {
+                        updatedMonitors.addAll(updateMonitorResponse);
+                    }
+                    if (detector.isWorkflowSupported() && enabledWorkflowUsage) {
+                        updateWorkflowStep(
+                            detector,
+                            monitorsToBeDeleted,
+                            refreshPolicy,
+                            listener,
+                            updatedMonitors,
+                            addNewMonitorsResponse,
+                            updateMonitorResponse
+                        );
+                    } else {
+                        deleteMonitorStep(monitorsToBeDeleted, refreshPolicy, updatedMonitors, listener);
+                    }
+                },
+                // Handle update monitor failed (step 2)
                 listener::onFailure);
             // Handle add failed (step 1)
         }, listener::onFailure);
+    }
+
+    private void deleteMonitorStep(
+        List<String> monitorsToBeDeleted,
+        RefreshPolicy refreshPolicy,
+        List<IndexMonitorResponse> updatedMonitors,
+        ActionListener<List<IndexMonitorResponse>> listener
+    ) {
+        monitorService.deleteAlertingMonitors(monitorsToBeDeleted,
+            refreshPolicy,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(List<DeleteMonitorResponse> deleteMonitorResponses) {
+                    listener.onResponse(updatedMonitors);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    log.error("Failed to delete the monitors", e);
+                    listener.onFailure(e);
+                }
+            });
+    }
+
+    private void updateWorkflowStep(
+        Detector detector,
+        List<String> monitorsToBeDeleted,
+        RefreshPolicy refreshPolicy,
+        ActionListener<List<IndexMonitorResponse>> listener,
+        List<IndexMonitorResponse> updatedMonitors,
+        List<IndexMonitorResponse> addNewMonitorsResponse,
+        List<IndexMonitorResponse> updateMonitorResponse
+    ) {
+        List<String> addedMonitorIds = addNewMonitorsResponse.stream().map(IndexMonitorResponse::getId)
+            .collect(Collectors.toList());
+        List<String> updatedMonitorIds = updateMonitorResponse.stream().map(IndexMonitorResponse::getId)
+            .collect(Collectors.toList());
+
+        // If there are no added or updated monitors - all monitors should be deleted
+        // Before deleting the monitors, workflow should be removed so there are no monitors that are part of the workflow
+        // which means that the workflow should be removed
+        if (addedMonitorIds.isEmpty() && updatedMonitorIds.isEmpty()) {
+            workflowService.deleteWorkflow(
+                detector.getWorkflowIds().get(0),
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(DeleteWorkflowResponse deleteWorkflowResponse) {
+                        detector.setWorkflowIds(Collections.emptyList());
+                        deleteMonitorStep(monitorsToBeDeleted, refreshPolicy, updatedMonitors, listener);
+                    }
+                    @Override
+                    public void onFailure(Exception e) {
+                        log.error("Failed to delete the workflow", e);
+                        listener.onFailure(e);
+                    }
+                }
+            );
+
+        } else {
+            // Update workflow and delete the monitors
+            workflowService.upsertWorkflow(
+                addedMonitorIds,
+                updatedMonitorIds,
+                detector,
+                refreshPolicy,
+                detector.getWorkflowIds().get(0),
+                Method.PUT,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(IndexWorkflowResponse workflowResponse) {
+                        deleteMonitorStep(monitorsToBeDeleted, refreshPolicy, updatedMonitors, listener);
+                    }
+                    @Override
+                    public void onFailure(Exception e) {
+                        log.error("Failed to update the workflow");
+                        listener.onFailure(e);
+                    }
+                });
+        }
     }
 
     private IndexMonitorRequest createDocLevelMonitorRequest(List<Pair<String, Rule>> queries, Detector detector, WriteRequest.RefreshPolicy refreshPolicy, String monitorId, RestRequest.Method restMethod) {
@@ -515,7 +653,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             triggers.add(new DocumentLevelTrigger(id, name, severity, actions, condition));
         }
 
-        Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), detector.getEnabled(), detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
+        Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), false, detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
                 Monitor.MonitorType.DOC_LEVEL_MONITOR, detector.getUser(), 1, docLevelMonitorInputs, triggers, Map.of(),
                 new DataSources(detector.getRuleIndex(),
                         detector.getFindingsIndex(),
@@ -593,36 +731,36 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             .aggregation(aggregationQueries.getAggBuilder());
         // input index can also be an index pattern or alias so we have to resolve it to concrete index
         String concreteIndex = IndexUtils.getNewIndexByCreationDate(
-                clusterService.state(),
-                indexNameExpressionResolver,
-                indices.get(0) // taking first one is fine because we expect that all indices in list share same mappings
+            clusterService.state(),
+            indexNameExpressionResolver,
+            indices.get(0) // taking first one is fine because we expect that all indices in list share same mappings
         );
         try {
             GetIndexMappingsResponse getIndexMappingsResponse = client.execute(
                     GetIndexMappingsAction.INSTANCE,
                     new GetIndexMappingsRequest(concreteIndex))
-                    .actionGet();
+                .actionGet();
             MappingMetadata mappingMetadata = getIndexMappingsResponse.mappings().get(concreteIndex);
             List<Pair<String, String>> pairs = MapperUtils.getAllAliasPathPairs(mappingMetadata);
             boolean timeStampAliasPresent = pairs.
-                    stream()
-                    .anyMatch(p ->
-                            TIMESTAMP_FIELD_ALIAS.equals(p.getLeft()) || TIMESTAMP_FIELD_ALIAS.equals(p.getRight()));
+                stream()
+                .anyMatch(p ->
+                    TIMESTAMP_FIELD_ALIAS.equals(p.getLeft()) || TIMESTAMP_FIELD_ALIAS.equals(p.getRight()));
             if(timeStampAliasPresent) {
                 BoolQueryBuilder boolQueryBuilder = searchSourceBuilder.query() == null
-                        ? new BoolQueryBuilder()
-                        : QueryBuilders.boolQuery().must(searchSourceBuilder.query());
+                    ? new BoolQueryBuilder()
+                    : QueryBuilders.boolQuery().must(searchSourceBuilder.query());
                 RangeQueryBuilder timeRangeFilter = QueryBuilders.rangeQuery(TIMESTAMP_FIELD_ALIAS)
-                        .gt("{{period_end}}||-1h")
-                        .lte("{{period_end}}")
-                        .format("epoch_millis");
+                    .gt("{{period_end}}||-1h")
+                    .lte("{{period_end}}")
+                    .format("epoch_millis");
                 boolQueryBuilder.must(timeRangeFilter);
                 searchSourceBuilder.query(boolQueryBuilder);
             }
         } catch (Exception e) {
             log.error(
-                    String.format(Locale.getDefault(),
-                            "Unable to verify presence of timestamp alias for index [%s] in detector [%s]. Not setting time range filter for bucket level monitor.",
+                String.format(Locale.getDefault(),
+                    "Unable to verify presence of timestamp alias for index [%s] in detector [%s]. Not setting time range filter for bucket level monitor.",
                     concreteIndex, detector.getName()), e);
         }
 
@@ -647,7 +785,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
          triggers.add(bucketLevelTrigger1);
          } **/
 
-        Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), detector.getEnabled(), detector.getSchedule(), detector.getLastUpdateTime(), detector.getEnabledTime(),
+        Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), false, detector.getSchedule(), detector.getLastUpdateTime(), null,
             MonitorType.BUCKET_LEVEL_MONITOR, detector.getUser(), 1, bucketLevelMonitorInputs, triggers, Map.of(),
             new DataSources(detector.getRuleIndex(),
                 detector.getFindingsIndex(),
@@ -692,48 +830,6 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         for (IndexMonitorRequest req: indexMonitors) {
             AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, req, namedWriteableRegistry, monitorResponseListener);
         }
-    }
-
-    /**
-     * Deletes the alerting monitors based on the given ids and notifies the listener that will be notified once all monitors have been deleted
-     * @param monitorIds monitor ids to be deleted
-     * @param refreshPolicy
-     * @param listener listener that will be notified once all the monitors are being deleted
-     */
-    private void deleteAlertingMonitors(List<String> monitorIds, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<List<DeleteMonitorResponse>> listener){
-        if (monitorIds == null || monitorIds.isEmpty()) {
-            listener.onResponse(new ArrayList<>());
-            return;
-        }
-        ActionListener<DeleteMonitorResponse> deletesListener = new GroupedActionListener<>(new ActionListener<>() {
-            @Override
-            public void onResponse(Collection<DeleteMonitorResponse> responses) {
-                SetOnce<RestStatus> errorStatusSupplier = new SetOnce<>();
-                if (responses.stream().filter(response -> {
-                    if (response.getStatus() != RestStatus.OK) {
-                        log.error("Monitor [{}] could not be deleted. Status [{}]", response.getId(), response.getStatus());
-                        errorStatusSupplier.trySet(response.getStatus());
-                        return true;
-                    }
-                    return false;
-                }).count() > 0) {
-                    listener.onFailure(new OpenSearchStatusException("Monitor associated with detected could not be deleted", errorStatusSupplier.get()));
-                }
-                listener.onResponse(responses.stream().collect(Collectors.toList()));
-            }
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(e);
-            }
-        }, monitorIds.size());
-
-        for (String monitorId : monitorIds) {
-            deleteAlertingMonitor(monitorId, refreshPolicy, deletesListener);
-        }
-    }
-    private void deleteAlertingMonitor(String monitorId, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<DeleteMonitorResponse> listener) {
-        DeleteMonitorRequest request = new DeleteMonitorRequest(monitorId, refreshPolicy);
-        AlertingPluginInterface.INSTANCE.deleteMonitor((NodeClient) client, request, listener);
     }
 
     private void onCreateMappingsResponse(CreateIndexResponse response) throws IOException {
@@ -917,19 +1013,19 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
                     try {
                         XContentParser xcp = XContentHelper.createParser(
-                                xContentRegistry, LoggingDeprecationHandler.INSTANCE,
-                                response.getSourceAsBytesRef(), XContentType.JSON
+                            xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                            response.getSourceAsBytesRef(), XContentType.JSON
                         );
 
                         Detector detector = Detector.docParse(xcp, response.getId(), response.getVersion());
 
                         // security is enabled and filterby is enabled
                         if (!checkUserPermissionsWithResource(
-                                originalContextUser,
-                                detector.getUser(),
-                                "detector",
-                                detector.getId(),
-                                TransportIndexDetectorAction.this.filterByEnabled
+                            originalContextUser,
+                            detector.getUser(),
+                            "detector",
+                            detector.getId(),
+                            TransportIndexDetectorAction.this.filterByEnabled
                         )
 
                         ) {
@@ -955,6 +1051,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             }
             request.getDetector().setMonitorIds(currentDetector.getMonitorIds());
             request.getDetector().setRuleIdMonitorIdMap(currentDetector.getRuleIdMonitorIdMap());
+            request.getDetector().setWorkflowIds(currentDetector.getWorkflowIds());
             Detector detector = request.getDetector();
 
             String ruleTopic = detector.getDetectorType();
@@ -1007,11 +1104,41 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
         public void initRuleIndexAndImportRules(IndexDetectorRequest request, ActionListener<List<IndexMonitorResponse>> listener) {
             ruleIndices.initPrepackagedRulesIndex(
-                    new ActionListener<>() {
-                        @Override
-                        public void onResponse(CreateIndexResponse response) {
-                            ruleIndices.onCreateMappingsResponse(response, true);
-                            ruleIndices.importRules(RefreshPolicy.IMMEDIATE, indexTimeout,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(CreateIndexResponse response) {
+                        ruleIndices.onCreateMappingsResponse(response, true);
+                        ruleIndices.importRules(RefreshPolicy.IMMEDIATE, indexTimeout,
+                            new ActionListener<>() {
+                                @Override
+                                public void onResponse(BulkResponse response) {
+                                    if (!response.hasFailures()) {
+                                        importRules(request, listener);
+                                    } else {
+                                        onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
+                                    }
+                                }
+
+                                @Override
+                                public void onFailure(Exception e) {
+                                    onFailures(e);
+                                }
+                            });
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        onFailures(e);
+                    }
+                },
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse response) {
+                        ruleIndices.onUpdateMappingsResponse(response, true);
+                        ruleIndices.deleteRules(new ActionListener<>() {
+                            @Override
+                            public void onResponse(BulkByScrollResponse response) {
+                                ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
                                     new ActionListener<>() {
                                         @Override
                                         public void onResponse(BulkResponse response) {
@@ -1027,85 +1154,55 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                                             onFailures(e);
                                         }
                                     });
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            onFailures(e);
-                        }
-                    },
-                    new ActionListener<>() {
-                        @Override
-                        public void onResponse(AcknowledgedResponse response) {
-                            ruleIndices.onUpdateMappingsResponse(response, true);
-                            ruleIndices.deleteRules(new ActionListener<>() {
-                                @Override
-                                public void onResponse(BulkByScrollResponse response) {
-                                    ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
-                                            new ActionListener<>() {
-                                                @Override
-                                                public void onResponse(BulkResponse response) {
-                                                    if (!response.hasFailures()) {
-                                                        importRules(request, listener);
-                                                    } else {
-                                                        onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
-                                                    }
-                                                }
-
-                                                @Override
-                                                public void onFailure(Exception e) {
-                                                    onFailures(e);
-                                                }
-                                            });
-                                }
-
-                                @Override
-                                public void onFailure(Exception e) {
-                                    onFailures(e);
-                                }
-                            });
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            onFailures(e);
-                        }
-                    },
-                    new ActionListener<>() {
-                        @Override
-                        public void onResponse(SearchResponse response) {
-                            if (response.isTimedOut()) {
-                                onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
                             }
 
-                            long count = response.getHits().getTotalHits().value;
-                            if (count == 0) {
-                                ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
-                                        new ActionListener<>() {
-                                            @Override
-                                            public void onResponse(BulkResponse response) {
-                                                if (!response.hasFailures()) {
-                                                    importRules(request, listener);
-                                                } else {
-                                                    onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
-                                                }
-                                            }
-
-                                            @Override
-                                            public void onFailure(Exception e) {
-                                                onFailures(e);
-                                            }
-                                        });
-                            } else {
-                                importRules(request, listener);
+                            @Override
+                            public void onFailure(Exception e) {
+                                onFailures(e);
                             }
+                        });
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        onFailures(e);
+                    }
+                },
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(SearchResponse response) {
+                        if (response.isTimedOut()) {
+                            onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
                         }
 
-                        @Override
-                        public void onFailure(Exception e) {
-                            onFailures(e);
+                        long count = response.getHits().getTotalHits().value;
+                        if (count == 0) {
+                            ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
+                                new ActionListener<>() {
+                                    @Override
+                                    public void onResponse(BulkResponse response) {
+                                        if (!response.hasFailures()) {
+                                            importRules(request, listener);
+                                        } else {
+                                            onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onFailure(Exception e) {
+                                        onFailures(e);
+                                    }
+                                });
+                        } else {
+                            importRules(request, listener);
                         }
                     }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        onFailures(e);
+                    }
+                }
             );
         }
 
@@ -1119,14 +1216,14 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             List<String> ruleIds = detectorInput.getPrePackagedRules().stream().map(DetectorRule::getId).collect(Collectors.toList());
 
             QueryBuilder queryBuilder =
-                    QueryBuilders.nestedQuery("rule",
-                            QueryBuilders.boolQuery().must(
-                                    QueryBuilders.matchQuery("rule.category", ruleTopic)
-                            ).must(
-                                    QueryBuilders.termsQuery("_id", ruleIds.toArray(new String[]{}))
-                            ),
-                            ScoreMode.Avg
-                    );
+                QueryBuilders.nestedQuery("rule",
+                    QueryBuilders.boolQuery().must(
+                        QueryBuilders.matchQuery("rule.category", ruleTopic)
+                    ).must(
+                        QueryBuilders.termsQuery("_id", ruleIds.toArray(new String[]{}))
+                    ),
+                    ScoreMode.Avg
+                );
 
             SearchRequest searchRequest = new SearchRequest(Rule.PRE_PACKAGED_RULES_INDEX)
                     .source(new SearchSourceBuilder()
@@ -1149,8 +1246,8 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                     try {
                         for (SearchHit hit: hits) {
                             XContentParser xcp = XContentType.JSON.xContent().createParser(
-                                    xContentRegistry,
-                                    LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString()
+                                xContentRegistry,
+                                LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString()
                             );
 
                             Rule rule = Rule.docParse(xcp, hit.getId(), hit.getVersion());
@@ -1165,7 +1262,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                             onFailures(new OpenSearchStatusException("Custom Rule Index not found", RestStatus.NOT_FOUND));
                         } else {
                             if (request.getMethod() == RestRequest.Method.POST) {
-                                createMonitorFromQueries(logIndex, queries, detector, listener, request.getRefreshPolicy());
+                                createMonitorFromQueries(queries, detector, listener, request.getRefreshPolicy());
                             } else if (request.getMethod() == RestRequest.Method.PUT) {
                                 updateMonitorFromQueries(logIndex, queries, detector, listener, request.getRefreshPolicy());
                             }
@@ -1208,8 +1305,8 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                     try {
                         for (SearchHit hit : hits) {
                             XContentParser xcp = XContentType.JSON.xContent().createParser(
-                                    xContentRegistry,
-                                    LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString()
+                                xContentRegistry,
+                                LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString()
                             );
 
                             Rule rule = Rule.docParse(xcp, hit.getId(), hit.getVersion());
@@ -1219,7 +1316,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                         }
 
                         if (request.getMethod() == RestRequest.Method.POST) {
-                            createMonitorFromQueries(logIndex, queries, detector, listener, request.getRefreshPolicy());
+                            createMonitorFromQueries(queries, detector, listener, request.getRefreshPolicy());
                         } else if (request.getMethod() == RestRequest.Method.PUT) {
                             updateMonitorFromQueries(logIndex, queries, detector, listener, request.getRefreshPolicy());
                         }
@@ -1239,15 +1336,15 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
             IndexRequest indexRequest;
             if (request.getMethod() == RestRequest.Method.POST) {
                 indexRequest = new IndexRequest(Detector.DETECTORS_INDEX)
-                        .setRefreshPolicy(request.getRefreshPolicy())
-                        .source(request.getDetector().toXContentWithUser(XContentFactory.jsonBuilder(), new ToXContent.MapParams(Map.of("with_type", "true"))))
-                        .timeout(indexTimeout);
+                    .setRefreshPolicy(request.getRefreshPolicy())
+                    .source(request.getDetector().toXContentWithUser(XContentFactory.jsonBuilder(), new ToXContent.MapParams(Map.of("with_type", "true"))))
+                    .timeout(indexTimeout);
             } else {
                 indexRequest = new IndexRequest(Detector.DETECTORS_INDEX)
-                        .setRefreshPolicy(request.getRefreshPolicy())
-                        .source(request.getDetector().toXContentWithUser(XContentFactory.jsonBuilder(), new ToXContent.MapParams(Map.of("with_type", "true"))))
-                        .id(request.getDetectorId())
-                        .timeout(indexTimeout);
+                    .setRefreshPolicy(request.getRefreshPolicy())
+                    .source(request.getDetector().toXContentWithUser(XContentFactory.jsonBuilder(), new ToXContent.MapParams(Map.of("with_type", "true"))))
+                    .id(request.getDetectorId())
+                    .timeout(indexTimeout);
             }
 
             client.index(indexRequest, new ActionListener<>() {
@@ -1260,7 +1357,30 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
                 @Override
                 public void onFailure(Exception e) {
-                    onFailures(e);
+                    // Revert the workflow and monitors created in previous steps
+                    workflowService.deleteWorkflow(request.getDetector().getWorkflowIds().get(0),
+                        new ActionListener<>() {
+                            @Override
+                            public void onResponse(DeleteWorkflowResponse deleteWorkflowResponse) {
+                                monitorService.deleteAlertingMonitors(request.getDetector().getMonitorIds(),
+                                    request.getRefreshPolicy(),
+                                    new ActionListener<>() {
+                                        @Override
+                                        public void onResponse(List<DeleteMonitorResponse> deleteMonitorResponses) {
+                                            onFailures(e);
+                                        }
+
+                                        @Override
+                                        public void onFailure(Exception e) {
+                                            onFailures(e);
+                                        }
+                                    });
+                            }
+                            @Override
+                            public void onFailure(Exception e) {
+                                onFailures(e);
+                            }
+                        });
                 }
             });
         }
@@ -1305,18 +1425,18 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
          */
         private Map<String, String> mapMonitorIds(List<IndexMonitorResponse> monitorResponses) {
             return monitorResponses.stream().collect(
-                    Collectors.toMap(
-                        // In the case of bucket level monitors rule id is trigger id
-                        it -> {
-                            if (MonitorType.BUCKET_LEVEL_MONITOR == it.getMonitor().getMonitorType()) {
-                                return it.getMonitor().getTriggers().get(0).getId();
-                            } else {
-                                return Detector.DOC_LEVEL_MONITOR;
-                            }
-                        },
-                        IndexMonitorResponse::getId
-                    )
-                );
+                Collectors.toMap(
+                    // In the case of bucket level monitors rule id is trigger id
+                    it -> {
+                        if (MonitorType.BUCKET_LEVEL_MONITOR == it.getMonitor().getMonitorType()) {
+                            return it.getMonitor().getTriggers().get(0).getId();
+                        } else {
+                            return Detector.DOC_LEVEL_MONITOR;
+                        }
+                    },
+                    IndexMonitorResponse::getId
+                )
+            );
         }
     }
 
@@ -1324,4 +1444,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         this.filterByEnabled = filterByEnabled;
     }
 
+    private void setEnabledWorkflowUsage(boolean enabledWorkflowUsage) {
+        this.enabledWorkflowUsage = enabledWorkflowUsage;
+    }
 }

--- a/src/main/java/org/opensearch/securityanalytics/util/MonitorService.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/MonitorService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.securityanalytics.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.SetOnce;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.support.GroupedActionListener;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.commons.alerting.AlertingPluginInterface;
+import org.opensearch.commons.alerting.action.DeleteMonitorRequest;
+import org.opensearch.commons.alerting.action.DeleteMonitorResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Alerting common class used for monitors manipulation
+ */
+public class MonitorService {
+    private static final Logger log = LogManager.getLogger(MonitorService.class);
+
+    private Client client;
+
+    public MonitorService() {
+    }
+
+    public MonitorService(Client client) {
+        this.client = client;
+    }
+
+    /**
+     * Deletes the alerting monitors based on the given ids and notifies the listener that will be notified once all monitors have been deleted
+     * @param monitorIds monitor ids to be deleted
+     * @param refreshPolicy
+     * @param listener listener that will be notified once all the monitors are being deleted
+     */
+    public void deleteAlertingMonitors(List<String> monitorIds, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<List<DeleteMonitorResponse>> listener){
+        if (monitorIds == null || monitorIds.isEmpty()) {
+            listener.onResponse(new ArrayList<>());
+            return;
+        }
+        ActionListener<DeleteMonitorResponse> deletesListener = new GroupedActionListener<>(new ActionListener<>() {
+            @Override
+            public void onResponse(Collection<DeleteMonitorResponse> responses) {
+                SetOnce<RestStatus> errorStatusSupplier = new SetOnce<>();
+                if (responses.stream().filter(response -> {
+                    if (response.getStatus() != RestStatus.OK) {
+                        log.error("Monitor [{}] could not be deleted. Status [{}]", response.getId(), response.getStatus());
+                        errorStatusSupplier.trySet(response.getStatus());
+                        return true;
+                    }
+                    return false;
+                }).count() > 0) {
+                    listener.onFailure(new OpenSearchStatusException("Monitor associated with detected could not be deleted", errorStatusSupplier.get()));
+                }
+                listener.onResponse(responses.stream().collect(Collectors.toList()));
+            }
+            @Override
+            public void onFailure(Exception e) {
+                log.error("Error deleting monitors", e.getSuppressed());
+                listener.onFailure(e);
+            }
+        }, monitorIds.size());
+
+        for (String monitorId : monitorIds) {
+            deleteAlertingMonitor(monitorId, refreshPolicy, deletesListener);
+        }
+    }
+
+    private void deleteAlertingMonitor(String monitorId, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<DeleteMonitorResponse> listener) {
+        DeleteMonitorRequest request = new DeleteMonitorRequest(monitorId, refreshPolicy);
+        AlertingPluginInterface.INSTANCE.deleteMonitor((NodeClient) client, request, listener);
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/util/WorkflowService.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/WorkflowService.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.securityanalytics.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.commons.alerting.AlertingPluginInterface;
+import org.opensearch.commons.alerting.action.DeleteMonitorResponse;
+import org.opensearch.commons.alerting.action.DeleteWorkflowRequest;
+import org.opensearch.commons.alerting.action.DeleteWorkflowResponse;
+import org.opensearch.commons.alerting.action.IndexMonitorResponse;
+import org.opensearch.commons.alerting.action.IndexWorkflowRequest;
+import org.opensearch.commons.alerting.action.IndexWorkflowResponse;
+import org.opensearch.commons.alerting.model.CompositeInput;
+import org.opensearch.commons.alerting.model.Delegate;
+import org.opensearch.commons.alerting.model.Monitor.MonitorType;
+import org.opensearch.commons.alerting.model.Sequence;
+import org.opensearch.commons.alerting.model.Workflow;
+import org.opensearch.commons.alerting.model.Workflow.WorkflowType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.securityanalytics.model.Detector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * Alerting common clas used for workflow manipulation
+ */
+public class WorkflowService {
+    private static final Logger log = LogManager.getLogger(WorkflowService.class);
+    private Client client;
+
+    private MonitorService monitorService;
+
+    public WorkflowService() {
+    }
+
+    public WorkflowService(Client client, MonitorService monitorService) {
+        this.client = client;
+        this.monitorService = monitorService;
+    }
+
+    /**
+     * Upserts the workflow - depending on the method and lists forwarded; If the method is put and updated
+     * If the workflow upsert failed, deleting monitors will be performed
+     * @param addedMonitors monitors to be added
+     * @param updatedMonitors monitors to be updated
+     * @param detector detector for which monitors needs to be added/updated
+     * @param refreshPolicy
+     * @param workflowId
+     * @param method http method POST/PUT
+     * @param listener
+     */
+    public void upsertWorkflow(
+        List<String> addedMonitors,
+        List<String> updatedMonitors,
+        Detector detector,
+        RefreshPolicy refreshPolicy,
+        String workflowId,
+        Method method,
+        ActionListener<IndexWorkflowResponse> listener
+    ) {
+        if (method != Method.POST && method != Method.PUT) {
+            log.error(String.format("Method %s not supported when upserting the workflow", method.name()));
+            listener.onFailure(SecurityAnalyticsException.wrap(new OpenSearchException("Method not supported")));
+            return;
+        }
+
+        List<String> monitorIds = new ArrayList<>();
+        monitorIds.addAll(addedMonitors);
+
+        if (updatedMonitors != null && !updatedMonitors.isEmpty()) {
+            monitorIds.addAll(updatedMonitors);
+        }
+
+        IndexWorkflowRequest indexWorkflowRequest = createWorkflowRequest(monitorIds,
+            detector,
+            refreshPolicy, workflowId, method);
+
+        AlertingPluginInterface.INSTANCE.indexWorkflow((NodeClient) client,
+            indexWorkflowRequest,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(IndexWorkflowResponse workflowResponse) {
+                    listener.onResponse(workflowResponse);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    // Remove created monitors and fail creation of workflow
+                    log.error("Failed workflow saving. Removing created monitors: " + addedMonitors.stream().collect(
+                        Collectors.joining()) , e);
+
+                    monitorService.deleteAlertingMonitors(addedMonitors,
+                        refreshPolicy,
+                        new ActionListener<>() {
+                            @Override
+                            public void onResponse(List<DeleteMonitorResponse> deleteMonitorResponses) {
+                                log.debug("Monitors successfully deleted");
+                                listener.onFailure(e);
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                log.error("Error deleting monitors", e);
+                                listener.onFailure(e);
+                            }
+                        });
+                }
+            });
+    }
+
+    public void deleteWorkflow(String workflowId, ActionListener<DeleteWorkflowResponse> deleteWorkflowListener) {
+        DeleteWorkflowRequest deleteWorkflowRequest = new DeleteWorkflowRequest(workflowId, false);
+        AlertingPluginInterface.INSTANCE.deleteWorkflow((NodeClient) client, deleteWorkflowRequest, deleteWorkflowListener);
+    }
+
+    private IndexWorkflowRequest createWorkflowRequest(List<String> monitorIds, Detector detector, RefreshPolicy refreshPolicy, String workflowId, Method method) {
+        AtomicInteger index = new AtomicInteger();
+
+        // TODO - update chained findings
+        List<Delegate> delegates = monitorIds.stream().map(
+            monitorId -> new Delegate(index.incrementAndGet(), monitorId, null)
+        ).collect(Collectors.toList());
+        
+        Sequence sequence = new Sequence(delegates);
+        CompositeInput compositeInput = new CompositeInput(sequence);
+
+        Workflow workflow = new Workflow(
+            workflowId,
+            Workflow.NO_VERSION,
+            detector.getName(),
+            detector.getEnabled(),
+            detector.getSchedule(),
+            detector.getLastUpdateTime(),
+            detector.getEnabledTime(),
+            WorkflowType.COMPOSITE,
+            detector.getUser(),
+            1,
+            List.of(compositeInput),
+            "security_analytics",
+            Collections.emptyList(),
+            false
+        );
+
+        return new IndexWorkflowRequest(
+            workflowId,
+            SequenceNumbers.UNASSIGNED_SEQ_NO,
+            SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            refreshPolicy,
+            method,
+            workflow,
+            null
+        );
+    }
+
+    private Map<String, String> mapMonitorIds(List<IndexMonitorResponse> monitorResponses) {
+        return monitorResponses.stream().collect(
+            Collectors.toMap(
+                // In the case of bucket level monitors rule id is trigger id
+                it -> {
+                    if (MonitorType.BUCKET_LEVEL_MONITOR == it.getMonitor().getMonitorType()) {
+                        return it.getMonitor().getTriggers().get(0).getId();
+                    } else {
+                        return Detector.DOC_LEVEL_MONITOR;
+                    }
+                },
+                IndexMonitorResponse::getId
+            )
+        );
+    }
+}
+

--- a/src/main/resources/mappings/detectors.json
+++ b/src/main/resources/mappings/detectors.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 1
+    "schema_version": 2
   },
   "properties": {
     "detector": {
@@ -87,6 +87,9 @@
               "ignore_above": 256
             }
           }
+        },
+        "workflow_ids": {
+          "type": "keyword"
         },
         "rule_index": {
           "type": "text",

--- a/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
+++ b/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
@@ -128,6 +128,66 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
         }
     }
 
+    protected void verifyWorkflow(Map<String, Object> detectorMap, List<String> monitorIds, int expectedDelegatesNum) throws IOException{
+        String workflowId = ((List<String>) detectorMap.get("workflow_ids")).get(0);
+
+        Map<String, Object> workflow = searchWorkflow(workflowId);
+        assertNotNull("Workflow not found", workflow);
+
+        List<Map<String, Object>> workflowInputs = (List<Map<String, Object>>) workflow.get("inputs");
+        assertEquals("Workflow not found", 1, workflowInputs.size());
+
+        Map<String, Object> sequence = ((Map<String, Object>)((Map<String, Object>)workflowInputs.get(0).get("composite_input")).get("sequence"));
+        assertNotNull("Sequence is null", sequence);
+
+        List<Map<String, Object>> delegates = (List<Map<String, Object>>) sequence.get("delegates");
+        assertEquals(expectedDelegatesNum, delegates.size());
+        // Assert that all monitors are present
+        for (Map<String, Object> delegate: delegates) {
+            assertTrue("Monitor doesn't exist in monitor list", monitorIds.contains(delegate.get("monitor_id")));
+        }
+    }
+
+    protected Map<String, Object> searchWorkflow(String workflowId) throws IOException{
+        String workflowRequest =   "{\n" +
+            "   \"query\":{\n" +
+            "      \"term\":{\n" +
+            "         \"_id\":{\n" +
+            "            \"value\":\"" + workflowId + "\"\n" +
+            "         }\n" +
+            "      }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(ScheduledJob.SCHEDULED_JOBS_INDEX, workflowRequest);
+        if (hits.size() == 0) {
+            return new HashMap<>();
+        }
+
+        SearchHit hit = hits.get(0);
+        return (Map<String, Object>) hit.getSourceAsMap().get("workflow");
+    }
+
+
+    protected List<Map<String, Object>> getAllWorkflows() throws IOException{
+        String workflowRequest =    "{\n" +
+            "   \"query\":{\n" +
+            "      \"exists\":{\n" +
+            "         \"field\": \"workflow\"" +
+            "         }\n" +
+            "      }\n" +
+            "   }";
+
+        List<SearchHit> hits = executeSearch(ScheduledJob.SCHEDULED_JOBS_INDEX, workflowRequest);
+        if (hits.size() == 0) {
+            return new ArrayList<>();
+        }
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (SearchHit hit: hits) {
+            result.add((Map<String, Object>) hit.getSourceAsMap().get("workflow"));
+        }
+        return result;
+    }
+
     protected String createDetector(Detector detector) throws IOException {
         Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
         Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
@@ -330,6 +390,14 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
 
     protected Response deleteAlertingMonitor(RestClient client, String monitorId) throws IOException {
         return makeRequest(client, "DELETE", String.format(Locale.getDefault(), "/_plugins/_alerting/monitors/%s", monitorId), new HashMap<>(), null);
+    }
+
+    protected Response executeAlertingWorkflow(String monitorId, Map<String, String> params) throws IOException {
+        return executeAlertingWorkflow(client(), monitorId, params);
+    }
+
+    protected Response executeAlertingWorkflow(RestClient client, String workflowId, Map<String, String> params) throws IOException {
+        return makeRequest(client, "POST", String.format(Locale.getDefault(), "/_plugins/_alerting/workflows/%s/_execute", workflowId), params, null);
     }
 
     protected List<SearchHit> executeSearch(String index, String request) throws IOException {
@@ -1651,7 +1719,6 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
         createDatastreamAPI(datastreamName);
     }
 
-
     protected void restoreAlertsFindingsIMSettings() throws IOException {
         updateClusterSetting(ALERT_HISTORY_ROLLOVER_PERIOD.getKey(), "720m");
         updateClusterSetting(ALERT_HISTORY_MAX_DOCS.getKey(), "100000");
@@ -1663,5 +1730,12 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
         updateClusterSetting(FINDING_HISTORY_INDEX_MAX_AGE.getKey(), "60d");
         updateClusterSetting(FINDING_HISTORY_RETENTION_PERIOD.getKey(), "60d");
 
+    }
+
+    protected void  enableOrDisableWorkflow(String trueOrFalse) throws IOException {
+        Request request = new Request("PUT", "_cluster/settings");
+        String entity = "{\"persistent\":{\"plugins.security_analytics.filter_by_backend_roles\" : " + trueOrFalse + "}}";
+        request.setJsonEntity(entity);
+        client().performRequest(request);
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -143,7 +143,7 @@ public class TestHelpers {
             DetectorTrigger trigger = new DetectorTrigger(null, "windows-trigger", "1", List.of(randomDetectorType()), List.of("QuarksPwDump Clearing Access History"), List.of("high"), List.of("T0008"), List.of());
             triggers.add(trigger);
         }
-        return new Detector(null, null, name, enabled, schedule, lastUpdateTime, enabledTime, detectorType, user, inputs, triggers, Collections.singletonList(""), "", "", "", "", "", "", Collections.emptyMap());
+        return new Detector(null, null, name, enabled, schedule, lastUpdateTime, enabledTime, detectorType, user, inputs, triggers, Collections.singletonList(""), "", "", "", "", "", "", Collections.emptyMap(), Collections.emptyList());
     }
 
     public static CustomLogType randomCustomLogType(String name, String description, String source) {
@@ -168,7 +168,28 @@ public class TestHelpers {
         Instant enabledTime = enabled ? Instant.now().truncatedTo(ChronoUnit.MILLIS) : null;
         Instant lastUpdateTime = Instant.now().truncatedTo(ChronoUnit.MILLIS);
 
-        return new Detector(null, null, name, enabled, schedule, lastUpdateTime, enabledTime, detectorType, null, inputs, Collections.emptyList(),Collections.singletonList(""), "", "", "", "", "", "", Collections.emptyMap());
+        return new Detector(
+            null,
+            null,
+            name,
+            enabled,
+            schedule,
+            lastUpdateTime,
+            enabledTime,
+            detectorType,
+            null,
+            inputs,
+            Collections.emptyList(),
+            Collections.singletonList(""),
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            Collections.emptyMap(),
+            Collections.emptyList()
+        );
     }
 
     public static CorrelationRule randomCorrelationRule(String name) {

--- a/src/test/java/org/opensearch/securityanalytics/action/IndexDetectorResponseTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/IndexDetectorResponseTests.java
@@ -49,7 +49,8 @@ public class IndexDetectorResponseTests extends OpenSearchTestCase {
                 null,
                 null,
                 DetectorMonitorConfig.getFindingsIndex("others_application"),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                Collections.emptyList()
         );
         IndexDetectorResponse response = new IndexDetectorResponse("1234", 1L, RestStatus.OK, detector);
         Assert.assertNotNull(response);

--- a/src/test/java/org/opensearch/securityanalytics/alerts/AlertingServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/alerts/AlertingServiceTests.java
@@ -64,7 +64,8 @@ public class AlertingServiceTests extends OpenSearchTestCase {
                 null,
                 null,
                 DetectorMonitorConfig.getFindingsIndex("others_application"),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                Collections.emptyList()
         );
         GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
 
@@ -240,7 +241,8 @@ public class AlertingServiceTests extends OpenSearchTestCase {
                 null,
                 null,
                 DetectorMonitorConfig.getFindingsIndex("others_application"),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                Collections.emptyList()
         );
         GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
 

--- a/src/test/java/org/opensearch/securityanalytics/findings/FindingServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/findings/FindingServiceTests.java
@@ -64,7 +64,8 @@ public class FindingServiceTests extends OpenSearchTestCase {
                 null,
                 null,
                 DetectorMonitorConfig.getFindingsIndex("others_application"),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                Collections.emptyList()
         );
         GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
 
@@ -184,7 +185,8 @@ public class FindingServiceTests extends OpenSearchTestCase {
                 null,
                 null,
                 DetectorMonitorConfig.getFindingsIndex("others_application"),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                Collections.emptyList()
         );
         GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
 

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
@@ -12,6 +12,7 @@ import static org.opensearch.securityanalytics.TestHelpers.randomDoc;
 import static org.opensearch.securityanalytics.TestHelpers.randomIndex;
 import static org.opensearch.securityanalytics.TestHelpers.randomRule;
 import static org.opensearch.securityanalytics.TestHelpers.windowsIndexMapping;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -856,6 +857,8 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
 
         Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
 
+
+
         String request = "{\n" +
             "   \"query\" : {\n" +
             "     \"match_all\":{\n" +
@@ -975,12 +978,472 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertTrue(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8").containsAll(docLevelFinding));
     }
 
-    private static void assertRuleMonitorFinding(Map<String, Object> executeResults, String ruleId,  int expectedDocCount, List<String> expectedTriggerResult) {
+    public void testCreateDetector_verifyWorkflowCreation_success() throws IOException {
+        updateClusterSetting(ENABLE_WORKFLOW_USAGE.getKey(), "true");
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        Response createMappingResponse = client().performRequest(createMappingRequest);
+
+        assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
+
+        String testOpCode = "Test";
+
+        String maxRuleId =  createRule(randomAggregationRule("max", " > 3", testOpCode));
+        String randomDocRuleId = createRule(randomRule());
+        List<DetectorRule> detectorRules = List.of(new DetectorRule(maxRuleId), new DetectorRule(randomDocRuleId));
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
+            Collections.emptyList());
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+
+        String request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match_all\":{\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
+
+         assertEquals(1, response.getHits().getTotalHits().value);
+
+        assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+        Map<String, Object> responseBody = asMap(createResponse);
+
+        String detectorId = responseBody.get("_id").toString();
+        request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+        Map<String, Object> detectorMap = (HashMap<String, Object>)(hit.getSourceAsMap().get("detector"));
+        List inputArr = (List) detectorMap.get("inputs");
+
+        assertEquals(2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
+
+        List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
+        assertEquals(2, monitorIds.size());
+
+        assertNotNull("Workflow not created", detectorMap.get("workflow_ids"));
+        assertEquals("Number of workflows not correct", 1, ((List<String>) detectorMap.get("workflow_ids")).size());
+
+        // Verify workflow
+        verifyWorkflow(detectorMap, monitorIds, 2);
+    }
+
+    public void testUpdateDetector_disabledWorkflowUsage_verifyWorkflowNotCreated_success() throws IOException {
+        // By default, workflow usage is disabled - disabling it just in any case
+        updateClusterSetting(ENABLE_WORKFLOW_USAGE.getKey(), "false");
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        Response createMappingResponse = client().performRequest(createMappingRequest);
+
+        assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
+
+        String randomDocRuleId = createRule(randomRule());
+
+        List<DetectorRule> detectorRules = List.of(new DetectorRule(randomDocRuleId));
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
+            Collections.emptyList());
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+
+        String request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match_all\":{\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
+
+        assertEquals(1, response.getHits().getTotalHits().value);
+
+        assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+        Map<String, Object> responseBody = asMap(createResponse);
+
+        String detectorId = responseBody.get("_id").toString();
+        request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+        Map<String, Object> detectorMap = (HashMap<String, Object>)(hit.getSourceAsMap().get("detector"));
+        List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
+        assertEquals(1, monitorIds.size());
+
+        assertTrue("Workflow created", ((List<String>) detectorMap.get("workflow_ids")).size() == 0);
+        List workflows = getAllWorkflows();
+        assertTrue("Workflow created", workflows.size() == 0);
+
+        // Enable workflow usage and verify detector update
+        updateClusterSetting(ENABLE_WORKFLOW_USAGE.getKey(), "true");
+        var updateResponse = makeRequest(client(), "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(detector));
+
+        assertEquals("Update detector failed", RestStatus.OK, restStatus(updateResponse));
+        hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        hit = hits.get(0);
+        detectorMap = (HashMap<String, Object>)(hit.getSourceAsMap().get("detector"));
+
+        // Verify that the workflow for the given detector is not added
+        assertTrue("Workflow created", ((List<String>) detectorMap.get("workflow_ids")).size() == 0);
+        workflows = getAllWorkflows();
+        assertTrue("Workflow created", workflows.size() == 0);
+    }
+
+    public void testUpdateDetector_removeRule_verifyWorkflowUpdate_success() throws IOException {
+        updateClusterSetting(ENABLE_WORKFLOW_USAGE.getKey(), "true");
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        Response createMappingResponse = client().performRequest(createMappingRequest);
+
+        assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
+
+        String testOpCode = "Test";
+
+        String maxRuleId =  createRule(randomAggregationRule("max", " > 3", testOpCode));
+        String randomDocRuleId = createRule(randomRule());
+
+        List<DetectorRule> detectorRules = List.of(new DetectorRule(maxRuleId), new DetectorRule(randomDocRuleId));
+
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
+            Collections.emptyList());
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+
+        String request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match_all\":{\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
+
+        assertEquals(1, response.getHits().getTotalHits().value);
+
+        assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+        Map<String, Object> responseBody = asMap(createResponse);
+
+        String detectorId = responseBody.get("_id").toString();
+        request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+        Map<String, Object> detectorMap = (HashMap<String, Object>)(hit.getSourceAsMap().get("detector"));
+        List inputArr = (List) detectorMap.get("inputs");
+
+        assertEquals(2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
+
+        List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
+        assertEquals(2, monitorIds.size());
+
+        assertNotNull("Workflow not created", detectorMap.get("workflow_ids"));
+        assertEquals("Number of workflows not correct", 1, ((List<String>) detectorMap.get("workflow_ids")).size());
+
+        // Verify workflow
+        verifyWorkflow(detectorMap, monitorIds, 2);
+
+        // Update detector - remove one agg rule; Verify workflow
+        DetectorInput newInput = new DetectorInput("windows detector for security analytics", List.of("windows"), Arrays.asList(new DetectorRule(randomDocRuleId)) , getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()));
+        detector = randomDetectorWithInputs(List.of(newInput));
+        createResponse = makeRequest(client(), "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(detector));
+
+        assertEquals("Update detector failed", RestStatus.OK, restStatus(createResponse));
+        hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        hit = hits.get(0);
+        detectorMap = (HashMap<String, Object>)(hit.getSourceAsMap().get("detector"));
+        inputArr = (List) detectorMap.get("inputs");
+
+        assertEquals(1, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
+
+        monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
+        assertEquals(1, monitorIds.size());
+
+        assertNotNull("Workflow not created", detectorMap.get("workflow_ids"));
+        assertEquals("Number of workflows not correct", 1, ((List<String>) detectorMap.get("workflow_ids")).size());
+
+        // Verify workflow
+        verifyWorkflow(detectorMap, monitorIds, 1);
+
+        indexDoc(index, "1", randomDoc(5, 3, testOpCode));
+        String workflowId = ((List<String>) detectorMap.get("workflow_ids")).get(0);
+
+        Response executeResponse = executeAlertingWorkflow(workflowId, Collections.emptyMap());
+
+        List<Map<String, Object>> monitorRunResults = (List<Map<String, Object>>) entityAsMap(executeResponse).get("workflow_run_result");
+        assertEquals(1, monitorRunResults.size());
+
+        int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) monitorRunResults.get(0).get("input_results")).get("results")).get(0).size();
+        assertEquals(6, noOfSigmaRuleMatches);
+
+        // Verify findings
+        Map<String, String> params = new HashMap<>();
+        params.put("detector_id", detectorId);
+        Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+        Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+
+        assertNotNull(getFindingsBody);
+        assertEquals(1, getFindingsBody.get("total_findings"));
+
+        String findingDetectorId = ((Map<String, Object>)((List)getFindingsBody.get("findings")).get(0)).get("detectorId").toString();
+        assertEquals(detectorId, findingDetectorId);
+
+        String findingIndex = ((Map<String, Object>)((List)getFindingsBody.get("findings")).get(0)).get("index").toString();
+        assertEquals(index, findingIndex);
+
+        List<Map<String, Object>> findings = (List)getFindingsBody.get("findings");
+
+        assertEquals(1, findings.size());
+        List<String> findingDocs = (List<String>) findings.get(0).get("related_doc_ids");
+        Assert.assertEquals(1, findingDocs.size());
+        assertTrue(Arrays.asList("1").containsAll(findingDocs));
+    }
+
+    public void testCreateDetector_workflowWithDuplicateMonitor_failure() throws IOException {
+        updateClusterSetting(ENABLE_WORKFLOW_USAGE.getKey(), "true");
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        Response createMappingResponse = client().performRequest(createMappingRequest);
+
+        assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
+
+        String testOpCode = "Test";
+
+        String maxRuleId =  createRule(randomAggregationRule("max", " > 3", testOpCode));
+        String randomDocRuleId = createRule(randomRule());
+
+        List<DetectorRule> detectorRules = List.of(new DetectorRule(maxRuleId), new DetectorRule(randomDocRuleId));
+
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
+            Collections.emptyList());
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+
+        String request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match_all\":{\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
+
+        assertEquals(1, response.getHits().getTotalHits().value);
+
+        assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+        Map<String, Object> responseBody = asMap(createResponse);
+
+        String detectorId = responseBody.get("_id").toString();
+        request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+        Map<String, Object> detectorMap = (HashMap<String, Object>)(hit.getSourceAsMap().get("detector"));
+        List inputArr = (List) detectorMap.get("inputs");
+
+        assertEquals(2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
+
+        List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
+        assertEquals(2, monitorIds.size());
+
+        assertNotNull("Workflow not created", detectorMap.get("workflow_ids"));
+        assertEquals("Number of workflows not correct", 1, ((List<String>) detectorMap.get("workflow_ids")).size());
+
+        // Verify workflow
+        verifyWorkflow(detectorMap, monitorIds, 2);
+    }
+
+    public void testCreateDetector_verifyWorkflowExecutionBucketLevelDocLevelMonitors_success() throws IOException {
+        updateClusterSetting(ENABLE_WORKFLOW_USAGE.getKey(), "true");
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        Response createMappingResponse = client().performRequest(createMappingRequest);
+
+        assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
+
+        String testOpCode = "Test";
+
+        String maxRuleId =  createRule(randomAggregationRule("max", " > 3", testOpCode));
+        String randomDocRuleId = createRule(randomRule());
+
+        List<DetectorRule> detectorRules = List.of(new DetectorRule(maxRuleId), new DetectorRule(randomDocRuleId));
+
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
+            Collections.emptyList());
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+
+        String request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match_all\":{\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
+
+        assertEquals(1, response.getHits().getTotalHits().value);
+
+        assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+        Map<String, Object> responseBody = asMap(createResponse);
+
+        String detectorId = responseBody.get("_id").toString();
+        request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+        Map<String, Object> detectorMap = (HashMap<String, Object>)(hit.getSourceAsMap().get("detector"));
+        List inputArr = (List) detectorMap.get("inputs");
+
+        assertEquals(2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
+
+        List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
+        assertEquals(2, monitorIds.size());
+
+        assertNotNull("Workflow not created", detectorMap.get("workflow_ids"));
+        assertEquals("Number of workflows not correct", 1, ((List<String>) detectorMap.get("workflow_ids")).size());
+
+        indexDoc(index, "1", randomDoc(5, 3, testOpCode));
+        indexDoc(index, "2", randomDoc(2, 3, testOpCode));
+        indexDoc(index, "3", randomDoc(4, 3, testOpCode));
+        indexDoc(index, "4", randomDoc(6, 2, testOpCode));
+        indexDoc(index, "5", randomDoc(1, 1, testOpCode));
+        // Verify workflow
+        verifyWorkflow(detectorMap, monitorIds, 2);
+
+        String workflowId = ((List<String>) detectorMap.get("workflow_ids")).get(0);
+
+        Response executeResponse = executeAlertingWorkflow(workflowId, Collections.emptyMap());
+
+        List<Map<String, Object>> monitorRunResults = (List<Map<String, Object>>) entityAsMap(executeResponse).get("workflow_run_result");
+
+        for (Map<String, Object> runResult : monitorRunResults) {
+            if (((Map<String, Object>) runResult.get("trigger_results")).get(maxRuleId) != null) {
+                assertRuleMonitorFinding(runResult, maxRuleId, 5, List.of("2", "3"));
+            } else {
+                int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) runResult.get("input_results")).get("results")).get(0).size();
+                // 5 prepackaged and 1 custom doc level rule
+                assertEquals(1, noOfSigmaRuleMatches);
+            }
+        }
+
+        // Verify findings
+        Map<String, String> params = new HashMap<>();
+        params.put("detector_id", detectorId);
+        Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+        Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+
+        assertNotNull(getFindingsBody);
+        assertEquals(6, getFindingsBody.get("total_findings"));
+
+        String findingDetectorId = ((Map<String, Object>)((List)getFindingsBody.get("findings")).get(0)).get("detectorId").toString();
+        assertEquals(detectorId, findingDetectorId);
+
+        String findingIndex = ((Map<String, Object>)((List)getFindingsBody.get("findings")).get(0)).get("index").toString();
+        assertEquals(index, findingIndex);
+
+        List<String> docLevelFinding = new ArrayList<>();
+        List<Map<String, Object>> findings = (List)getFindingsBody.get("findings");
+
+        Set<String> docLevelRules = new HashSet<>(List.of(randomDocRuleId));
+
+        for(Map<String, Object> finding : findings) {
+            List<Map<String, Object>> queries = (List<Map<String, Object>>) finding.get("queries");
+            Set<String> findingRules = queries.stream().map(it -> it.get("id").toString()).collect(Collectors.toSet());
+            // In this test case all doc level rules are matching the finding rule ids
+            if(docLevelRules.containsAll(findingRules)) {
+                docLevelFinding.addAll((List<String>) finding.get("related_doc_ids"));
+            } else {
+                List<String> findingDocs = (List<String>) finding.get("related_doc_ids");
+                Assert.assertEquals(4, findingDocs.size());
+                assertTrue(Arrays.asList("1", "2", "3", "4").containsAll(findingDocs));
+            }
+        }
+        // Verify doc level finding
+        assertTrue(Arrays.asList("1", "2", "3", "4", "5").containsAll(docLevelFinding));
+    }
+
+
+    private static void assertRuleMonitorFinding(Map<String, Object> executeResults, String ruleId, int expectedDocCount, List<String> expectedTriggerResult) {
         List<Map<String, Object>> buckets = ((List<Map<String, Object>>)(((Map<String, Object>)((Map<String, Object>)((Map<String, Object>)((List<Object>)((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0)).get("aggregations")).get("result_agg")).get("buckets")));
         Integer docCount = buckets.stream().mapToInt(it -> (Integer)it.get("doc_count")).sum();
         assertEquals(expectedDocCount, docCount.intValue());
 
         List<String> triggerResultBucketKeys = ((Map<String, Object>)((Map<String, Object>) ((Map<String, Object>)executeResults.get("trigger_results")).get(ruleId)).get("agg_result_buckets")).keySet().stream().collect(Collectors.toList());
-        assertEquals(expectedTriggerResult, triggerResultBucketKeys);
+        Assert.assertEquals(expectedTriggerResult, triggerResultBucketKeys);
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
@@ -1214,7 +1214,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
 
         Response executeResponse = executeAlertingWorkflow(workflowId, Collections.emptyMap());
 
-        List<Map<String, Object>> monitorRunResults = (List<Map<String, Object>>) entityAsMap(executeResponse).get("workflow_run_result");
+        List<Map<String, Object>> monitorRunResults = (List<Map<String, Object>>) entityAsMap(executeResponse).get("monitor_run_results");
         assertEquals(1, monitorRunResults.size());
 
         int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) monitorRunResults.get(0).get("input_results")).get("results")).get(0).size();
@@ -1389,7 +1389,8 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
 
         Response executeResponse = executeAlertingWorkflow(workflowId, Collections.emptyMap());
 
-        List<Map<String, Object>> monitorRunResults = (List<Map<String, Object>>) entityAsMap(executeResponse).get("workflow_run_result");
+        Map<String, Object> executeWorkflowResponseMap = entityAsMap(executeResponse);
+        List<Map<String, Object>> monitorRunResults = (List<Map<String, Object>>) executeWorkflowResponseMap.get("monitor_run_results");
 
         for (Map<String, Object> runResult : monitorRunResults) {
             if (((Map<String, Object>) runResult.get("trigger_results")).get(maxRuleId) != null) {

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import org.opensearch.securityanalytics.model.DetectorTrigger;
 
 import static org.opensearch.securityanalytics.TestHelpers.*;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE;
 
 public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
 
@@ -811,6 +812,7 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
 
 
     public void testDeletingADetector_single_Monitor() throws IOException {
+        updateClusterSetting(ENABLE_WORKFLOW_USAGE.getKey(), "true");
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
         // Execute CreateMappingsAction to add alias mapping for index

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
@@ -809,6 +809,115 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertEquals(0, hits.size());
     }
 
+
+    public void testDeletingADetector_single_Monitor() throws IOException {
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+            "{ \"index_name\":\"" + index + "\"," +
+                "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                "  \"partial\":true" +
+                "}"
+        );
+
+        Response response = client().performRequest(createMappingRequest);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+        // Create detector #1 of type test_windows
+        Detector detector1 = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of())));
+        String detectorId1 = createDetector(detector1);
+
+        String request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId1 + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+
+        Map<String, Object> responseBody = hit.getSourceAsMap();
+        Map<String, Object> detectorResponse1 = (Map<String, Object>) responseBody.get("detector");
+
+        indexDoc(index, "1", randomDoc());
+        String monitorId =  ((List<String>) (detectorResponse1).get("monitor_id")).get(0);
+
+        verifyWorkflow(detectorResponse1, Arrays.asList(monitorId), 1);
+
+        Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+        Map<String, Object> executeResults = entityAsMap(executeResponse);
+
+        int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+        Assert.assertEquals(5, noOfSigmaRuleMatches);
+        // Create detector #2 of type windows
+        Detector detector2 = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of())));
+        String detectorId2 = createDetector(detector2);
+
+        request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId2 + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        hit = hits.get(0);
+
+        responseBody = hit.getSourceAsMap();
+        Map<String, Object> detectorResponse2 = (Map<String, Object>) responseBody.get("detector");
+        monitorId = ((List<String>) (detectorResponse2).get("monitor_id")).get(0);
+
+        verifyWorkflow(detectorResponse2, Arrays.asList(monitorId), 1);
+
+        indexDoc(index, "2", randomDoc());
+
+        executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+        executeResults = entityAsMap(executeResponse);
+        noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+        Assert.assertEquals(5, noOfSigmaRuleMatches);
+
+        Response deleteResponse = makeRequest(client(), "DELETE", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId1, Collections.emptyMap(), null);
+        Assert.assertEquals("Delete detector failed", RestStatus.OK, restStatus(deleteResponse));
+
+        String workflowId1 = ((List<String>) detectorResponse1.get("workflow_ids")).get(0);
+
+        Map<String, Object> workflow1 = searchWorkflow(workflowId1);
+        assertEquals("Workflow " + workflowId1 + " not deleted", Collections.emptyMap(), workflow1);
+
+        deleteResponse = makeRequest(client(), "DELETE", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId2, Collections.emptyMap(), null);
+        Assert.assertEquals("Delete detector failed", RestStatus.OK, restStatus(deleteResponse));
+
+        String workflowId2 = ((List<String>) detectorResponse2.get("workflow_ids")).get(0);
+        Map<String, Object> workflow2 = searchWorkflow(workflowId2);
+        assertEquals("Workflow " + workflowId2 + " not deleted", Collections.emptyMap(), workflow2);
+
+        // We deleted all detectors of type windows, so we expect that queryIndex is deleted
+        Assert.assertFalse(doesIndexExist(String.format(Locale.ROOT, ".opensearch-sap-%s-detectors-queries-000001", "test_windows")));
+
+        request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId1 + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        Assert.assertEquals(0, hits.size());
+
+        request = "{\n" +
+            "   \"query\" : {\n" +
+            "     \"match\":{\n" +
+            "        \"_id\": \"" + detectorId2 + "\"\n" +
+            "     }\n" +
+            "   }\n" +
+            "}";
+        hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        Assert.assertEquals(0, hits.size());
+    }
+
     public void testDeletingADetector_oneDetectorType_multiple_ruleTopicIndex() throws IOException {
         String index1 = "test_index_1";
         createIndex(index1, Settings.EMPTY);


### PR DESCRIPTION
Enables workflow creation - all the monitors related with the given detector will be part of the detector Enables workflow update during detector update
Deletes the workflow during the detector deletion
Adds additional field to a detector

