### PR TITLE
Fix duplicate ecs mappings which returns incorrect log index field in mapping view API (#786)

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
@@ -481,6 +481,7 @@ public class MapperService {
                             String rawPath = requiredField.getRawField();
                             String ocsfPath = requiredField.getOcsf();
                             if (allFieldsFromIndex.contains(rawPath)) {
+                                // if the alias was already added into applyable aliases, then skip to avoid duplicates
                                 if (!applyableAliases.contains(alias) && !applyableAliases.contains(rawPath)) {
                                     if (alias != null) {
                                         // Maintain list of found paths in index
@@ -503,7 +504,10 @@ public class MapperService {
                             }
                         }
 
+                        // turn unmappedFieldAliases into a set to remove duplicates
                         Set<String> setOfUnmappedFieldAliases = new HashSet<>(unmappedFieldAliases);
+
+                        // filter out aliases that were included in applyableAliases already
                         List<String> filteredUnmappedFieldAliases = setOfUnmappedFieldAliases.stream()
                                 .filter(e -> applyableAliases.contains(e) == false)
                                 .collect(Collectors.toList());
@@ -514,7 +518,9 @@ public class MapperService {
                             if (allFieldsFromIndex.contains(mapping.getOcsf())) {
                                 aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf()));
                             } else if (mapping.getEcs() != null) {
+                                // check if aliasMappingFields already contains a key
                                 if (aliasMappingFields.containsKey(mapping.getEcs())) {
+                                    // if the pathOfApplyableAliases contains the raw field, then override the existing map
                                     if (pathsOfApplyableAliases.contains(mapping.getRawField())){
                                         aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getRawField()));
                                     }

--- a/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
@@ -503,7 +503,8 @@ public class MapperService {
                             }
                         }
 
-                        List<String> filteredUnmappedFieldAliases = unmappedFieldAliases.stream()
+                        Set<String> setOfUnmappedFieldAliases = new HashSet<>(unmappedFieldAliases);
+                        List<String> filteredUnmappedFieldAliases = setOfUnmappedFieldAliases.stream()
                                 .filter(e -> applyableAliases.contains(e) == false)
                                 .collect(Collectors.toList());
 
@@ -514,7 +515,7 @@ public class MapperService {
                                 aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf()));
                             } else if (mapping.getEcs() != null) {
                                 if (aliasMappingFields.containsKey(mapping.getEcs())) {
-                                    if (pathsOfApplyableAliases.contains(mapping.getRawField())) {
+                                    if (pathsOfApplyableAliases.contains(mapping.getRawField())){
                                         aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getRawField()));
                                     }
                                 } else {

--- a/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
@@ -395,6 +395,7 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
     }
 
+    // Tests mappings where multiple raw fields correspond to one ecs value
     public void testGetMappingsViewWindowsSuccess() throws IOException {
 
         String testIndexName = "get_mappings_view_index";
@@ -459,6 +460,7 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
         assert(!filteredUnmappedFieldAliases.contains("winlog.event_id"));
     }
 
