### PR TITLE
fix detector writeTo() method missing fields

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/model/Detector.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Detector.java
@@ -208,7 +208,11 @@ public class Detector implements Writeable, ToXContentObject {
         }
         out.writeStringCollection(monitorIds);
         out.writeString(ruleIndex);
-
+        out.writeString(alertsIndex);
+        out.writeString(alertsHistoryIndex);
+        out.writeString(alertsHistoryIndexPattern);
+        out.writeString(findingsIndex);
+        out.writeString(findingsIndexPattern);
         out.writeMap(ruleIdMonitorIdMap, StreamOutput::writeString, StreamOutput::writeString);
 
         if (workflowIds != null) {

--- a/src/main/java/org/opensearch/securityanalytics/model/Detector.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Detector.java
@@ -167,12 +167,12 @@ public class Detector implements Writeable, ToXContentObject {
                 sin.readList(DetectorInput::readFrom),
                 sin.readList(DetectorTrigger::readFrom),
                 sin.readStringList(),
-                sin.readString(),
-                sin.readString(),
-                sin.readString(),
-                sin.readString(),
-                sin.readString(),
-                sin.readString(),
+                sin.readOptionalString(),
+                sin.readOptionalString(),
+                sin.readOptionalString(),
+                sin.readOptionalString(),
+                sin.readOptionalString(),
+                sin.readOptionalString(),
                 sin.readMap(StreamInput::readString, StreamInput::readString),
                 sin.readStringList(),
                 sin.readBoolean()
@@ -207,12 +207,12 @@ public class Detector implements Writeable, ToXContentObject {
             it.writeTo(out);
         }
         out.writeStringCollection(monitorIds);
-        out.writeString(ruleIndex);
-        out.writeString(alertsIndex);
-        out.writeString(alertsHistoryIndex);
-        out.writeString(alertsHistoryIndexPattern);
-        out.writeString(findingsIndex);
-        out.writeString(findingsIndexPattern);
+        out.writeOptionalString(ruleIndex);
+        out.writeOptionalString(alertsIndex);
+        out.writeOptionalString(alertsHistoryIndex);
+        out.writeOptionalString(alertsHistoryIndexPattern);
+        out.writeOptionalString(findingsIndex);
+        out.writeOptionalString(findingsIndexPattern);
         out.writeMap(ruleIdMonitorIdMap, StreamOutput::writeString, StreamOutput::writeString);
 
         if (workflowIds != null) {

--- a/src/test/java/org/opensearch/securityanalytics/model/WriteableTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/WriteableTests.java
@@ -13,15 +13,42 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.util.List;
 
+import static org.opensearch.securityanalytics.TestHelpers.parser;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetector;
 import static org.opensearch.securityanalytics.TestHelpers.randomUser;
 import static org.opensearch.securityanalytics.TestHelpers.randomUserEmpty;
+import static org.opensearch.securityanalytics.TestHelpers.toJsonStringWithUser;
 
 public class WriteableTests extends OpenSearchTestCase {
 
     public void testDetectorAsAStream() throws IOException {
         Detector detector = randomDetector(List.of());
         detector.setInputs(List.of(new DetectorInput("", List.of(), List.of(), List.of())));
+        logger.error(toJsonStringWithUser(detector));
+        BytesStreamOutput out = new BytesStreamOutput();
+        detector.writeTo(out);
+        StreamInput sin = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        Detector newDetector = new Detector(sin);
+        Assert.assertEquals("Round tripping Detector doesn't work", detector, newDetector);
+    }
+
+    public void testDetector() throws IOException { // an edge case of detector serialization that failed testDetectorAsAStream() intermittently
+        String detectorString = "{\"type\":\"detector\",\"name\":\"MczAuRCrve\",\"detector_type\":\"test_windows\"," +
+                "\"user\":{\"name\":\"QhKrfthgxw\",\"backend_roles\":[\"uYvGLCPhfX\",\"fOLkcRxMWR\"],\"roles\"" +
+                ":[\"YuucNpVzTm\",\"all_access\"],\"custom_attribute_names\":[\"test_attr=test\"]," +
+                "\"user_requested_tenant\":null},\"threat_intel_enabled\":false,\"enabled\":false,\"enabled_time\"" +
+                ":null,\"schedule\":{\"period\":{\"interval\":5,\"unit\":\"MINUTES\"}},\"inputs\":[{\"detector_input\"" +
+                ":{\"description\":\"\",\"indices\":[],\"custom_rules\":[],\"pre_packaged_rules\":[]}}],\"triggers\"" +
+                ":[{\"id\":\"SiWfaosBBiNA8if0E1bC\",\"name\":\"windows-trigger\",\"severity\":\"1\",\"types\"" +
+                ":[\"test_windows\"],\"ids\":[\"QuarksPwDump Clearing Access History\"],\"sev_levels\":[\"high\"]," +
+                "\"tags\":[\"T0008\"],\"actions\":[],\"detection_types\":[\"rules\"]}],\"last_update_time\":" +
+                "1698300892093,\"monitor_id\":[\"\"],\"workflow_ids\":[],\"bucket_monitor_id_rule_id\"" +
+                ":{},\"rule_topic_index\":\"\",\"alert_index\":\"\",\"alert_history_index\":\"\"," +
+                "\"alert_history_index_pattern\":\"\",\"findings_index\":\"\",\"findings_index_pattern\":\"\"}";
+        Detector detector = Detector.parse(parser(detectorString), null, null);
+//        Detector detector = randomDetector(List.of());
+//        detector.setInputs(List.of(new DetectorInput("", List.of(), List.of(), List.of())));
+//        logger.error(toJsonStringWithUser(detector));
         BytesStreamOutput out = new BytesStreamOutput();
         detector.writeTo(out);
         StreamInput sin = StreamInput.wrap(out.bytes().toBytesRef().bytes);


### PR DESCRIPTION
### Description
fix detector writeTo() method missing fields. 

Fixes flaky test `org.opensearch.securityanalytics.model.WriteableTests.testDetectorAsAStream()`

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
