### PR TITLE
Address search request timeouts as transient error

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
@@ -228,7 +228,7 @@ public class JoinEngine {
             @Override
             public void onResponse(SearchResponse response) {
                 if (response.isTimedOut()) {
-                    correlateFindingAction.onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                    correlateFindingAction.onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                 }
 
                 Iterator<SearchHit> hits = response.getHits().iterator();

--- a/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
@@ -81,7 +81,7 @@ public class VectorEmbeddingsEngine {
             @Override
             public void onResponse(SearchResponse response) {
                 if (response.isTimedOut()) {
-                    correlateFindingAction.onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                    correlateFindingAction.onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                 }
 
                 Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
@@ -249,7 +249,7 @@ public class VectorEmbeddingsEngine {
             @Override
             public void onResponse(SearchResponse response) {
                 if (response.isTimedOut()) {
-                    correlateFindingAction.onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                    correlateFindingAction.onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                 }
 
                 try {
@@ -425,7 +425,7 @@ public class VectorEmbeddingsEngine {
                                 @Override
                                 public void onResponse(SearchResponse response) {
                                     if (response.isTimedOut()) {
-                                        correlateFindingAction.onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                                        correlateFindingAction.onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                                     }
 
                                     long totalHits = response.getHits().getTotalHits().value;

--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -276,7 +276,7 @@ public class LogTypeService {
             @Override
             public void onResponse(SearchResponse response) {
                 if (response.isTimedOut()) {
-                    listener.onFailure(new OpenSearchStatusException("Unknown error", RestStatus.INTERNAL_SERVER_ERROR));
+                    listener.onFailure(new OpenSearchStatusException("Unknown error", RestStatus.REQUEST_TIMEOUT));
                 }
                 if (response.getHits().getTotalHits().value > 0) {
                     listener.onResponse(null);

--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -276,7 +276,7 @@ public class LogTypeService {
             @Override
             public void onResponse(SearchResponse response) {
                 if (response.isTimedOut()) {
-                    listener.onFailure(new OpenSearchStatusException("Unknown error", RestStatus.REQUEST_TIMEOUT));
+                    listener.onFailure(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                 }
                 if (response.getHits().getTotalHits().value > 0) {
                     listener.onResponse(null);

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestSearchRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestSearchRuleAction.java
@@ -81,7 +81,7 @@ public class RestSearchRuleAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(SearchResponse response) throws Exception {
                 if (response.isTimedOut()) {
-                    return new BytesRestResponse(RestStatus.REQUEST_TIMEOUT, response.toString());
+                    return new BytesRestResponse(RestStatus.REQUEST_TIMEOUT, "Search request timed out");
                 }
 
                 try {

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -223,7 +223,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                     @Override
                     public void onResponse(SearchResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                            onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                         }
 
                         SearchHits hits = response.getHits();
@@ -336,7 +336,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                                         @Override
                                         public void onResponse(SearchResponse response) {
                                             if (response.isTimedOut()) {
-                                                onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                                                onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                                             }
 
                                             SearchHit[] hits = response.getHits().getHits();
@@ -392,7 +392,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                             @Override
                             public void onResponse(SearchResponse response) {
                                 if (response.isTimedOut()) {
-                                    onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                                    onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                                 }
 
                                 SearchHit[] hits = response.getHits().getHits();

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -336,7 +336,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                                         @Override
                                         public void onResponse(SearchResponse response) {
                                             if (response.isTimedOut()) {
-                                                onFailures(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
+                                                onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
                                             }
 
                                             SearchHit[] hits = response.getHits().getHits();
@@ -392,7 +392,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                             @Override
                             public void onResponse(SearchResponse response) {
                                 if (response.isTimedOut()) {
-                                    onFailures(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
+                                    onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
                                 }
 
                                 SearchHit[] hits = response.getHits().getHits();

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCorrelationRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCorrelationRuleAction.java
@@ -65,7 +65,7 @@ public class TransportDeleteCorrelationRuleAction extends HandledTransportAction
                                     new OpenSearchStatusException(
                                         String.format(
                                                 Locale.getDefault(),
-                                                "Search request timed out. Correlation Rule with id %s cannot be deleted",
+                                                "Request timed out. Correlation Rule with id %s cannot be deleted",
                                                 correlationRuleId
                                         ),
                                         RestStatus.REQUEST_TIMEOUT)

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCorrelationRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCorrelationRuleAction.java
@@ -65,7 +65,7 @@ public class TransportDeleteCorrelationRuleAction extends HandledTransportAction
                                     new OpenSearchStatusException(
                                         String.format(
                                                 Locale.getDefault(),
-                                                "Correlation Rule with id %s cannot be deleted",
+                                                "Search request timed out. Correlation Rule with id %s cannot be deleted",
                                                 correlationRuleId
                                         ),
                                         RestStatus.REQUEST_TIMEOUT)

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCorrelationRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCorrelationRuleAction.java
@@ -68,7 +68,7 @@ public class TransportDeleteCorrelationRuleAction extends HandledTransportAction
                                                 "Correlation Rule with id %s cannot be deleted",
                                                 correlationRuleId
                                         ),
-                                        RestStatus.INTERNAL_SERVER_ERROR)
+                                        RestStatus.REQUEST_TIMEOUT)
                             );
                             return;
                         }

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCustomLogTypeAction.java
@@ -174,7 +174,7 @@ public class TransportDeleteCustomLogTypeAction extends HandledTransportAction<D
                     @Override
                     public void onResponse(SearchResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be deleted", logType.getId()), RestStatus.REQUEST_TIMEOUT));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Search request timed out. Log Type with id %s cannot be deleted", logType.getId()), RestStatus.REQUEST_TIMEOUT));
                             return;
                         }
 
@@ -187,7 +187,7 @@ public class TransportDeleteCustomLogTypeAction extends HandledTransportAction<D
                             @Override
                             public void onResponse(SearchResponse response) {
                                 if (response.isTimedOut()) {
-                                    onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be deleted", logType.getId()), RestStatus.REQUEST_TIMEOUT));
+                                    onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Search request timed out. Log Type with id %s cannot be deleted", logType.getId()), RestStatus.REQUEST_TIMEOUT));
                                     return;
                                 }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCustomLogTypeAction.java
@@ -174,7 +174,7 @@ public class TransportDeleteCustomLogTypeAction extends HandledTransportAction<D
                     @Override
                     public void onResponse(SearchResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be deleted", logType.getId()), RestStatus.INTERNAL_SERVER_ERROR));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be deleted", logType.getId()), RestStatus.REQUEST_TIMEOUT));
                             return;
                         }
 
@@ -187,7 +187,7 @@ public class TransportDeleteCustomLogTypeAction extends HandledTransportAction<D
                             @Override
                             public void onResponse(SearchResponse response) {
                                 if (response.isTimedOut()) {
-                                    onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be deleted", logType.getId()), RestStatus.INTERNAL_SERVER_ERROR));
+                                    onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be deleted", logType.getId()), RestStatus.REQUEST_TIMEOUT));
                                     return;
                                 }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteRuleAction.java
@@ -231,7 +231,7 @@ public class TransportDeleteRuleAction extends HandledTransportAction<DeleteRule
                     @Override
                     public void onResponse(BulkByScrollResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Search request timed out. Rule with id %s cannot be deleted", ruleId), RestStatus.REQUEST_TIMEOUT));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Request timed out. Rule with id %s cannot be deleted", ruleId), RestStatus.REQUEST_TIMEOUT));
                             return;
                         }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteRuleAction.java
@@ -152,7 +152,7 @@ public class TransportDeleteRuleAction extends HandledTransportAction<DeleteRule
                     @Override
                     public void onResponse(SearchResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Rule with id %s cannot be deleted", rule.getId()), RestStatus.INTERNAL_SERVER_ERROR));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Rule with id %s cannot be deleted", rule.getId()), RestStatus.REQUEST_TIMEOUT));
                             return;
                         }
 
@@ -231,7 +231,7 @@ public class TransportDeleteRuleAction extends HandledTransportAction<DeleteRule
                     @Override
                     public void onResponse(BulkByScrollResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Rule with id %s cannot be deleted", ruleId), RestStatus.INTERNAL_SERVER_ERROR));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Rule with id %s cannot be deleted", ruleId), RestStatus.REQUEST_TIMEOUT));
                             return;
                         }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteRuleAction.java
@@ -152,7 +152,7 @@ public class TransportDeleteRuleAction extends HandledTransportAction<DeleteRule
                     @Override
                     public void onResponse(SearchResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Rule with id %s cannot be deleted", rule.getId()), RestStatus.REQUEST_TIMEOUT));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Search request timed out. Rule with id %s cannot be deleted", rule.getId()), RestStatus.REQUEST_TIMEOUT));
                             return;
                         }
 
@@ -231,7 +231,7 @@ public class TransportDeleteRuleAction extends HandledTransportAction<DeleteRule
                     @Override
                     public void onResponse(BulkByScrollResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Rule with id %s cannot be deleted", ruleId), RestStatus.REQUEST_TIMEOUT));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Search request timed out. Rule with id %s cannot be deleted", ruleId), RestStatus.REQUEST_TIMEOUT));
                             return;
                         }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexCustomLogTypeAction.java
