### PR TITLE
Fixes verifying workflow test when security is enabled

### DIFF
--- a/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
+++ b/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
@@ -157,13 +157,14 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
             "      }\n" +
             "   }\n" +
             "}";
-        List<SearchHit> hits = executeSearch(ScheduledJob.SCHEDULED_JOBS_INDEX, workflowRequest);
+        List<SearchHit> hits = executeWorkflowSearch("/_plugins/_alerting/monitors", workflowRequest);
+
         if (hits.size() == 0) {
             return new HashMap<>();
         }
 
         SearchHit hit = hits.get(0);
-        return (Map<String, Object>) hit.getSourceAsMap().get("workflow");
+        return (Map<String, Object>) hit.getSourceAsMap();
     }
 
 
@@ -412,6 +413,16 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
         Assert.assertEquals("Search failed", RestStatus.OK, restStatus(response));
 
         SearchResponse searchResponse = SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, response.getEntity().getContent()));
+        return Arrays.asList(searchResponse.getHits().getHits());
+    }
+
+    protected List<SearchHit> executeWorkflowSearch(String url, String request) throws IOException {
+
+        Response response = makeRequest(client(), "POST", String.format(Locale.getDefault(), "%s/_search", url), Collections.emptyMap(), new StringEntity(request), new BasicHeader("Content-Type", "application/json"));
+        Assert.assertEquals("Workflow search failed", RestStatus.OK, restStatus(response));
+
+        SearchResponse searchResponse = SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, response.getEntity().getContent()));
+
         return Arrays.asList(searchResponse.getHits().getHits());
     }
 


### PR DESCRIPTION
### Description
Fixes 2.10.0 integ tests failures by retrieving the workflow search through a post API call.
 
### Issues Resolved
[#525](https://github.com/opensearch-project/security-analytics/issues/525)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
