### PR TITLE
auto expand replicas for logtype index

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -439,10 +439,16 @@ public class LogTypeService {
 
         if (state.routingTable().hasIndex(LOG_TYPE_INDEX) == false) {
             isConfigIndexInitialized = false;
+            Settings indexSettings = Settings.builder()
+                    .put("index.hidden", true)
+                    .put("index.auto_expand_replicas", "0-all")
+                    .build();
+
             CreateIndexRequest createIndexRequest = new CreateIndexRequest();
             createIndexRequest.settings(logTypeIndexSettings());
             createIndexRequest.index(LOG_TYPE_INDEX);
             createIndexRequest.mapping(logTypeIndexMapping());
+            createIndexRequest.settings(indexSettings);
             createIndexRequest.cause("auto(sap-logtype api)");
             client.admin().indices().create(createIndexRequest, new ActionListener<>() {
                 @Override

--- a/src/main/java/org/opensearch/securityanalytics/util/CustomLogTypeIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/CustomLogTypeIndices.java
@@ -42,9 +42,13 @@ public class CustomLogTypeIndices {
 
     public void initCustomLogTypeIndex(ActionListener<CreateIndexResponse> actionListener) throws IOException {
         if (!customLogTypeIndexExists()) {
+            Settings indexSettings = Settings.builder()
+                    .put("index.hidden", true)
+                    .put("index.auto_expand_replicas", "0-all")
+                    .build();
             CreateIndexRequest indexRequest = new CreateIndexRequest(LogTypeService.LOG_TYPE_INDEX)
                     .mapping(customLogTypeMappings())
-                    .settings(Settings.builder().put("index.hidden", true).build());
+                    .settings(indexSettings);
             client.indices().create(indexRequest, actionListener);
         }
     }


### PR DESCRIPTION
### Description
auto expand replicas for logtype index
 
### Issues Resolved
makes single-node OS cluster green
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