@@ -218,12 +218,12 @@ public class TransportIndexCustomLogTypeAction extends HandledTransportAction<In
                     @Override
                     public void onResponse(SearchResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.INTERNAL_SERVER_ERROR));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
                             return;
                         }
 
                         if (response.getHits().getTotalHits().value != 1) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.INTERNAL_SERVER_ERROR));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
                             return;
                         }
 
@@ -243,7 +243,7 @@ public class TransportIndexCustomLogTypeAction extends HandledTransportAction<In
                                         @Override
                                         public void onResponse(SearchResponse response) {
                                             if (response.isTimedOut()) {
-                                                onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.INTERNAL_SERVER_ERROR));
+                                                onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
                                                 return;
                                             }
 
@@ -256,7 +256,7 @@ public class TransportIndexCustomLogTypeAction extends HandledTransportAction<In
                                                 @Override
                                                 public void onResponse(SearchResponse response) {
                                                     if (response.isTimedOut()) {
-                                                        onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.INTERNAL_SERVER_ERROR));
+                                                        onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
                                                         return;
                                                     }
 
@@ -379,7 +379,7 @@ public class TransportIndexCustomLogTypeAction extends HandledTransportAction<In
                             @Override
                             public void onResponse(SearchResponse response) {
                                 if (response.isTimedOut()) {
-                                    onFailures(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
+                                    onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
                                     return;
                                 }
 
@@ -399,7 +399,7 @@ public class TransportIndexCustomLogTypeAction extends HandledTransportAction<In
                                     @Override
                                     public void onResponse(SearchResponse response) {
                                         if (response.isTimedOut()) {
-                                            onFailures(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
+                                            onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
                                             return;
                                         }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexCustomLogTypeAction.java
@@ -218,12 +218,12 @@ public class TransportIndexCustomLogTypeAction extends HandledTransportAction<In
                     @Override
                     public void onResponse(SearchResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Search request timed out. Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
                             return;
                         }
 
                         if (response.getHits().getTotalHits().value != 1) {
-                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
+                            onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.INTERNAL_SERVER_ERROR));
                             return;
                         }
 
@@ -243,7 +243,7 @@ public class TransportIndexCustomLogTypeAction extends HandledTransportAction<In
                                         @Override
                                         public void onResponse(SearchResponse response) {
                                             if (response.isTimedOut()) {
-                                                onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
+                                                onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Search request timed out. Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
                                                 return;
                                             }
 
@@ -256,7 +256,7 @@ public class TransportIndexCustomLogTypeAction extends HandledTransportAction<In
                                                 @Override
                                                 public void onResponse(SearchResponse response) {
                                                     if (response.isTimedOut()) {
-                                                        onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
+                                                        onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Search request timed out. Log Type with id %s cannot be updated", logTypeId), RestStatus.REQUEST_TIMEOUT));
                                                         return;
                                                     }
 
@@ -379,7 +379,7 @@ public class TransportIndexCustomLogTypeAction extends HandledTransportAction<In
                             @Override
                             public void onResponse(SearchResponse response) {
                                 if (response.isTimedOut()) {
-                                    onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                                    onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                                     return;
                                 }
 
@@ -399,7 +399,7 @@ public class TransportIndexCustomLogTypeAction extends HandledTransportAction<In
                                     @Override
                                     public void onResponse(SearchResponse response) {
                                         if (response.isTimedOut()) {
-                                            onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                                            onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                                             return;
                                         }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -1237,7 +1237,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                     @Override
                     public void onResponse(SearchResponse response) {
                         if (response.isTimedOut()) {
-                            onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                            onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                         }
 
                         long count = response.getHits().getTotalHits().value;
@@ -1302,7 +1302,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                 @Override
                 public void onResponse(SearchResponse response) {
                     if (response.isTimedOut()) {
-                        onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                        onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                     }
 
                     SearchHits hits = response.getHits();
@@ -1362,7 +1362,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                 @Override
                 public void onResponse(SearchResponse response) {
                     if (response.isTimedOut()) {
-                        onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                        onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                     }
 
                     SearchHits hits = response.getHits();

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
@@ -237,7 +237,7 @@ public class TransportIndexRuleAction extends HandledTransportAction<IndexRuleRe
                         @Override
                         public void onResponse(SearchResponse response) {
                             if (response.isTimedOut()) {
-                                onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Rule with id %s cannot be updated", rule.getId()), RestStatus.INTERNAL_SERVER_ERROR));
+                                onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Rule with id %s cannot be updated", rule.getId()), RestStatus.REQUEST_TIMEOUT));
                                 return;
                             }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
@@ -237,7 +237,7 @@ public class TransportIndexRuleAction extends HandledTransportAction<IndexRuleRe
                         @Override
                         public void onResponse(SearchResponse response) {
                             if (response.isTimedOut()) {
-                                onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Rule with id %s cannot be updated", rule.getId()), RestStatus.REQUEST_TIMEOUT));
+                                onFailures(new OpenSearchStatusException(String.format(Locale.getDefault(), "Search request timed out. Rule with id %s cannot be updated", rule.getId()), RestStatus.REQUEST_TIMEOUT));
                                 return;
                             }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportListCorrelationAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportListCorrelationAction.java
@@ -119,7 +119,7 @@ public class TransportListCorrelationAction extends HandledTransportAction<ListC
                 @Override
                 public void onResponse(SearchResponse response) {
                     if (response.isTimedOut()) {
-                        onFailures(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                        onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                     }
 
                     Map<String, CorrelatedFinding> correlatedFindings = new HashMap<>();

--- a/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
@@ -328,7 +328,7 @@ public class RuleIndices {
                     @Override
                     public void onResponse(SearchResponse response) {
                         if (response.isTimedOut()) {
-                            listener.onFailure(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
+                            listener.onFailure(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
                         }
                         try {
                             SearchHit[] hits = response.getHits().getHits();

--- a/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
@@ -328,7 +328,7 @@ public class RuleIndices {
                     @Override
                     public void onResponse(SearchResponse response) {
                         if (response.isTimedOut()) {
-                            listener.onFailure(new OpenSearchStatusException(response.toString(), RestStatus.REQUEST_TIMEOUT));
+                            listener.onFailure(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                         }
                         try {
                             SearchHit[] hits = response.getHits().getHits();


### PR DESCRIPTION
### Description
Change rest status on search request timeouts to be a transient error: `REQUEST_TIMEOUT`

### Issues Resolved
[#502](https://github.com/opensearch-project/security-analytics/issues/502)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
