### PR TITLE
#709 Return empty response for empty mappings and no applied aliases

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
@@ -330,17 +330,10 @@ public class MapperService {
                         }
                     }
 
-                    if (appliedAliases.size() == 0) {
-                        actionListener.onFailure(SecurityAnalyticsException.wrap(
-                                new OpenSearchStatusException("No applied aliases found", RestStatus.NOT_FOUND))
-                        );
-                        return;
-                    }
-
-                    // Traverse mappings and do copy with excluded type=alias properties
-                    MappingsTraverser mappingsTraverser = new MappingsTraverser(mappingMetadata);
-                    // Resulting mapping after filtering
-                    Map<String, Object> filteredMapping = mappingsTraverser.traverseAndCopyWithFilter(appliedAliases);
+                        // Traverse mappings and do copy with excluded type=alias properties
+                        MappingsTraverser mappingsTraverser = new MappingsTraverser(mappingMetadata);
+                        // Resulting mapping after filtering
+                        Map<String, Object> filteredMapping = mappingsTraverser.traverseAndCopyWithFilter(appliedAliases);
 
 
                     // Construct filtered mappings and return them as result

--- a/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
@@ -330,11 +330,10 @@ public class MapperService {
                         }
                     }
 
-                        // Traverse mappings and do copy with excluded type=alias properties
-                        MappingsTraverser mappingsTraverser = new MappingsTraverser(mappingMetadata);
-                        // Resulting mapping after filtering
-                        Map<String, Object> filteredMapping = mappingsTraverser.traverseAndCopyWithFilter(appliedAliases);
-
+                    // Traverse mappings and do copy with excluded type=alias properties
+                    MappingsTraverser mappingsTraverser = new MappingsTraverser(mappingMetadata);
+                    // Resulting mapping after filtering
+                    Map<String, Object> filteredMapping = mappingsTraverser.traverseAndCopyWithFilter(appliedAliases);
 
                     // Construct filtered mappings and return them as result
                     ImmutableOpenMap.Builder<String, MappingMetadata> outIndexMappings = ImmutableOpenMap.builder();

--- a/src/main/java/org/opensearch/securityanalytics/mapper/MappingsTraverser.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MappingsTraverser.java
@@ -5,23 +5,23 @@
 
 package org.opensearch.securityanalytics.mapper;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.ListIterator;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.mapper.MapperService;
-import org.opensearch.securityanalytics.rules.condition.ConditionListener;
 
 import java.io.IOException;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.HashMap;
@@ -38,6 +38,8 @@ import static org.opensearch.securityanalytics.mapper.MapperUtils.ALIAS;
  * can be setup, to skip any nodes which contains them, during traversal
  */
 public class MappingsTraverser {
+
+    private static final Logger log = LogManager.getLogger(MappingsTraverser.class);
 
     /**
      * Traverser listener used to process leaves
@@ -157,7 +159,10 @@ public class MappingsTraverser {
         try {
 
             Map<String, Object> rootProperties = (Map<String, Object>) this.mappingsMap.get(PROPERTIES);
-            rootProperties.forEach((k, v) -> nodeStack.push(new Node(Map.of(k, v), null, rootProperties, "", "")));
+
+            if (Objects.nonNull(rootProperties)) {
+                rootProperties.forEach((k, v) -> nodeStack.push(new Node(Map.of(k, v), null, rootProperties, "", "")));
+            }
 
             while (nodeStack.size() > 0) {
                 Node node = nodeStack.pop();
@@ -193,6 +198,7 @@ public class MappingsTraverser {
             // This is coming from listeners.
             throw e;
         } catch (Exception e) {
+            log.error("Error traversing mappings tree", e);
             notifyError("Error traversing mappings tree");
         }
     }

--- a/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
@@ -67,6 +67,27 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
         assertTrue(respMap.containsKey(testIndexPattern));
     }
 
+    // Tests the case when the mappings map is empty
+    public void testGetMappings_emptyIndex_Success() throws IOException {
+        String testIndexName1 = "my_index_1";
+        String testIndexName2 = "my_index_2";
+        String testIndexPattern = "my_index*";
+
+        createSampleIndex(testIndexName1);
+        createSampleIndex(testIndexName2);
+
+        Request request = new Request("GET", MAPPER_BASE_URI + "?index_name=" + testIndexPattern);
+        Response response = client().performRequest(request);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+        Map<String, Object> respMap = (Map<String, Object>) responseAsMap(response);
+        Map<String, Object> props = (Map<String, Object>)((Map<String, Object>) respMap.get(testIndexPattern)).get("mappings");
+
+        // Assert that indexName returned is one passed by user
+        assertTrue(respMap.containsKey(testIndexPattern));
+        //Assert that mappings map is also present in the output
+        assertTrue(props.containsKey("properties"));
+    }
+
     public void testGetMappingSuccess_1() throws IOException {
         String testIndexName1 = "my_index_1";
         String testIndexPattern = "my_index*";
@@ -234,13 +255,14 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(1L, searchResponse.getHits().getTotalHits().value);
     }
 
+    // Tests the case when alias mappings are not present on the index
     public void testUpdateAndGetMapping_notFound_Success() throws IOException {
 
         String testIndexName = "my_index";
 
         createSampleIndex(testIndexName);
 
-        // Execute UpdateMappingsAction to add alias mapping for index
+        // Execute UpdateMappingsAction to add other settings except alias mapping for index
         Request updateRequest = new Request("PUT", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
         // both req params and req body are supported
         updateRequest.setJsonEntity(
@@ -248,21 +270,20 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
                         "  \"field\":\"netflow.source_transport_port\","+
                         "  \"alias\":\"\\u0000\" }"
         );
-        // request.addParameter("indexName", testIndexName);
-        // request.addParameter("ruleTopic", "netflow");
+
         Response response = client().performRequest(updateRequest);
         assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
 
         // Execute GetIndexMappingsAction and verify mappings
         Request getRequest = new Request("GET", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
         getRequest.addParameter("index_name", testIndexName);
-        try {
-            client().performRequest(getRequest);
-            fail();
-        } catch (ResponseException e) {
-            assertEquals(HttpStatus.SC_NOT_FOUND, e.getResponse().getStatusLine().getStatusCode());
-            assertTrue(e.getMessage().contains("No applied aliases found"));
-        }
+        response = client().performRequest(getRequest);
+        XContentParser parser = createParser(JsonXContent.jsonXContent, new String(response.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8));
+        assertTrue(
+                (((Map)((Map)parser.map()
+                        .get(testIndexName))
+                        .get("mappings"))
+                        .containsKey("properties")));
     }
 
     public void testExistingMappingsAreUntouched() throws IOException {


### PR DESCRIPTION

### Description
Returns an empty response instead of exception in case of:

1. empty index mappings are present,
2. no applied aliases are present on the index
 
### Issues Resolved
#709 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
