### PR TITLE
Fix tests for sigma rule with null condition for 2.11

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
@@ -131,7 +131,7 @@ public class OSQueryBackend extends QueryBackend {
         this.reEscapeChar = "\\";
         this.reExpression = "%s: /%s/";
         this.cidrExpression = "%s: \"%s\"";
-        this.fieldNullExpression = "%s: null";
+        this.fieldNullExpression = "%s: (NOT [* TO *])";
         this.unboundValueStrExpression = "\"%s\"";
         this.unboundValueNumExpression = "\"%s\"";
         this.unboundWildcardExpression = "%s";

--- a/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
@@ -288,7 +288,7 @@ public class QueryBackendTests extends OpenSearchTestCase {
                         "                sel:\n" +
                         "                    fieldA1: null\n" +
                         "                condition: sel", false));
-        Assert.assertEquals("mappedA: null", queries.get(0).toString());
+        Assert.assertEquals("mappedA: (NOT [* TO *])", queries.get(0).toString());
     }
 
     public void testConvertValueRegex() throws IOException, SigmaError {
@@ -531,7 +531,7 @@ public class QueryBackendTests extends OpenSearchTestCase {
                         "                        - value2\n" +
                         "                        - null\n" +
                         "                condition: sel", false));
-        Assert.assertEquals("(mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: null)", queries.get(0).toString());
+        Assert.assertEquals("(mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: (NOT [* TO *]))", queries.get(0).toString());
     }
 
     public void testConvertOrInListNumbers() throws IOException, SigmaError {


### PR DESCRIPTION
### Description
Fix integ test and unit tests for sigma rule with null condition in 2.11
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
