### PR TITLE
Allow deletion of custom log type if custom rule index is missing

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteRuleAction.java
@@ -227,6 +227,7 @@ public class TransportDeleteRuleAction extends HandledTransportAction<DeleteRule
             new DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
                 .source(Rule.CUSTOM_RULES_INDEX)
                 .filter(QueryBuilders.matchQuery("_id", ruleId))
+                .refresh(true)
                 .execute(new ActionListener<>() {
                     @Override
                     public void onResponse(BulkByScrollResponse response) {

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/CustomLogTypeRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/CustomLogTypeRestApiIT.java
@@ -387,6 +387,64 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
         });
     }
 
+   @SuppressWarnings("unchecked")
+    public void testEditACustomLogTypeNameWhenCustomRuleIndexMissing() throws IOException {
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.CUSTOM_LOG_TYPE_URI, Collections.emptyMap(), toHttpEntity(customLogType));
+        Assert.assertEquals("Create custom log type failed", RestStatus.CREATED, restStatus(createResponse));
+
+        Map<String, Object> responseBody = asMap(createResponse);
+        String logTypeId = responseBody.get("_id").toString();
+        Assert.assertEquals(customLogType.getDescription(), ((Map<String, Object>) responseBody.get("logType")).get("description"));
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+                "{ \"index_name\":\"" + index + "\"," +
+                        "  \"rule_topic\":\"" + customLogType.getName() + "\", " +
+                        "  \"partial\":true, " +
+                        "  \"alias_mappings\":{}" +
+                        "}"
+        );
+
+        Response response = client().performRequest(createMappingRequest);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        String rule = randomRule();
+
+        createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.RULE_BASE_URI, Collections.singletonMap("category", customLogType.getName()),
+                new StringEntity(rule), new BasicHeader("Content-Type", "application/json"));
+        Assert.assertEquals("Create rule failed", RestStatus.CREATED, restStatus(createResponse));
+
+        responseBody = asMap(createResponse);
+        String createdId = responseBody.get("_id").toString();
+
+        DetectorInput input = new DetectorInput("custom log type detector for security analytics", List.of(index), List.of(new DetectorRule(createdId)),
+                List.of());
+        Detector detector = randomDetectorWithInputs(List.of(input), customLogType.getName());
+
+        createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+        Assert.assertEquals("Create detector successful", RestStatus.CREATED, restStatus(createResponse));
+
+        responseBody = asMap(createResponse);
+        createdId = responseBody.get("_id").toString();
+
+        Response deleteResponse = makeRequest(client(), "DELETE", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + createdId, Collections.emptyMap(), null);
+        Assert.assertEquals("Delete detector successful", RestStatus.OK, restStatus(deleteResponse));
+
+        makeRequest(client(), "DELETE",  "/.opensearch-sap-custom-rules-config", Collections.emptyMap(), new StringEntity(""));
+
+       customLogType = TestHelpers.randomCustomLogType("test", null, "Access Management", "Custom");
+       Response updatedResponse = makeRequest(client(), "PUT", SecurityAnalyticsPlugin.CUSTOM_LOG_TYPE_URI + "/" + logTypeId, Collections.emptyMap(), toHttpEntity(customLogType));
+       Assert.assertEquals("Update custom log type successful", RestStatus.OK, restStatus(updatedResponse));
+
+       responseBody = asMap(updatedResponse);
+       Assert.assertEquals(customLogType.getCategory(), ((Map<String, Object>) responseBody.get("logType")).get("category"));
+   }
+
     @SuppressWarnings("unchecked")
     public void testEditACustomLogTypeName() throws IOException, InterruptedException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
@@ -594,7 +652,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
         createdId = responseBody.get("_id").toString();
 
         Response deleteResponse = makeRequest(client(), "DELETE", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + createdId, Collections.emptyMap(), null);
-        Assert.assertEquals("Delete detector failed", RestStatus.OK, restStatus(deleteResponse));
+        Assert.assertEquals("Delete detector successful", RestStatus.OK, restStatus(deleteResponse));
 
         makeRequest(client(), "DELETE",  "/.opensearch-sap-custom-rules-config", Collections.emptyMap(), new StringEntity(""));
 


### PR DESCRIPTION
### Description
In the case when the detector index is present, but the custom rule index is missing, we want to allow the deletion of custom log types to be successful instead of throwing an error.
 
### Issues Resolved
#700 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
