### PR TITLE
add field based rules support in correlation engine

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -295,6 +295,7 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
                 SecurityAnalyticsSettings.CORRELATION_HISTORY_RETENTION_PERIOD,
                 SecurityAnalyticsSettings.IS_CORRELATION_INDEX_SETTING,
                 SecurityAnalyticsSettings.CORRELATION_TIME_WINDOW,
+                SecurityAnalyticsSettings.ENABLE_AUTO_CORRELATIONS,
                 SecurityAnalyticsSettings.DEFAULT_MAPPING_SCHEMA,
                 SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE,
                 SecurityAnalyticsSettings.TIF_UPDATE_INTERVAL,

--- a/src/main/java/org/opensearch/securityanalytics/model/CorrelationQuery.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/CorrelationQuery.java
@@ -22,33 +22,45 @@ public class CorrelationQuery implements Writeable, ToXContentObject {
     private static final String QUERY = "query";
     private static final String CATEGORY = "category";
 
+    private static final String FIELD = "field";
+
     private String index;
 
     private String query;
 
     private String category;
 
-    public CorrelationQuery(String index, String query, String category) {
+    private String field;
+
+    public CorrelationQuery(String index, String query, String category, String field) {
         this.index = index;
         this.query = query;
         this.category = category;
+        this.field = field;
     }
 
     public CorrelationQuery(StreamInput sin) throws IOException {
-        this(sin.readString(), sin.readString(), sin.readString());
+        this(sin.readString(), sin.readOptionalString(), sin.readString(), sin.readOptionalString());
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(index);
-        out.writeString(query);
+        out.writeOptionalString(query);
         out.writeString(category);
+        out.writeOptionalString(field);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(INDEX, index).field(QUERY, query).field(CATEGORY, category);
+        builder.field(INDEX, index).field(CATEGORY, category);
+        if (query != null) {
+            builder.field(QUERY, query);
+        }
+        if (field != null) {
+            builder.field(FIELD, field);
+        }
         return builder.endObject();
     }
 
@@ -56,6 +68,7 @@ public class CorrelationQuery implements Writeable, ToXContentObject {
         String index = null;
         String query = null;
         String category = null;
+        String field = null;
 
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -72,11 +85,14 @@ public class CorrelationQuery implements Writeable, ToXContentObject {
                 case CATEGORY:
                     category = xcp.text();
                     break;
+                case FIELD:
+                    field = xcp.text();
+                    break;
                 default:
                     xcp.skipChildren();
             }
         }
-        return new CorrelationQuery(index, query, category);
+        return new CorrelationQuery(index, query, category, field);
     }
 
     public static CorrelationQuery readFrom(StreamInput sin) throws IOException {
@@ -93,5 +109,9 @@ public class CorrelationQuery implements Writeable, ToXContentObject {
 
     public String getCategory() {
         return category;
+    }
+
+    public String getField() {
+        return field;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -138,8 +138,11 @@ public class SecurityAnalyticsSettings {
             Setting.Property.NodeScope, Setting.Property.Dynamic
     );
 
+    /**
+     * Setting which enables auto correlations
+     */
     public static final Setting<Boolean> ENABLE_AUTO_CORRELATIONS = Setting.boolSetting(
-            "plugins.security_analytics.enable_auto_correlations",
+            "plugins.security_analytics.auto_correlations_enabled",
             false,
             Setting.Property.NodeScope, Setting.Property.Dynamic
     );

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -138,6 +138,12 @@ public class SecurityAnalyticsSettings {
             Setting.Property.NodeScope, Setting.Property.Dynamic
     );
 
+    public static final Setting<Boolean> ENABLE_AUTO_CORRELATIONS = Setting.boolSetting(
+            "plugins.security_analytics.enable_auto_correlations",
+            false,
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+    );
+
     public static final Setting<String> DEFAULT_MAPPING_SCHEMA = Setting.simpleString(
             "plugins.security_analytics.mappings.default_schema",
             "ecs",

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -96,6 +96,8 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
 
     private volatile long setupTimestamp;
 
+    private volatile boolean enableAutoCorrelation;
+
     @Inject
     public TransportCorrelateFindingAction(TransportService transportService,
                                            Client client,
@@ -118,8 +120,10 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
 
         this.indexTimeout = SecurityAnalyticsSettings.INDEX_TIMEOUT.get(this.settings);
         this.corrTimeWindow = SecurityAnalyticsSettings.CORRELATION_TIME_WINDOW.get(this.settings).getMillis();
+        this.enableAutoCorrelation = SecurityAnalyticsSettings.ENABLE_AUTO_CORRELATIONS.get(this.settings);
         this.clusterService.getClusterSettings().addSettingsUpdateConsumer(SecurityAnalyticsSettings.INDEX_TIMEOUT, it -> indexTimeout = it);
         this.clusterService.getClusterSettings().addSettingsUpdateConsumer(SecurityAnalyticsSettings.CORRELATION_TIME_WINDOW, it -> corrTimeWindow = it.getMillis());
+        this.clusterService.getClusterSettings().addSettingsUpdateConsumer(SecurityAnalyticsSettings.ENABLE_AUTO_CORRELATIONS, it -> enableAutoCorrelation = it);
         this.setupTimestamp = System.currentTimeMillis();
     }
 
@@ -220,7 +224,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
 
             this.response =new AtomicReference<>();
 
-            this.joinEngine = new JoinEngine(client, request, xContentRegistry, corrTimeWindow, this, logTypeService);
+            this.joinEngine = new JoinEngine(client, request, xContentRegistry, corrTimeWindow, this, logTypeService, enableAutoCorrelation);
             this.vectorEmbeddingsEngine = new VectorEmbeddingsEngine(client, indexTimeout, corrTimeWindow, this);
         }
 

--- a/src/main/resources/mappings/finding_mapping.json
+++ b/src/main/resources/mappings/finding_mapping.json
@@ -46,6 +46,9 @@
               "type" : "keyword"
             }
           }
+        },
+        "fields": {
+          "type": "text"
         }
       }
     },

