### PR TITLE
Force google guava to 32.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,12 @@ repositories {
 sourceSets.main.java.srcDirs = ['src/main/generated','src/main/java']
 configurations {
     zipArchive
+
+    all {
+        resolutionStrategy {
+            force "com.google.guava:guava:32.0.1-jre"
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
### Description
Force google guava to 32.0.1 due to spotless still using 31.1
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
