### PR TITLE
#683 Sigma keywords field not handled correctly

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
@@ -132,10 +132,10 @@ public class OSQueryBackend extends QueryBackend {
         this.reExpression = "%s: /%s/";
         this.cidrExpression = "%s: \"%s\"";
         this.fieldNullExpression = "%s: null";
-        this.unboundValueStrExpression = "%s: \"%s\"";
-        this.unboundValueNumExpression = "%s: %s";
-        this.unboundWildcardExpression = "%s: %s";
-        this.unboundReExpression = "%s: /%s/";
+        this.unboundValueStrExpression = "\"%s\"";
+        this.unboundValueNumExpression = "\"%s\"";
+        this.unboundWildcardExpression = "\"%s\"";
+        this.unboundReExpression = "\"/%s/\""; // TODO
         this.compareOpExpression = "\"%s\" \"%s\" %s";
         this.valExpCount = 0;
         this.aggQuery = "{\"%s\":{\"terms\":{\"field\":\"%s\"},\"aggs\":{\"%s\":{\"%s\":{\"field\":\"%s\"}}}}}";
@@ -333,27 +333,27 @@ public class OSQueryBackend extends QueryBackend {
     public Object convertConditionValStr(ConditionValueExpression condition) throws SigmaValueError {
         SigmaString value = (SigmaString) condition.getValue();
 
-        String field = getFinalValueField();
-        ruleQueryFields.put(field, Map.of("type", "text", "analyzer", "rule_analyzer"));
+//        String field = getFinalValueField();
+//        ruleQueryFields.put(field, Map.of("type", "text", "analyzer", "rule_analyzer"));
         boolean containsWildcard = value.containsWildcard();
-        return String.format(Locale.getDefault(), (containsWildcard? this.unboundWildcardExpression: this.unboundValueStrExpression), field, this.convertValueStr((SigmaString) condition.getValue()));
+        return String.format(Locale.getDefault(), (containsWildcard? this.unboundWildcardExpression: this.unboundValueStrExpression), this.convertValueStr((SigmaString) condition.getValue()));
     }
 
     @Override
     public Object convertConditionValNum(ConditionValueExpression condition) {
-        String field = getFinalValueField();
+//        String field = getFinalValueField();
 
-        SigmaNumber number = (SigmaNumber) condition.getValue();
-        ruleQueryFields.put(field, number.getNumOpt().isLeft()? Collections.singletonMap("type", "integer"): Collections.singletonMap("type", "float"));
+//        SigmaNumber number = (SigmaNumber) condition.getValue();
+//        ruleQueryFields.put(field, number.getNumOpt().isLeft()? Collections.singletonMap("type", "integer"): Collections.singletonMap("type", "float"));
 
-        return String.format(Locale.getDefault(), this.unboundValueNumExpression, field, condition.getValue().toString());
+        return String.format(Locale.getDefault(), this.unboundValueNumExpression, condition.getValue().toString());
     }
 
     @Override
     public Object convertConditionValRe(ConditionValueExpression condition) {
-        String field = getFinalValueField();
-        ruleQueryFields.put(field, Map.of("type", "text", "analyzer", "rule_analyzer"));
-        return String.format(Locale.getDefault(), this.unboundReExpression, field, convertValueRe((SigmaRegularExpression) condition.getValue()));
+//        String field = getFinalValueField();
+//        ruleQueryFields.put(field, Map.of("type", "text", "analyzer", "rule_analyzer"));
+        return String.format(Locale.getDefault(), this.unboundReExpression, convertValueRe((SigmaRegularExpression) condition.getValue()));
     }
 
 // TODO: below methods will be supported when Sigma Expand Modifier is supported.

--- a/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
@@ -332,27 +332,17 @@ public class OSQueryBackend extends QueryBackend {
     @Override
     public Object convertConditionValStr(ConditionValueExpression condition) throws SigmaValueError {
         SigmaString value = (SigmaString) condition.getValue();
-
-//        String field = getFinalValueField();
-//        ruleQueryFields.put(field, Map.of("type", "text", "analyzer", "rule_analyzer"));
         boolean containsWildcard = value.containsWildcard();
         return String.format(Locale.getDefault(), (containsWildcard? this.unboundWildcardExpression: this.unboundValueStrExpression), this.convertValueStr((SigmaString) condition.getValue()));
     }
 
     @Override
     public Object convertConditionValNum(ConditionValueExpression condition) {
-//        String field = getFinalValueField();
-
-//        SigmaNumber number = (SigmaNumber) condition.getValue();
-//        ruleQueryFields.put(field, number.getNumOpt().isLeft()? Collections.singletonMap("type", "integer"): Collections.singletonMap("type", "float"));
-
         return String.format(Locale.getDefault(), this.unboundValueNumExpression, condition.getValue().toString());
     }
 
     @Override
     public Object convertConditionValRe(ConditionValueExpression condition) {
-//        String field = getFinalValueField();
-//        ruleQueryFields.put(field, Map.of("type", "text", "analyzer", "rule_analyzer"));
         return String.format(Locale.getDefault(), this.unboundReExpression, convertValueRe((SigmaRegularExpression) condition.getValue()));
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
@@ -134,8 +134,8 @@ public class OSQueryBackend extends QueryBackend {
         this.fieldNullExpression = "%s: null";
         this.unboundValueStrExpression = "\"%s\"";
         this.unboundValueNumExpression = "\"%s\"";
-        this.unboundWildcardExpression = "\"%s\"";
-        this.unboundReExpression = "\"/%s/\""; // TODO
+        this.unboundWildcardExpression = "%s";
+        this.unboundReExpression = "\"/%s/\"";
         this.compareOpExpression = "\"%s\" \"%s\" %s";
         this.valExpCount = 0;
         this.aggQuery = "{\"%s\":{\"terms\":{\"field\":\"%s\"},\"aggs\":{\"%s\":{\"%s\":{\"field\":\"%s\"}}}}}";

--- a/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
@@ -135,7 +135,7 @@ public class OSQueryBackend extends QueryBackend {
         this.unboundValueStrExpression = "\"%s\"";
         this.unboundValueNumExpression = "\"%s\"";
         this.unboundWildcardExpression = "%s";
-        this.unboundReExpression = "\"/%s/\"";
+        this.unboundReExpression = "/%s/";
         this.compareOpExpression = "\"%s\" \"%s\" %s";
         this.valExpCount = 0;
         this.aggQuery = "{\"%s\":{\"terms\":{\"field\":\"%s\"},\"aggs\":{\"%s\":{\"%s\":{\"field\":\"%s\"}}}}}";

--- a/src/main/resources/rules/test_windows/win_sample_rule.yml
+++ b/src/main/resources/rules/test_windows/win_sample_rule.yml
@@ -21,6 +21,6 @@ detection:
     HostName|startswith: 'EC2AMAZ'
   keywords:
     - "NT AUTHORITY"
-  condition: selection and keywords
+  condition: selection or keywords
 falsepositives:
   - Unknown

--- a/src/main/resources/rules/test_windows/win_sample_rule.yml
+++ b/src/main/resources/rules/test_windows/win_sample_rule.yml
@@ -19,6 +19,8 @@ detection:
     EventID: 22
     Message|contains: 'C:\\Program Files\\nxlog\\nxlog.exe'
     HostName|startswith: 'EC2AMAZ'
-  condition: selection
+  keywords:
+    - "NT AUTHORITY"
+  condition: selection and keywords
 falsepositives:
   - Unknown

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -379,6 +379,68 @@ public class TestHelpers {
                 "level: high";
     }
 
+    public static String randomRuleWithStringKeywords() {
+        return "title: Remote Encrypting File System Abuse\n" +
+                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
+                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
+                "references:\n" +
+                "    - https://attack.mitre.org/tactics/TA0008/\n" +
+                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
+                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
+                "    - https://github.com/zeronetworks/rpcfirewall\n" +
+                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
+                "tags:\n" +
+                "    - attack.defense_evasion\n" +
+                "status: experimental\n" +
+                "author: Sagie Dulce, Dekel Paz\n" +
+                "date: 2022/01/01\n" +
+                "modified: 2022/01/01\n" +
+                "logsource:\n" +
+                "    product: rpc_firewall\n" +
+                "    category: application\n" +
+                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
+                "detection:\n" +
+                "    selection:\n" +
+                "        EventID: 21\n" +
+                "    keywords:\n" +
+                "        - \"INFO\"\n" +
+                "    condition: selection or keywords\n" +
+                "falsepositives:\n" +
+                "    - Legitimate usage of remote file encryption\n" +
+                "level: high";
+    }
+
+    public static String randomRuleWithDateKeywords() {
+        return "title: Remote Encrypting File System Abuse\n" +
+                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
+                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
+                "references:\n" +
+                "    - https://attack.mitre.org/tactics/TA0008/\n" +
+                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
+                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
+                "    - https://github.com/zeronetworks/rpcfirewall\n" +
+                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
+                "tags:\n" +
+                "    - attack.defense_evasion\n" +
+                "status: experimental\n" +
+                "author: Sagie Dulce, Dekel Paz\n" +
+                "date: 2022/01/01\n" +
+                "modified: 2022/01/01\n" +
+                "logsource:\n" +
+                "    product: rpc_firewall\n" +
+                "    category: application\n" +
+                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
+                "detection:\n" +
+                "    selection:\n" +
+                "        EventID: 21\n" +
+                "    keywords:\n" +
+                "        - \"2020-02-04T14:59:39.343541+00:00\"\n" +
+                "    condition: selection or keywords\n" +
+                "falsepositives:\n" +
+                "    - Legitimate usage of remote file encryption\n" +
+                "level: high";
+    }
+
     public static String countAggregationTestRule() {
         return "            title: Test\n" +
                 "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
@@ -1399,6 +1461,48 @@ public class TestHelpers {
                 "    }";
     }
 
+    public static String windowsIndexMappingOnlyNumericAndDate() {
+        return "\"properties\": {\n" +
+                "      \"@timestamp\": {\"type\":\"date\"},\n" +
+                "      \"EventTime\": {\n" +
+                "        \"type\": \"date\"\n" +
+                "      },\n" +
+                "      \"ExecutionProcessID\": {\n" +
+                "        \"type\": \"long\"\n" +
+                "      },\n" +
+                "      \"ExecutionThreadID\": {\n" +
+                "        \"type\": \"integer\"\n" +
+                "      },\n" +
+                "      \"EventID\": {\n" +
+                "        \"type\": \"integer\"\n" +
+                "      },\n" +
+                "      \"TaskValue\": {\n" +
+                "        \"type\": \"integer\"\n" +
+                "      }\n" +
+                "    }";
+    }
+
+    public static String windowsIndexMappingOnlyNumericAndText() {
+        return "\"properties\": {\n" +
+                "      \"TaskName\": {\n" +
+                "        \"type\": \"text\"\n" +
+                "      },\n" +
+                "      \"ExecutionProcessID\": {\n" +
+                "        \"type\": \"long\"\n" +
+                "      },\n" +
+                "      \"ExecutionThreadID\": {\n" +
+                "        \"type\": \"integer\"\n" +
+                "      },\n" +
+                "      \"EventID\": {\n" +
+                "        \"type\": \"integer\"\n" +
+                "      },\n" +
+                "      \"TaskValue\": {\n" +
+                "        \"type\": \"integer\"\n" +
+                "      }\n" +
+                "    }";
+    }
+
+
     public static String randomDoc(int severity,  int version, String opCode) {
         String doc =  "{\n" +
                 "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
@@ -1436,6 +1540,28 @@ public class TestHelpers {
                 "}";
         return String.format(Locale.ROOT, doc, severity, version, opCode);
 
+    }
+
+    public static String randomDocOnlyNumericAndDate(int severity, int version, String opCode) {
+        String doc =  "{\n" +
+                "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
+                "\"ExecutionProcessID\":2001,\n" +
+                "\"ExecutionThreadID\":2616,\n" +
+                "\"EventID\": 1234,\n" +
+                "\"TaskValue\":22\n" +
+                "}";
+        return String.format(Locale.ROOT, doc, severity, version, opCode);
+    }
+
+    public static String randomDocOnlyNumericAndText(int severity, int version, String opCode) {
+        String doc =  "{\n" +
+                "\"TaskName\":\"SYSTEM\",\n" +
+                "\"ExecutionProcessID\":2001,\n" +
+                "\"ExecutionThreadID\":2616,\n" +
+                "\"EventID\": 1234,\n" +
+                "\"TaskValue\":22\n" +
+                "}";
+        return String.format(Locale.ROOT, doc, severity, version, opCode);
     }
 
     //Add IPs in HostName field.

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -347,6 +347,39 @@ public class TestHelpers {
                 "level: high";
     }
 
+    public static String randomRuleWithKeywords() {
+        return "title: Remote Encrypting File System Abuse\n" +
+                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
+                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
+                "references:\n" +
+                "    - https://attack.mitre.org/tactics/TA0008/\n" +
+                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
+                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
+                "    - https://github.com/zeronetworks/rpcfirewall\n" +
+                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
+                "tags:\n" +
+                "    - attack.defense_evasion\n" +
+                "status: experimental\n" +
+                "author: Sagie Dulce, Dekel Paz\n" +
+                "date: 2022/01/01\n" +
+                "modified: 2022/01/01\n" +
+                "logsource:\n" +
+                "    product: rpc_firewall\n" +
+                "    category: application\n" +
+                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
+                "detection:\n" +
+                "    selection:\n" +
+                "        EventID: 21\n" +
+                "    keywords:\n" +
+                "        - 1996\n" +
+                "        - 'windows '\n" +
+                "        - AccessDeniedException\n" +
+                "    condition: selection or keywords\n" +
+                "falsepositives:\n" +
+                "    - Legitimate usage of remote file encryption\n" +
+                "level: high";
+    }
+
     public static String countAggregationTestRule() {
         return "            title: Test\n" +
                 "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -1542,7 +1542,7 @@ public class TestHelpers {
         return "{\n" +
                 "  \"endpoint\": \"/customer_records.txt\",\n" +
                 "  \"http_method\": \"POST\",\n" +
-                "  \"keywords\": \"PermissionDenied\"\n" +
+                "  \"keywords\": \"INVALID\"\n" +
                 "}";
     }
 

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -372,8 +372,7 @@ public class TestHelpers {
                 "        EventID: 21\n" +
                 "    keywords:\n" +
                 "        - 1996\n" +
-                "        - 'windows '\n" +
-                "        - AccessDeniedException\n" +
+                "        - EC2AMAZ*\n" +
                 "    condition: selection or keywords\n" +
                 "falsepositives:\n" +
                 "    - Legitimate usage of remote file encryption\n" +

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
@@ -33,7 +33,16 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
-import static org.opensearch.securityanalytics.TestHelpers.*;
+import static org.opensearch.securityanalytics.TestHelpers.randomAggregationRule;
+import static org.opensearch.securityanalytics.TestHelpers.randomDetector;
+import static org.opensearch.securityanalytics.TestHelpers.randomDetectorType;
+import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputs;
+import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputsAndTriggers;
+import static org.opensearch.securityanalytics.TestHelpers.randomDoc;
+import static org.opensearch.securityanalytics.TestHelpers.randomIndex;
+import static org.opensearch.securityanalytics.TestHelpers.randomRule;
+import static org.opensearch.securityanalytics.TestHelpers.randomRuleWithKeywords;
+import static org.opensearch.securityanalytics.TestHelpers.windowsIndexMapping;
 import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE;
 
 public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {

--- a/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
@@ -7,6 +7,9 @@ package org.opensearch.securityanalytics.rules.backend;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.opensearch.securityanalytics.rules.exceptions.SigmaError;
 import org.opensearch.securityanalytics.rules.exceptions.SigmaTypeError;
@@ -15,6 +18,7 @@ import org.opensearch.securityanalytics.rules.objects.SigmaRule;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class QueryBackendTests extends OpenSearchTestCase {
+    private static final Logger log = LogManager.getLogger(QueryBackendTests.class);
 
     private static Map<String, String> testFieldMapping = Map.of(
         "EventID", "event_uid",
@@ -880,6 +884,107 @@ public class QueryBackendTests extends OpenSearchTestCase {
                 "    - attack.t1197\n" +
                 "    - attack.s0190", false));
         Assert.assertEquals(true, true);
+    }
+
+    public void testKeywordsFieldAsString() throws IOException, SigmaError {
+        OSQueryBackend queryBackend = testBackend();
+        List<Object> queries = queryBackend.convertRule(SigmaRule.fromYaml(
+                "            title: Test\n" +
+                        "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
+                        "            status: test\n" +
+                        "            level: critical\n" +
+                        "            description: Detects QuarksPwDump clearing access history in hive\n" +
+                        "            author: Florian Roth\n" +
+                        "            date: 2017/05/15\n" +
+                        "            logsource:\n" +
+                        "                category: test_category\n" +
+                        "                product: test_product\n" +
+                        "            detection:\n" +
+                        "                sel:\n" +
+                        "                    fieldA1: \n" +
+                        "                        - value1\n" +
+                        "                        - value2\n" +
+                        "                        - value3\n" +
+                        "                keywords:\n" +
+                        "                     - valueA\n" +
+                        "                     - valueB\n" +
+                        "                condition: sel or keywords", false));
+        Assert.assertEquals("((mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: \"value3\")) OR ((\"valueA\") OR (\"valueB\"))", queries.get(0).toString());
+    }
+
+    public void testKeywordsFieldAsNumber() throws IOException, SigmaError {
+        OSQueryBackend queryBackend = testBackend();
+        List<Object> queries = queryBackend.convertRule(SigmaRule.fromYaml(
+                "            title: Test\n" +
+                        "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
+                        "            status: test\n" +
+                        "            level: critical\n" +
+                        "            description: Detects QuarksPwDump clearing access history in hive\n" +
+                        "            author: Florian Roth\n" +
+                        "            date: 2017/05/15\n" +
+                        "            logsource:\n" +
+                        "                category: test_category\n" +
+                        "                product: test_product\n" +
+                        "            detection:\n" +
+                        "                sel:\n" +
+                        "                    fieldA1: \n" +
+                        "                        - value1\n" +
+                        "                        - value2\n" +
+                        "                        - value3\n" +
+                        "                keywords:\n" +
+                        "                     - 1\n" +
+                        "                     - 2\n" +
+                        "                condition: sel and keywords", false));
+        Assert.assertEquals("((mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: \"value3\")) AND ((\"1\") OR (\"2\"))", queries.get(0).toString());
+    }
+
+//    public void testKeywordsFieldAsRegexAndWildcard() throws IOException, SigmaError {
+//        OSQueryBackend queryBackend = testBackend();
+//        List<Object> queries = queryBackend.convertRule(SigmaRule.fromYaml(
+//                "            title: Test\n" +
+//                        "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
+//                        "            status: test\n" +
+//                        "            level: critical\n" +
+//                        "            description: Detects QuarksPwDump clearing access history in hive\n" +
+//                        "            author: Florian Roth\n" +
+//                        "            date: 2017/05/15\n" +
+//                        "            logsource:\n" +
+//                        "                category: test_category\n" +
+//                        "                product: test_product\n" +
+//                        "            detection:\n" +
+//                        "                sel:\n" +
+//                        "                    fieldA1: \n" +
+//                        "                        - value1\n" +
+//                        "                        - value2\n" +
+//                        "                        - value3\n" +
+//                        "                keywords:\n" +
+//                        "                     - ^[0-9]+$\n" +
+//                        "                     - test*\n" +
+//                        "                condition: sel or keywords", false));
+//        log.info(queries.get(0).toString());
+//        Assert.assertEquals("((mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: \"value3\")) OR ((/^[0-9]+$/) OR (\"test*\"))", queries.get(0).toString());
+//    }
+
+    public void test() throws IOException, SigmaError {
+        OSQueryBackend queryBackend = testBackend();
+        List<Object> queries = queryBackend.convertRule(SigmaRule.fromYaml(
+                "            title: Test\n" +
+                        "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
+                        "            status: test\n" +
+                        "            level: critical\n" +
+                        "            description: Detects QuarksPwDump clearing access history in hive\n" +
+                        "            author: Florian Roth\n" +
+                        "            date: 2017/05/15\n" +
+                        "            logsource:\n" +
+                        "                category: test_category\n" +
+                        "                product: test_product\n" +
+                        "            detection:\n" +
+                        "                selection:\n" +
+                        "                    eventID: 21\n" +
+                        "                keywords:\n" +
+                        "                     - \"22\"\n" +
+                        "                condition: selection or keywords", false));
+        log.info(queries.get(0).toString());
     }
 
     private OSQueryBackend testBackend() throws IOException {

--- a/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
@@ -961,7 +961,7 @@ public class QueryBackendTests extends OpenSearchTestCase {
                         "                     - test*\n" +
                         "                condition: sel or keywords", false));
         log.info(queries.get(0).toString());
-        Assert.assertEquals("((mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: \"value3\")) OR (\"test*\")", queries.get(0).toString());
+        Assert.assertEquals("((mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: \"value3\")) OR (test*)", queries.get(0).toString());
     }
 
     public void test() throws IOException, SigmaError {

--- a/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
@@ -938,32 +938,31 @@ public class QueryBackendTests extends OpenSearchTestCase {
         Assert.assertEquals("((mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: \"value3\")) AND ((\"1\") OR (\"2\"))", queries.get(0).toString());
     }
 
-//    public void testKeywordsFieldAsRegexAndWildcard() throws IOException, SigmaError {
-//        OSQueryBackend queryBackend = testBackend();
-//        List<Object> queries = queryBackend.convertRule(SigmaRule.fromYaml(
-//                "            title: Test\n" +
-//                        "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
-//                        "            status: test\n" +
-//                        "            level: critical\n" +
-//                        "            description: Detects QuarksPwDump clearing access history in hive\n" +
-//                        "            author: Florian Roth\n" +
-//                        "            date: 2017/05/15\n" +
-//                        "            logsource:\n" +
-//                        "                category: test_category\n" +
-//                        "                product: test_product\n" +
-//                        "            detection:\n" +
-//                        "                sel:\n" +
-//                        "                    fieldA1: \n" +
-//                        "                        - value1\n" +
-//                        "                        - value2\n" +
-//                        "                        - value3\n" +
-//                        "                keywords:\n" +
-//                        "                     - ^[0-9]+$\n" +
-//                        "                     - test*\n" +
-//                        "                condition: sel or keywords", false));
-//        log.info(queries.get(0).toString());
-//        Assert.assertEquals("((mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: \"value3\")) OR ((/^[0-9]+$/) OR (\"test*\"))", queries.get(0).toString());
-//    }
+    public void testKeywordsFieldAsWildcard() throws IOException, SigmaError {
+        OSQueryBackend queryBackend = testBackend();
+        List<Object> queries = queryBackend.convertRule(SigmaRule.fromYaml(
+                "            title: Test\n" +
+                        "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
+                        "            status: test\n" +
+                        "            level: critical\n" +
+                        "            description: Detects QuarksPwDump clearing access history in hive\n" +
+                        "            author: Florian Roth\n" +
+                        "            date: 2017/05/15\n" +
+                        "            logsource:\n" +
+                        "                category: test_category\n" +
+                        "                product: test_product\n" +
+                        "            detection:\n" +
+                        "                sel:\n" +
+                        "                    fieldA1: \n" +
+                        "                        - value1\n" +
+                        "                        - value2\n" +
+                        "                        - value3\n" +
+                        "                keywords:\n" +
+                        "                     - test*\n" +
+                        "                condition: sel or keywords", false));
+        log.info(queries.get(0).toString());
+        Assert.assertEquals("((mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: \"value3\")) OR (\"test*\")", queries.get(0).toString());
+    }
 
     public void test() throws IOException, SigmaError {
         OSQueryBackend queryBackend = testBackend();


### PR DESCRIPTION
### Description
Changes the query construction of keywords in sigma rules from ```(_0:"value")``` to ```("value")``` to create a query string query without a designated field so that the keywords are instead matched against all the fields in a document.

### Issues Resolved
#683 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