+    // Tests mappings where multiple raw fields correspond to one ecs value and all fields are present in the index
     public void testGetMappingsViewMulitpleRawFieldsSuccess() throws IOException {
 
         String testIndexName = "get_mappings_view_index";
@@ -469,7 +471,6 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
                 "  \"EventId\": 2," +
                 "  \"event_uid\": 3" +
                 "}";
-
         indexDoc(testIndexName, "1", sampleDoc);
 
         // Execute GetMappingsViewAction to add alias mapping for index
@@ -500,8 +501,6 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
         assert(!filteredUnmappedFieldAliases.contains("winlog.provider_name"));
         assert(!filteredUnmappedFieldAliases.contains("host.hostname"));
         assert(!filteredUnmappedFieldAliases.contains("winlog.event_id"));
-        List<HashMap<String, Object>> iocFieldsList = (List<HashMap<String, Object>>) respMap.get(GetMappingsViewResponse.THREAT_INTEL_FIELD_ALIASES);
-        assertEquals(iocFieldsList.size(), 1);
     }
 
     public void testCreateMappings_withDatastream_success() throws IOException {

--- a/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
@@ -409,17 +409,97 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
         Response response = client().performRequest(request);
         assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
         Map<String, Object> respMap = responseAsMap(response);
+
         // Verify alias mappings
         Map<String, Object> props = (Map<String, Object>) respMap.get("properties");
-        assertEquals(2, props.size());
+        assertEquals(3, props.size());
+        assertTrue(props.containsKey("winlog.event_data.LogonType"));
+        assertTrue(props.containsKey("winlog.provider_name"));
         assertTrue(props.containsKey("host.hostname"));
-        assertTrue(props.containsKey("winlog.event_id"));
+
         // Verify unmapped index fields
         List<String> unmappedIndexFields = (List<String>) respMap.get("unmapped_index_fields");
-        assertEquals(4, unmappedIndexFields.size());
+        assertEquals(3, unmappedIndexFields.size());
+        assert(unmappedIndexFields.contains("plain1"));
+        assert(unmappedIndexFields.contains("ParentUser.first"));
+        assert(unmappedIndexFields.contains("ParentUser.last"));
+
         // Verify unmapped field aliases
         List<String> filteredUnmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
-        assertEquals(203, filteredUnmappedFieldAliases.size());
+        assertEquals(191, filteredUnmappedFieldAliases.size());
+        assert(!filteredUnmappedFieldAliases.contains("winlog.event_data.LogonType"));
+        assert(!filteredUnmappedFieldAliases.contains("winlog.provider_name"));
+        assert(!filteredUnmappedFieldAliases.contains("host.hostname"));
+        List<HashMap<String, Object>> iocFieldsList = (List<HashMap<String, Object>>) respMap.get(GetMappingsViewResponse.THREAT_INTEL_FIELD_ALIASES);
+        assertEquals(iocFieldsList.size(), 1);
+
+        // Index a doc for a field with multiple raw fields corresponding to one ecs field
+        indexDoc(testIndexName, "1", "{ \"EventID\": 1 }");
+        // Execute GetMappingsViewAction to add alias mapping for index
+        request = new Request("GET", SecurityAnalyticsPlugin.MAPPINGS_VIEW_BASE_URI);
+        // both req params and req body are supported
+        request.addParameter("index_name", testIndexName);
+        request.addParameter("rule_topic", "windows");
+        response = client().performRequest(request);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+        respMap = responseAsMap(response);
+
+        // Verify alias mappings
+        props = (Map<String, Object>) respMap.get("properties");
+        assertEquals(4, props.size());
+        assertTrue(props.containsKey("winlog.event_id"));
+
+        // verify unmapped index fields
+        unmappedIndexFields = (List<String>) respMap.get("unmapped_index_fields");
+        assertEquals(3, unmappedIndexFields.size());
+
+        // verify unmapped field aliases
+        filteredUnmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
+        assertEquals(190, filteredUnmappedFieldAliases.size());
+        assert(!filteredUnmappedFieldAliases.contains("winlog.event_id"));
+    }
+
+    public void testGetMappingsViewMulitpleRawFieldsSuccess() throws IOException {
+
+        String testIndexName = "get_mappings_view_index";
+
+        createSampleWindex(testIndexName);
+        String sampleDoc = "{" +
+                "  \"EventID\": 1," +
+                "  \"EventId\": 2," +
+                "  \"event_uid\": 3" +
+                "}";
+
+        indexDoc(testIndexName, "1", sampleDoc);
+
+        // Execute GetMappingsViewAction to add alias mapping for index
+        Request request = new Request("GET", SecurityAnalyticsPlugin.MAPPINGS_VIEW_BASE_URI);
+        // both req params and req body are supported
+        request.addParameter("index_name", testIndexName);
+        request.addParameter("rule_topic", "windows");
+        Response response = client().performRequest(request);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+        Map<String, Object> respMap = responseAsMap(response);
+
+        // Verify alias mappings
+        Map<String, Object> props = (Map<String, Object>) respMap.get("properties");
+        assertEquals(4, props.size());
+        assertTrue(props.containsKey("winlog.event_data.LogonType"));
+        assertTrue(props.containsKey("winlog.provider_name"));
+        assertTrue(props.containsKey("host.hostname"));
+        assertTrue(props.containsKey("winlog.event_id"));
+
+        // Verify unmapped index fields
+        List<String> unmappedIndexFields = (List<String>) respMap.get("unmapped_index_fields");
+        assertEquals(5, unmappedIndexFields.size());
+
+        // Verify unmapped field aliases
+        List<String> filteredUnmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
+        assertEquals(190, filteredUnmappedFieldAliases.size());
+        assert(!filteredUnmappedFieldAliases.contains("winlog.event_data.LogonType"));
+        assert(!filteredUnmappedFieldAliases.contains("winlog.provider_name"));
+        assert(!filteredUnmappedFieldAliases.contains("host.hostname"));
+        assert(!filteredUnmappedFieldAliases.contains("winlog.event_id"));
         List<HashMap<String, Object>> iocFieldsList = (List<HashMap<String, Object>>) respMap.get(GetMappingsViewResponse.THREAT_INTEL_FIELD_ALIASES);
         assertEquals(iocFieldsList.size(), 1);
     }
