### PR TITLE
Delete detector successfully if workflow is missing

### DIFF
--- a/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
+++ b/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
@@ -403,6 +403,14 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
         return makeRequest(client, "POST", String.format(Locale.getDefault(), "/_plugins/_alerting/workflows/%s/_execute", workflowId), params, null);
     }
 
+    protected Response deleteAlertingWorkflow(String workflowId) throws IOException {
+        return deleteAlertingWorkflow(client(), workflowId);
+    }
+
+    protected Response deleteAlertingWorkflow(RestClient client, String workflowId) throws IOException {
+        return makeRequest(client, "DELETE", String.format(Locale.getDefault(), "/_plugins/_alerting/workflows/%s", workflowId), new HashMap<>(), null);
+    }
+
     protected List<SearchHit> executeSearch(String index, String request) throws IOException {
         return executeSearch(index, request, true);
     }

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
@@ -23,6 +23,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.client.ResponseException;
 import org.opensearch.commons.alerting.model.IntervalSchedule;
 import org.opensearch.commons.alerting.model.Monitor.MonitorType;
+import org.opensearch.commons.alerting.model.ScheduledJob;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.search.SearchHit;
@@ -72,10 +73,34 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
     @SuppressWarnings("unchecked")
     public void testDeletingADetector_MonitorNotExists() throws IOException {
         updateClusterSetting(ENABLE_WORKFLOW_USAGE.getKey(), "false");
-        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+        final String detectorId = setupDetector();
+        final Map<String, Object> detectorSourceAsMap = getDetectorSourceAsMap(detectorId);
+
+        final String monitorId = ((List<String>) detectorSourceAsMap.get("monitor_id")).get(0);
+        final Response deleteMonitorResponse = deleteAlertingMonitor(monitorId);
+        assertEquals(200, deleteMonitorResponse.getStatusLine().getStatusCode());
+        entityAsMap(deleteMonitorResponse);
+
+        validateDetectorDeletion(detectorId);
+    }
+
+    public void testDeletingADetector_WorkflowUsageEnabled_WorkflowDoesntExist() throws IOException {
+        final String detectorId = setupDetector();
+        final Map<String, Object> detectorSourceAsMap = getDetectorSourceAsMap(detectorId);
+
+        final String workflowId = ((List<String>) detectorSourceAsMap.get("workflow_ids")).get(0);
+        final Response deleteWorkflowResponse = deleteAlertingWorkflow(workflowId);
+        assertEquals(200, deleteWorkflowResponse.getStatusLine().getStatusCode());
+        entityAsMap(deleteWorkflowResponse);
+
+        validateDetectorDeletion(detectorId);
+    }
+
+    private String setupDetector() throws IOException {
+        final String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
         // Execute CreateMappingsAction to add alias mapping for index
-        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        final Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
         // both req params and req body are supported
         createMappingRequest.setJsonEntity(
                 "{ \"index_name\":\"" + index + "\"," +
@@ -84,31 +109,39 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
                         "}"
         );
 
-        Response response = client().performRequest(createMappingRequest);
+        final Response response = client().performRequest(createMappingRequest);
         assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
-        // Create detector #1 of type test_windows
-        Detector detector1 = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of(), List.of())));
-        String detectorId1 = createDetector(detector1);
+        // Create detector of type test_windows
+        final DetectorTrigger detectorTrigger = new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()),
+                List.of(), List.of(), List.of(), List.of(), List.of());
+        final Detector detector = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(detectorTrigger));
+        return createDetector(detector);
+    }
 
-        String request = "{\n" +
+    private Map<String, Object> getDetectorSourceAsMap(final String detectorId) throws IOException {
+        final String request = getDetectorQuery(detectorId);
+        final List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        final SearchHit hit = hits.get(0);
+        return (Map<String, Object>) hit.getSourceAsMap().get("detector");
+    }
+
+    private String getDetectorQuery(final String detectorId) {
+        return "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match\":{\n" +
-                "        \"_id\": \"" + detectorId1 + "\"\n" +
+                "        \"_id\": \"" + detectorId + "\"\n" +
                 "     }\n" +
                 "   }\n" +
                 "}";
-        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
-        SearchHit hit = hits.get(0);
+    }
 
-        String monitorId = ((List<String>) ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id")).get(0);
-
-        Response deleteMonitorResponse = deleteAlertingMonitor(monitorId);
-        assertEquals(200, deleteMonitorResponse.getStatusLine().getStatusCode());
-        entityAsMap(deleteMonitorResponse);
-
-        Response deleteResponse = makeRequest(client(), "DELETE", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId1, Collections.emptyMap(), null);
+    private void validateDetectorDeletion(final String detectorId) throws IOException {
+        final Response deleteResponse = makeRequest(client(), "DELETE", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId,
+                Collections.emptyMap(), null);
         Assert.assertEquals("Delete detector failed", RestStatus.OK, restStatus(deleteResponse));
-        hits = executeSearch(Detector.DETECTORS_INDEX, request);
+
+        final String request = getDetectorQuery(detectorId);
+        final List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
         Assert.assertEquals(0, hits.size());
     }
 


### PR DESCRIPTION
### Description
When workflow usage is enabled, deleting a detector after the workflow has been deleted will fail with a "Workflow not found" exception. This PR adds logic to check for a 404 on workflow deletion and proceed with detector deletion if so.
 
### Issues Resolved
Partially https://github.com/opensearch-project/security-analytics/issues/618

Related PR: https://github.com/opensearch-project/alerting/pull/1346
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [N/A] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
