### PR TITLE
adds support for alerts and triggers on group by based sigma rules 

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/model/DetectorTrigger.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/DetectorTrigger.java
@@ -309,6 +309,22 @@ public class DetectorTrigger implements Writeable, ToXContentObject {
         return severity;
     }
 
+    public List<String> getRuleTypes() {
+        return ruleTypes;
+    }
+
+    public List<String> getRuleIds() {
+        return ruleIds;
+    }
+
+    public List<String> getRuleSeverityLevels() {
+        return ruleSeverityLevels;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
     public List<Action> getActions() {
         List<Action> transformedActions = new ArrayList<>();
 

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -100,7 +100,7 @@ public class SecurityAnalyticsSettings {
 
     public static final Setting<Boolean> ENABLE_WORKFLOW_USAGE = Setting.boolSetting(
         "plugins.security_analytics.enable_workflow_usage",
-        false,
+        true,
         Setting.Property.NodeScope, Setting.Property.Dynamic
     );
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -850,7 +850,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
          triggers.add(bucketLevelTrigger1);
          } **/
 
-        Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName() + UUID.randomUUID(), false, detector.getSchedule(), detector.getLastUpdateTime(), null,
+        Monitor monitor = new Monitor(monitorId, Monitor.NO_VERSION, detector.getName(), false, detector.getSchedule(), detector.getLastUpdateTime(), null,
             MonitorType.BUCKET_LEVEL_MONITOR, detector.getUser(), 1, bucketLevelMonitorInputs, triggers, Map.of(),
             new DataSources(detector.getRuleIndex(),
                 detector.getFindingsIndex(),

--- a/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
+++ b/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
@@ -128,6 +128,7 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
         }
     }
 
+
     protected void verifyWorkflow(Map<String, Object> detectorMap, List<String> monitorIds, int expectedDelegatesNum) throws IOException{
         String workflowId = ((List<String>) detectorMap.get("workflow_ids")).get(0);
 

--- a/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
+++ b/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
@@ -128,7 +128,6 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
         }
     }
 
-
     protected void verifyWorkflow(Map<String, Object> detectorMap, List<String> monitorIds, int expectedDelegatesNum) throws IOException{
         String workflowId = ((List<String>) detectorMap.get("workflow_ids")).get(0);
 

--- a/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
+++ b/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
@@ -127,7 +127,6 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
             assertEquals(RestStatus.OK, restStatus(response));
         }
     }