@@ -1314,15 +1394,12 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
     private void createSampleWindex(String indexName, Settings settings, String aliases) throws IOException {
         String indexMapping =
                 "    \"properties\": {" +
-//                        "        \"EventId\": {" +
-//                        "          \"type\": \"integer\"" +
-//                        "        }," +
-                        "        \"EventID\": {" +
+                        "        \"LogonType\": {" +
                         "          \"type\": \"integer\"" +
                         "        }," +
-//                        "        \"event_uid\": {" +
-//                        "          \"type\": \"integer\"" +
-//                        "        }," +
+                        "        \"Provider\": {" +
+                        "          \"type\": \"text\"" +
+                        "        }," +
                         "        \"hostname\": {" +
                         "          \"type\": \"text\"" +
                         "        }," +
@@ -1356,11 +1433,10 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
 
         createIndex(indexName, settings, indexMapping, aliases);
 
-        // Insert sample doc
+        // Insert sample doc with event_uid not explicitly mapped
         String sampleDoc = "{" +
-//                "  \"EventId\":1," +
-                "  \"EventID\":2," +
-                "  \"event_uid\":3," +
+                "  \"LogonType\":1," +
+                "  \"Provider\":\"Microsoft-Windows-Security-Auditing\"," +
                 "  \"hostname\":\"FLUXCAPACITOR\"" +
                 "}";
 

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/OCSFDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/OCSFDetectorRestApiIT.java
@@ -436,7 +436,7 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(20, unmappedIndexFields.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
-        assertEquals(25, unmappedFieldAliases.size());
+        assertEquals(24, unmappedFieldAliases.size());
     }
 
     @SuppressWarnings("unchecked")
@@ -502,7 +502,7 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(17, unmappedIndexFields.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
-        assertEquals(26, unmappedFieldAliases.size());
+        assertEquals(25, unmappedFieldAliases.size());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Description
An ecs field may have multiple raw fields associated with it. Currently, in the `getMappingsView` api, the ecs field will only map to one raw field. The new implementation will automatically map the ecs field to whatever field is present in the index. If multiple raw fields are present in an index, it will automatically map to one of the raw fields and add the other(s) into the `unmappedIndexFields` list.
 
This PR also removes duplicates from the `unmappedFieldAliases` list.

### Issues Resolved
#786 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