--- a/src/main/resources/mappings/finding_mapping.json
+++ b/src/main/resources/mappings/finding_mapping.json
@@ -1,7 +1,7 @@
 {
   "dynamic": "strict",
   "_meta" : {
-    "schema_version": 3
+    "schema_version": 4
   },
   "properties": {
     "schema_version": {

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -225,9 +225,9 @@ public class TestHelpers {
         name = name.isEmpty()? "><script>prompt(document.domain)</script>": name;
         return new CorrelationRule(CorrelationRule.NO_ID, CorrelationRule.NO_VERSION, name,
                 List.of(
-                        new CorrelationQuery("vpc_flow1", "dstaddr:192.168.1.*", "network"),
-                        new CorrelationQuery("ad_logs1", "azure.platformlogs.result_type:50126", "ad_ldap")
-                ));
+                        new CorrelationQuery("vpc_flow1", "dstaddr:192.168.1.*", "network", null),
+                        new CorrelationQuery("ad_logs1", "azure.platformlogs.result_type:50126", "ad_ldap", null)
+                ), 300000L);
     }
 
     public static String randomRule() {
@@ -260,7 +260,6 @@ public class TestHelpers {
     }
 
 
-
     public static String randomNullRule() {
         return "title: null field\n" +
                 "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
@@ -289,6 +288,29 @@ public class TestHelpers {
                 "falsepositives:\n" +
                 "    - Legitimate usage of remote file encryption\n" +
                 "level: high";
+    }
+
+    public static String randomRuleForCorrelations(String value) {
+        return "id: 5f92fff9-82e2-48ab-8fc1-8b133556a551\n" +
+                "logsource:\n" +
+                "  product: cloudtrail\n" +
+                "title: AWS User Created\n" +
+                "description: AWS User Created\n" +
+                "tags:\n" +
+                "  - attack.test1\n" +
+                "falsepositives:\n" +
+                "  - Legit User Account Administration\n" +
+                "level: high\n" +
+                "date: 2022/01/01\n" +
+                "status: experimental\n" +
+                "references:\n" +
+                "  - 'https://github.com/RhinoSecurityLabs/AWS-IAM-Privilege-Escalation'\n" +
+                "author: toffeebr33k\n" +
+                "detection:\n" +
+                "  condition: selection_source\n" +
+                "  selection_source:\n" +
+                "    EventName:\n" +
+                "      - " + value;
     }
 
     public static String randomRuleForMappingView(String field) {
@@ -869,6 +891,29 @@ public class TestHelpers {
         return String.format(Locale.ROOT, rule, opCode, aggFunction, signAndValue);
     }
 
+    public static String randomCloudtrailAggrRule() {
+        return  "id: c64c5175-5189-431b-a55e-6d9882158250\n" +
+                "logsource:\n" +
+                "  product: cloudtrail\n" +
+                "title: Accounts created and deleted within 24h\n" +
+                "description: Flag suspicious activity of accounts created and deleted within 24h\n" +
+                "date: 2021/09/23\n" +
+                "tags:\n" +
+                "  - attack.exfiltration\n" +
+                "falsepositives: [ ]\n" +
+                "level: high\n" +
+                "status: test\n" +
+                "references: [ ]\n" +
+                "author: Sashank\n" +
+                "detection:\n" +
+                "  selection:\n" +
+                "    EventName:\n" +
+                "      - CREATED\n" +
+                "      - DELETED\n" +
+                "  timeframe: 24h\n" +
+                "  condition: selection | count(*) by AccountName >= 2";
+    }
+
     public static String windowsIndexMapping() {
         return "\"properties\": {\n" +
                 "      \"@timestamp\": {\"type\":\"date\"},\n" +
@@ -882,7 +927,10 @@ public class TestHelpers {
                 "        \"type\": \"text\"\n" +
                 "      },\n" +
                 "      \"AccountName\": {\n" +
-                "        \"type\": \"text\"\n" +
+                "        \"type\": \"keyword\"\n" +
+                "      },\n" +
+                "      \"EventName\": {\n" +
+                "        \"type\": \"keyword\"\n" +
                 "      },\n" +
                 "      \"AccountType\": {\n" +
                 "        \"type\": \"text\",\n" +
@@ -1023,7 +1071,7 @@ public class TestHelpers {
                 "        \"type\": \"date\"\n" +
                 "      },\n" +
                 "      \"EventType\": {\n" +
-                "        \"type\": \"integer\"\n" +
+                "        \"type\": \"keyword\"\n" +
                 "      },\n" +
                 "      \"ExecutionProcessID\": {\n" +
                 "        \"type\": \"long\"\n" +
@@ -1684,6 +1732,7 @@ public class TestHelpers {
                 "\"Severity\":\"INFO\",\n" +
                 "\"EventID\":22,\n" +
                 "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n" +
+                "\"SourceIp\":\"1.2.3.4\",\n" +
                 "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n" +
                 "\"Version\":5,\n" +
                 "\"TaskValue\":22,\n" +
@@ -1712,6 +1761,13 @@ public class TestHelpers {
                 "}";
     }
 
+    public static String randomCloudtrailAggrDoc(String eventType, String accountId) {
+        return "{\n" +
+                "  \"AccountName\": \"" + accountId + "\",\n" +
+                "  \"EventType\": \"" + eventType + "\"\n" +
+                "}";
+    }
+
     public static String randomVpcFlowDoc() {
         return "{\n" +
                 "  \"version\": 1,\n" +
@@ -1731,6 +1787,60 @@ public class TestHelpers {
                 "  \"azure.platformlogs.result_type\": 50126,\n" +
                 "  \"azure.signinlogs.result_description\": \"Invalid username or password or Invalid on-premises username or password.\",\n" +
                 "  \"azure.signinlogs.props.user_id\": \"DEYSUBHO\"\n" +
+                "}";
+    }
+
+    public static String randomCloudtrailDoc(String user, String event) {
+        return "{\n" +
+                "    \"eventVersion\": \"1.08\",\n" +
+                "    \"userIdentity\": {\n" +
+                "        \"type\": \"IAMUser\",\n" +
+                "        \"principalId\": \"AIDA6ON6E4XEGITEXAMPLE\",\n" +
+                "        \"arn\": \"arn:aws:iam::888888888888:user/Mary\",\n" +
+                "        \"accountId\": \"888888888888\",\n" +
+                "        \"accessKeyId\": \"AKIAIOSFODNN7EXAMPLE\",\n" +
+                "        \"userName\": \"Mary\",\n" +
+                "        \"sessionContext\": {\n" +
+                "            \"sessionIssuer\": {},\n" +
+                "            \"webIdFederationData\": {},\n" +
+                "            \"attributes\": {\n" +
+                "                \"creationDate\": \"2023-07-19T21:11:57Z\",\n" +
+                "                \"mfaAuthenticated\": \"false\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    },\n" +
+                "    \"eventTime\": \"2023-07-19T21:25:09Z\",\n" +
+                "    \"eventSource\": \"iam.amazonaws.com\",\n" +
+                "    \"EventName\": \"" + event + "\",\n" +
+                "    \"awsRegion\": \"us-east-1\",\n" +
+                "    \"sourceIPAddress\": \"192.0.2.0\",\n" +
+                "    \"AccountName\": \"" + user + "\",\n" +
+                "    \"userAgent\": \"aws-cli/2.13.5 Python/3.11.4 Linux/4.14.255-314-253.539.amzn2.x86_64 exec-env/CloudShell exe/x86_64.amzn.2 prompt/off command/iam.create-user\",\n" +
+                "    \"requestParameters\": {\n" +
+                "        \"userName\": \"" + user + "\"\n" +
+                "    },\n" +
+                "    \"responseElements\": {\n" +
+                "        \"user\": {\n" +
+                "            \"path\": \"/\",\n" +
+                "            \"arn\": \"arn:aws:iam::888888888888:user/Richard\",\n" +
+                "            \"userId\": \"AIDA6ON6E4XEP7EXAMPLE\",\n" +
+                "            \"createDate\": \"Jul 19, 2023 9:25:09 PM\",\n" +
+                "            \"userName\": \"Richard\"\n" +
+                "        }\n" +
+                "    },\n" +
+                "    \"requestID\": \"2d528c76-329e-410b-9516-EXAMPLE565dc\",\n" +
+                "    \"eventID\": \"ba0801a1-87ec-4d26-be87-EXAMPLE75bbb\",\n" +
+                "    \"readOnly\": false,\n" +
+                "    \"eventType\": \"AwsApiCall\",\n" +
+                "    \"managementEvent\": true,\n" +
+                "    \"recipientAccountId\": \"888888888888\",\n" +
+                "    \"eventCategory\": \"Management\",\n" +
+                "    \"tlsDetails\": {\n" +
+                "        \"tlsVersion\": \"TLSv1.2\",\n" +
+                "        \"cipherSuite\": \"ECDHE-RSA-AES128-GCM-SHA256\",\n" +
+                "        \"clientProvidedHostHeader\": \"iam.amazonaws.com\"\n" +
+                "    },\n" +
+                "    \"sessionCredentialFromConsole\": \"true\"\n" +
                 "}";
     }
 
@@ -1762,6 +1872,312 @@ public class TestHelpers {
                 "        \"type\": \"text\"\n" +
                 "      }\n" +
                 "    }";
+    }
+
+    public static String cloudtrailMappings() {
+        return "\"properties\": {\n" +
+                "        \"Records\": {\n" +
+                "          \"properties\": {\n" +
+                "            \"awsRegion\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"eventCategory\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"eventID\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"eventName\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"eventSource\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"eventTime\": {\n" +
+                "              \"type\": \"date\"\n" +
+                "            },\n" +
+                "            \"eventType\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"eventVersion\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"managementEvent\": {\n" +
+                "              \"type\": \"boolean\"\n" +
+                "            },\n" +
+                "            \"readOnly\": {\n" +
+                "              \"type\": \"boolean\"\n" +
+                "            },\n" +
+                "            \"recipientAccountId\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"requestID\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"requestParameters\": {\n" +
+                "              \"properties\": {\n" +
+                "                \"userName\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"fields\": {\n" +
+                "                    \"keyword\": {\n" +
+                "                      \"type\": \"keyword\",\n" +
+                "                      \"ignore_above\": 256\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"responseElements\": {\n" +
+                "              \"properties\": {\n" +
+                "                \"user\": {\n" +
+                "                  \"properties\": {\n" +
+                "                    \"arn\": {\n" +
+                "                      \"type\": \"text\",\n" +
+                "                      \"fields\": {\n" +
+                "                        \"keyword\": {\n" +
+                "                          \"type\": \"keyword\",\n" +
+                "                          \"ignore_above\": 256\n" +
+                "                        }\n" +
+                "                      }\n" +
+                "                    },\n" +
+                "                    \"createDate\": {\n" +
+                "                      \"type\": \"text\",\n" +
+                "                      \"fields\": {\n" +
+                "                        \"keyword\": {\n" +
+                "                          \"type\": \"keyword\",\n" +
+                "                          \"ignore_above\": 256\n" +
+                "                        }\n" +
+                "                      }\n" +
+                "                    },\n" +
+                "                    \"path\": {\n" +
+                "                      \"type\": \"text\",\n" +
+                "                      \"fields\": {\n" +
+                "                        \"keyword\": {\n" +
+                "                          \"type\": \"keyword\",\n" +
+                "                          \"ignore_above\": 256\n" +
+                "                        }\n" +
+                "                      }\n" +
+                "                    },\n" +
+                "                    \"userId\": {\n" +
+                "                      \"type\": \"text\",\n" +
+                "                      \"fields\": {\n" +
+                "                        \"keyword\": {\n" +
+                "                          \"type\": \"keyword\",\n" +
+                "                          \"ignore_above\": 256\n" +
+                "                        }\n" +
+                "                      }\n" +
+                "                    },\n" +
+                "                    \"userName\": {\n" +
+                "                      \"type\": \"text\",\n" +
+                "                      \"fields\": {\n" +
+                "                        \"keyword\": {\n" +
+                "                          \"type\": \"keyword\",\n" +
+                "                          \"ignore_above\": 256\n" +
+                "                        }\n" +
+                "                      }\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"sessionCredentialFromConsole\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"sourceIPAddress\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"tlsDetails\": {\n" +
+                "              \"properties\": {\n" +
+                "                \"cipherSuite\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"fields\": {\n" +
+                "                    \"keyword\": {\n" +
+                "                      \"type\": \"keyword\",\n" +
+                "                      \"ignore_above\": 256\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                },\n" +
+                "                \"clientProvidedHostHeader\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"fields\": {\n" +
+                "                    \"keyword\": {\n" +
+                "                      \"type\": \"keyword\",\n" +
+                "                      \"ignore_above\": 256\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                },\n" +
+                "                \"tlsVersion\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"fields\": {\n" +
+                "                    \"keyword\": {\n" +
+                "                      \"type\": \"keyword\",\n" +
+                "                      \"ignore_above\": 256\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"userAgent\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"userIdentity\": {\n" +
+                "              \"properties\": {\n" +
+                "                \"accessKeyId\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"fields\": {\n" +
+                "                    \"keyword\": {\n" +
+                "                      \"type\": \"keyword\",\n" +
+                "                      \"ignore_above\": 256\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                },\n" +
+                "                \"accountId\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"fields\": {\n" +
+                "                    \"keyword\": {\n" +
+                "                      \"type\": \"keyword\",\n" +
+                "                      \"ignore_above\": 256\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                },\n" +
+                "                \"arn\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"fields\": {\n" +
+                "                    \"keyword\": {\n" +
+                "                      \"type\": \"keyword\",\n" +
+                "                      \"ignore_above\": 256\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                },\n" +
+                "                \"principalId\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"fields\": {\n" +
+                "                    \"keyword\": {\n" +
+                "                      \"type\": \"keyword\",\n" +
+                "                      \"ignore_above\": 256\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                },\n" +
+                "                \"sessionContext\": {\n" +
+                "                  \"properties\": {\n" +
+                "                    \"attributes\": {\n" +
+                "                      \"properties\": {\n" +
+                "                        \"creationDate\": {\n" +
+                "                          \"type\": \"date\"\n" +
+                "                        },\n" +
+                "                        \"mfaAuthenticated\": {\n" +
+                "                          \"type\": \"text\",\n" +
+                "                          \"fields\": {\n" +
+                "                            \"keyword\": {\n" +
+                "                              \"type\": \"keyword\",\n" +
+                "                              \"ignore_above\": 256\n" +
+                "                            }\n" +
+                "                          }\n" +
+                "                        }\n" +
+                "                      }\n" +
+                "                    },\n" +
+                "                    \"sessionIssuer\": {\n" +
+                "                      \"type\": \"object\"\n" +
+                "                    },\n" +
+                "                    \"webIdFederationData\": {\n" +
+                "                      \"type\": \"object\"\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                },\n" +
+                "                \"type\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"fields\": {\n" +
+                "                    \"keyword\": {\n" +
+                "                      \"type\": \"keyword\",\n" +
+                "                      \"ignore_above\": 256\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                },\n" +
+                "                \"userName\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"fields\": {\n" +
+                "                    \"keyword\": {\n" +
+                "                      \"type\": \"keyword\",\n" +
+                "                      \"ignore_above\": 256\n" +
+                "                    }\n" +
+                "                  }\n" +
+                "                }\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }}";
     }
 
     public static String s3AccessLogMappings() {

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -259,7 +259,6 @@ public class TestHelpers {
                 "level: high";
     }
 
-
     public static String randomNullRule() {
         return "title: null field\n" +
                 "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
@@ -290,7 +289,7 @@ public class TestHelpers {
                 "level: high";
     }
 
-    public static String randomRuleForCorrelations(String value) {
+    public static String randomCloudtrailRuleForCorrelations(String value) {
         return "id: 5f92fff9-82e2-48ab-8fc1-8b133556a551\n" +
                 "logsource:\n" +
                 "  product: cloudtrail\n" +

--- a/src/test/java/org/opensearch/securityanalytics/findings/FindingIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/findings/FindingIT.java
@@ -264,7 +264,7 @@ public class FindingIT extends SecurityAnalyticsRestTestCase {
         getFindingsBody = entityAsMap(getFindingsResponse);
         Assert.assertEquals(1, getFindingsBody.get("total_findings"));
     }
-    @Ignore
+
     public void testGetFindings_rolloverByMaxAge_success() throws IOException, InterruptedException {
 
         updateClusterSetting(FINDING_HISTORY_ROLLOVER_PERIOD.getKey(), "1s");

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
@@ -5,6 +5,8 @@
 package org.opensearch.securityanalytics.resthandler;
 
 import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.Assert;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Request;
@@ -28,12 +30,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static org.opensearch.securityanalytics.TestHelpers.randomAggregationRule;
+import static org.opensearch.securityanalytics.TestHelpers.randomCloudtrailAggrRule;
+import static org.opensearch.securityanalytics.TestHelpers.randomCloudtrailDoc;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetector;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorType;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputs;
@@ -1900,6 +1905,81 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
         // Verify no rules match test document
         assertEquals(0, noOfSigmaRuleMatches);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCreateDetectorWithCloudtrailAggrRule() throws IOException {
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+        indexDoc(index, "0", randomCloudtrailDoc("A12346", "CREATED"));
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+                "{ \"index_name\":\"" + index + "\"," +
+                        "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                        "  \"partial\":true" +
+                        "}"
+        );
+
+        Response response = client().performRequest(createMappingRequest);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        String rule = randomCloudtrailAggrRule();
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.RULE_BASE_URI, Collections.singletonMap("category", randomDetectorType()),
+                new StringEntity(rule), new BasicHeader("Content-Type", "application/json"));
+        Assert.assertEquals("Create rule failed", RestStatus.CREATED, restStatus(createResponse));
+        Map<String, Object> responseBody = asMap(createResponse);
+        String createdId = responseBody.get("_id").toString();
+
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of(index), List.of(new DetectorRule(createdId)),
+                List.of());
+        Detector detector = randomDetectorWithInputsAndTriggers(List.of(input),
+                List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(), List.of(createdId), List.of(), List.of(), List.of(), List.of())));
+
+        createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+        Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+
+        responseBody = asMap(createResponse);
+
+        createdId = responseBody.get("_id").toString();
+        int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+        Assert.assertNotEquals("response is missing Id", Detector.NO_ID, createdId);
+        Assert.assertTrue("incorrect version", createdVersion > 0);
+        Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, createdId), createResponse.getHeader("Location"));
+        Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("rule_topic_index"));
+        Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("findings_index"));
+        Assert.assertFalse(((Map<String, Object>) responseBody.get("detector")).containsKey("alert_index"));
+
+        String detectorTypeInResponse = (String) ((Map<String, Object>)responseBody.get("detector")).get("detector_type");
+        Assert.assertEquals("Detector type incorrect", randomDetectorType().toLowerCase(Locale.ROOT), detectorTypeInResponse);
+
+        String request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match\":{\n" +
+                "        \"_id\": \"" + createdId + "\"\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+
+        String workflowId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("workflow_ids")).get(0);
+
+        indexDoc(index, "1", randomCloudtrailDoc("A12345", "CREATED"));
+        executeAlertingWorkflow(workflowId, Collections.emptyMap());
+        indexDoc(index, "2", randomCloudtrailDoc("A12345", "DELETED"));
+        executeAlertingWorkflow(workflowId, Collections.emptyMap());
+
+        Map<String, String> params = new HashMap<>();
+        params.put("detector_id", createdId);
+        Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+        Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+
+        // Assert findings
+        assertNotNull(getFindingsBody);
+        assertEquals(1, getFindingsBody.get("total_findings"));
     }
 
     private static void assertRuleMonitorFinding(Map<String, Object> executeResults, String ruleId, int expectedDocCount, List<String> expectedTriggerResult) {

--- a/src/test/java/org/opensearch/securityanalytics/rules/aggregation/AggregationBackendTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/aggregation/AggregationBackendTests.java
@@ -216,4 +216,39 @@ public class AggregationBackendTests extends OpenSearchTestCase {
         Assert.assertEquals("{\"result_agg\":{\"terms\":{\"field\":\"fieldB\"},\"aggs\":{\"fieldA\":{\"avg\":{\"field\":\"fieldA\"}}}}}", aggQuery);
         Assert.assertEquals("{\"buckets_path\":{\"fieldA\":\"fieldA\"},\"parent_bucket_path\":\"result_agg\",\"script\":{\"source\":\"params.fieldA > 110.0\",\"lang\":\"painless\"}}", bucketTriggerQuery);
     }
+
+    public void testCloudtrailAggregationRule() throws IOException, SigmaError {
+        OSQueryBackend queryBackend = new OSQueryBackend(Map.of(), true, true);
+        List<Object> queries = queryBackend.convertRule(SigmaRule.fromYaml(
+                "id: c64c5175-5189-431b-a55e-6d9882158250\n" +
+                        "logsource:\n" +
+                        "  product: cloudtrail\n" +
+                        "title: Accounts created and deleted within 24h\n" +
+                        "description: Flag suspicious activity of accounts created and deleted within 24h\n" +
+                        "date: 2021/09/23\n" +
+                        "tags:\n" +
+                        "  - attack.exfiltration\n" +
+                        "falsepositives: [ ]\n" +
+                        "level: high\n" +
+                        "status: test\n" +
+                        "references: [ ]\n" +
+                        "author: Sashank\n" +
+                        "detection:\n" +
+                        "  selection:\n" +
+                        "    event:\n" +
+                        "      - CREATED\n" +
+                        "      - DELETED\n" +
+                        "  timeframe: 24h\n" +
+                        "  condition: selection | count(*) by accountid > 2", true));
+
+        String query = queries.get(0).toString();
+        Assert.assertEquals("(event: \"CREATED\") OR (event: \"DELETED\")", query);
+
+        OSQueryBackend.AggregationQueries aggQueries = (OSQueryBackend.AggregationQueries) queries.get(1);
+        String aggQuery = aggQueries.getAggQuery();
+        String bucketTriggerQuery = aggQueries.getBucketTriggerQuery();
+
+        Assert.assertEquals("{\"result_agg\":{\"terms\":{\"field\":\"accountid\"}}}", aggQuery);
+        Assert.assertEquals("{\"buckets_path\":{\"_cnt\":\"_count\"},\"parent_bucket_path\":\"result_agg\",\"script\":{\"source\":\"params._cnt > 2.0\",\"lang\":\"painless\"}}", bucketTriggerQuery);
+    }
 }


### PR DESCRIPTION
### Description
add field based correlation rules support in correlation engine.

e.g., sample correlation rule with group by field
```
POST /_plugins/_security_analytics/correlation/rules
{
  "correlate": [
    {
      "index": "windows5",
      "field": "SourceIp",
      "category": "windows"
    },
    {
      "index": "vpc_flow1",
      "category": "vpcflow",
      "field": "netflow.srcaddr"
    }
  ],
  "name": "vpcflow to windows",
  "time_window": 300000
}
```

sample correlation rule with group by field & filter query
```
{
  "correlate": [
    {
      "index": "cloudtrail-5",
      "query": "eventName:CreateUser",
      "field": "requestParameters.userName",
      "category": "cloudtrail"
    },
    {
      "index": "cloudtrail-5",
      "category": "cloudtrail",
      "query": "eventName:DeleteUser",
      "field": "requestParameters.userName"
    }
  ],
  "name": "cloudtrail create to delete account",
  "time_window": 600000
}
```

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
