### PR TITLE
Update LogTypeService.java

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -445,7 +445,8 @@ public class LogTypeService {
             isConfigIndexInitialized = false;
             Settings indexSettings = Settings.builder()
                     .put("index.hidden", true)
-                    .put("index.auto_expand_replicas", "0-all")
+                    .put("number_of_shards", 1) // Setting pri shard count to 1 to reduce sharding overhead in large clusters since this index is set to auto-expand replicas "all"
+                    .put("index.auto_expand_replicas", "0-all") 
                     .build();
 
             CreateIndexRequest createIndexRequest = new CreateIndexRequest();


### PR DESCRIPTION
Changed the index settings for the .opensearch-sap-log-types-config index from the default of 5 primary shards to 1 reduce the overall number of shards created for the index.

### Description
This change will reduce the number of tiny shards in the cluster when this system index is created.
 
### Issues Resolved
Can help some of the complaints regarding the high number of shards in this thread: https://github.com/opensearch-project/opensearch-build/issues/4285
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