-
     protected void verifyWorkflow(Map<String, Object> detectorMap, List<String> monitorIds, int expectedDelegatesNum) throws IOException{
         String workflowId = ((List<String>) detectorMap.get("workflow_ids")).get(0);
 
@@ -429,6 +428,11 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
 
     protected boolean alertingMonitorExists(String monitorId) throws IOException {
         return alertingMonitorExists(client(), monitorId);
+    }
+
+    protected Response getAlertingMonitor(RestClient client, String monitorId) throws IOException {
+        Response response = makeRequest(client, "GET", String.format(Locale.getDefault(), "/_plugins/_alerting/monitors/%s", monitorId), Collections.emptyMap(), null);
+        return response;
     }
 
     protected boolean alertingMonitorExists(RestClient client, String monitorId) throws IOException {

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -65,6 +65,10 @@ public class TestHelpers {
     public static Detector randomDetectorWithInputs(List<DetectorInput> inputs) {
         return randomDetector(null, null, null, inputs, List.of(), null, null, null, null);
     }
+
+    public static Detector randomDetectorWithInputsAndTriggers(List<DetectorInput> inputs, List<DetectorTrigger> triggers) {
+        return randomDetector(null, null, null, inputs, triggers, null, null, null, null);
+    }
     public static Detector randomDetectorWithInputs(List<DetectorInput> inputs, String detectorType) {
         return randomDetector(null, detectorType, null, inputs, List.of(), null, null, null, null);
     }
@@ -83,9 +87,6 @@ public class TestHelpers {
         DetectorInput input = new DetectorInput("windows detector for security analytics", inputIndices, Collections.emptyList(),
                 rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
         return randomDetector(null, null, null, List.of(input), triggers, null, null, null, null);
-    }
-    public static Detector randomDetectorWithInputsAndTriggers(List<DetectorInput> inputs, List<DetectorTrigger> triggers) {
-        return randomDetector(null, null, null, inputs, triggers, null, null, null, null);
     }
 
     public static Detector randomDetectorWithTriggers(List<String> rules, List<DetectorTrigger> triggers, String detectorType, DetectorInput input) {

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
@@ -750,7 +750,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         List<String> aggRuleIds = new ArrayList<>();
         String testOpCode = "Test";
         aggRuleIds.add(createRule(randomAggregationRule("min", " > 3", testOpCode)));
-        List<DetectorRule> detectorRules = aggRuleIds.stream().map(DetectorRule::new).collect(Collectors.toList());
+        List<DetectorRule> detectorRules = aggRuleIds.stream().map(id -> new DetectorRule(id)).collect(Collectors.toList());
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
             Collections.emptyList());
         Detector detector = randomDetectorWithInputs(List.of(input));
@@ -901,7 +901,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
 
         Map<String, Integer> numberOfMonitorTypes = new HashMap<>();
 
-        for (String monitorId: monitorIds) {
+         for (String monitorId: monitorIds) {
             Map<String, String> monitor  = (Map<String, String>)(entityAsMap(client().performRequest(new Request("GET", "/_plugins/_alerting/monitors/" + monitorId)))).get("monitor");
             numberOfMonitorTypes.merge(monitor.get("monitor_type"), 1, Integer::sum);
             Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
@@ -1015,7 +1015,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             "}";
         SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
 
-         assertEquals(1, response.getHits().getTotalHits().value);
+         assertEquals(2, response.getHits().getTotalHits().value);
 
         assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
         Map<String, Object> responseBody = asMap(createResponse);
@@ -1036,13 +1036,13 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
 
         List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
-        assertEquals(2, monitorIds.size());
+        assertEquals(3, monitorIds.size());
 
         assertNotNull("Workflow not created", detectorMap.get("workflow_ids"));
         assertEquals("Number of workflows not correct", 1, ((List<String>) detectorMap.get("workflow_ids")).size());
 
         // Verify workflow
-        verifyWorkflow(detectorMap, monitorIds, 2);
+        verifyWorkflow(detectorMap, monitorIds, 3);
     }
 
     public void testUpdateDetector_disabledWorkflowUsage_verifyWorkflowNotCreated_success() throws IOException {
@@ -1158,7 +1158,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             "}";
         SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
 
-        assertEquals(1, response.getHits().getTotalHits().value);
+        assertEquals(2, response.getHits().getTotalHits().value);
 
         assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
         Map<String, Object> responseBody = asMap(createResponse);
@@ -1179,13 +1179,13 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
 
         List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
-        assertEquals(2, monitorIds.size());
+        assertEquals(3, monitorIds.size());
 
         assertNotNull("Workflow not created", detectorMap.get("workflow_ids"));
         assertEquals("Number of workflows not correct", 1, ((List<String>) detectorMap.get("workflow_ids")).size());
 
         // Verify workflow
-        verifyWorkflow(detectorMap, monitorIds, 2);
+        verifyWorkflow(detectorMap, monitorIds, 3);
 
         // Update detector - remove one agg rule; Verify workflow
         DetectorInput newInput = new DetectorInput("windows detector for security analytics", List.of("windows"), Arrays.asList(new DetectorRule(randomDocRuleId)) , getRandomPrePackagedRules().stream().map(DetectorRule::new).collect(Collectors.toList()));
@@ -1282,7 +1282,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             "}";
         SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
 
-        assertEquals(1, response.getHits().getTotalHits().value);
+        assertEquals(2, response.getHits().getTotalHits().value);
 
         assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
         Map<String, Object> responseBody = asMap(createResponse);
@@ -1303,13 +1303,13 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
 
         List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
-        assertEquals(2, monitorIds.size());
+        assertEquals(3, monitorIds.size());
 
         assertNotNull("Workflow not created", detectorMap.get("workflow_ids"));
         assertEquals("Number of workflows not correct", 1, ((List<String>) detectorMap.get("workflow_ids")).size());
 
         // Verify workflow
-        verifyWorkflow(detectorMap, monitorIds, 2);
+        verifyWorkflow(detectorMap, monitorIds, 3);
     }
 
     public void testCreateDetector_verifyWorkflowExecutionBucketLevelDocLevelMonitors_success() throws IOException {
@@ -1351,7 +1351,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             "}";
         SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
 
-        assertEquals(1, response.getHits().getTotalHits().value);
+        assertEquals(2, response.getHits().getTotalHits().value);
 
         assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
         Map<String, Object> responseBody = asMap(createResponse);
@@ -1372,7 +1372,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
 
         List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
-        assertEquals(2, monitorIds.size());
+        assertEquals(3, monitorIds.size());
 
         assertNotNull("Workflow not created", detectorMap.get("workflow_ids"));
         assertEquals("Number of workflows not correct", 1, ((List<String>) detectorMap.get("workflow_ids")).size());
@@ -1383,7 +1383,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         indexDoc(index, "4", randomDoc(6, 2, testOpCode));
         indexDoc(index, "5", randomDoc(1, 1, testOpCode));
         // Verify workflow
-        verifyWorkflow(detectorMap, monitorIds, 2);
+        verifyWorkflow(detectorMap, monitorIds, 3);
 
         String workflowId = ((List<String>) detectorMap.get("workflow_ids")).get(0);
 
@@ -1409,7 +1409,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
 
         assertNotNull(getFindingsBody);
-        assertEquals(6, getFindingsBody.get("total_findings"));
+        assertEquals(10, getFindingsBody.get("total_findings"));
 
         String findingDetectorId = ((Map<String, Object>)((List)getFindingsBody.get("findings")).get(0)).get("detectorId").toString();
         assertEquals(detectorId, findingDetectorId);
@@ -1421,7 +1421,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         List<Map<String, Object>> findings = (List)getFindingsBody.get("findings");
 
         Set<String> docLevelRules = new HashSet<>(List.of(randomDocRuleId));
-
+        List<String> bucketLevelMonitorFindingDocs = new ArrayList<>();
         for(Map<String, Object> finding : findings) {
             List<Map<String, Object>> queries = (List<Map<String, Object>>) finding.get("queries");
             Set<String> findingRules = queries.stream().map(it -> it.get("id").toString()).collect(Collectors.toSet());
@@ -1430,10 +1430,16 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                 docLevelFinding.addAll((List<String>) finding.get("related_doc_ids"));
             } else {
                 List<String> findingDocs = (List<String>) finding.get("related_doc_ids");
-                Assert.assertEquals(4, findingDocs.size());
-                assertTrue(Arrays.asList("1", "2", "3", "4").containsAll(findingDocs));
+                if (((Map<String, Object>) ((List<Object>) finding.get("queries")).get(0)).get("query").equals("_id:*")) {
+                    Assert.assertEquals(1, findingDocs.size());
+                    bucketLevelMonitorFindingDocs.addAll(findingDocs);
+                } else {
+                    Assert.assertEquals(4, findingDocs.size());
+                    assertTrue(Arrays.asList("1", "2", "3", "4").containsAll(findingDocs));
+                }
             }
         }
+        assertTrue(bucketLevelMonitorFindingDocs.containsAll(Arrays.asList("1", "2", "3", "4")));
         // Verify doc level finding
         assertTrue(Arrays.asList("1", "2", "3", "4", "5").containsAll(docLevelFinding));
     }

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
@@ -67,6 +67,7 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testDeletingADetector_MonitorNotExists() throws IOException {
+        updateClusterSetting(ENABLE_WORKFLOW_USAGE.getKey(), "false");
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
         // Execute CreateMappingsAction to add alias mapping for index


### PR DESCRIPTION
### Description
- For each group by rule a bucket level monitor is created.
- Bucket level monitor doesn't support the current detector triggers which cater focussedly to per document alerting 
- This change uses workflow's chained monitor findings feature to feed findings generated by all bucket level monitors as source data to a match all doc level monitor. The chained findings monitor simply creates findings for all docs which match the bucket level monitor rule and honors the detector trigger condition creating alerts if there are any group by rules mentioned in the trigger.

Behaviour of non-group by rule matching is unaffected.
