### PR TITLE
Addresses changes related to default admin credentials

### DIFF
--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - "*"
+env:
+  OPENSEARCH_INITIAL_ADMIN_PASSWORD: myStrongPassword123!
 
 jobs:
   build:
@@ -69,20 +71,20 @@ jobs:
         if: env.imagePresent == 'true'
         run: |
           cd ..
-          docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" opensearch-security-analytics:test
+          docker run -p 9200:9200 -d -p 9600:9600 -e OPENSEARCH_INITIAL_ADMIN_PASSWORD=${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} -e "discovery.type=single-node" opensearch-security-analytics:test
           sleep 120
 
       - name: Run SecurityAnalytics Test for security enabled test cases
         if: env.imagePresent == 'true'
         run: |
-          cluster_running=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure`
+          cluster_running=`curl -XGET https://localhost:9200/_cat/plugins -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} --insecure`
           echo $cluster_running
-          security=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure |grep opensearch-security|wc -l`
+          security=`curl -XGET https://localhost:9200/_cat/plugins -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} --insecure |grep opensearch-security|wc -l`
           echo $security
           if [ $security -gt 0 ]
           then
             echo "Security plugin is available"
-            ./gradlew :integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Dhttps=true -Duser=admin -Dpassword=admin
+            ./gradlew :integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Dhttps=true -Duser=admin -Dpassword=${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
           else
             echo "Security plugin is NOT available skipping this run as tests without security have already been run"
           fi


### PR DESCRIPTION
### Description
There were recent changes to admin credentials using demo configuration. `admin` is no longer an accepted password, instead a custom password needs to be supplied. This PR address that change in the security test workflow.
 
### Issues Resolved
- Resolves #831 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
