### PR TITLE
Use a common constant to specify the version for log type mappings #708

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
     implementation "org.apache.commons:commons-csv:1.10.0"
+    implementation 'org.json:json:20210307'
 
     // Needed for integ tests
     zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${opensearch_build}"

--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
     implementation "org.apache.commons:commons-csv:1.10.0"
-    implementation 'org.json:json:20210307'
+    implementation 'org.json:json:20231013'
 
     // Needed for integ tests
     zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${opensearch_build}"

--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
     implementation "org.apache.commons:commons-csv:1.10.0"
-    implementation 'org.json:json:20231013'
 
     // Needed for integ tests
     zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${opensearch_build}"

--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -4,7 +4,6 @@
  */
 package org.opensearch.securityanalytics.logtype;
 
-import org.json.JSONObject;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,6 +25,8 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.cluster.routing.Preference;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -784,8 +785,8 @@ public class LogTypeService {
     }
 
     public void setLogTypeMappingVersion() {
-        String logTypeIndexMapping = logTypeIndexMapping();
-        JSONObject jsonObject = new JSONObject(logTypeIndexMapping);
-        this.logTypeMappingVersion = jsonObject.getJSONObject("_meta").getInt("schema_version");
+        Map<String, Object> logTypeConfigAsMap =
+                XContentHelper.convertToMap(JsonXContent.jsonXContent, logTypeIndexMapping(), false);
+        this.logTypeMappingVersion = (int)((Map)logTypeConfigAsMap.get("_meta")).get("schema_version");
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/LogTypeServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/LogTypeServiceTests.java
@@ -108,7 +108,9 @@ public class LogTypeServiceTests extends OpenSearchIntegTestCase {
     }
 
     public void testSetLogTypeMappingSchema() {
-        assertEquals(2, logTypeService.logTypeMappingVersion);
+        int expectedVersion = 2;
+        int version = logTypeService.logTypeMappingVersion;
+        assertEquals(expectedVersion, version);
     }
 
     private void indexFieldMappings(List<FieldMappingDoc> fieldMappingDocs) {

--- a/src/test/java/org/opensearch/securityanalytics/LogTypeServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/LogTypeServiceTests.java
@@ -107,7 +107,9 @@ public class LogTypeServiceTests extends OpenSearchIntegTestCase {
 
     }
 
-
+    public void testSetLogTypeMappingSchema() {
+        assertEquals(2, logTypeService.logTypeMappingVersion);
+    }
 
     private void indexFieldMappings(List<FieldMappingDoc> fieldMappingDocs) {
         PlainActionFuture<Void> fut = new PlainActionFuture<>();


### PR DESCRIPTION
### Description
Sets the ```log_type_mapping_version``` in ```LogTypeService.java``` to the same schema version values used in ```log_type_config_mapping.json```
 
### Issues Resolved
#708 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
