### PR TITLE
[BUG] ArrayIndexOutOfBoundsException for inconsistent detector index behavior 

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -262,7 +262,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
 
                         SearchHits hits = response.getHits();
                         // Detectors Index hits count could be more even if we fetch one
-                        if (hits.getTotalHits().value >= 1) {
+                        if (hits.getTotalHits().value >= 1 && hits.getHits().length > 0) {
                             try {
                                 SearchHit hit = hits.getAt(0);
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -261,7 +261,8 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                         }
 
                         SearchHits hits = response.getHits();
-                        if (hits.getTotalHits().value == 1) {
+                        // Detectors Index hits count could be more even if we fetch one
+                        if (hits.getTotalHits().value >= 1) {
                             try {
                                 SearchHit hit = hits.getAt(0);
 
@@ -271,6 +272,9 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                                 );
                                 Detector detector = Detector.docParse(xcp, hit.getId(), hit.getVersion());
                                 joinEngine.onSearchDetectorResponse(detector, finding);
+                            } catch (ArrayIndexOutOfBoundsException e) {
+                                log.error("ArrayIndexOutOfBoundsException for request {}", searchRequest.toString(), e);
+                                onFailures(new OpenSearchStatusException("detector not found given monitor id", RestStatus.INTERNAL_SERVER_ERROR));
                             } catch (IOException e) {
                                 onFailures(e);
                             }

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -272,10 +272,8 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                                 );
                                 Detector detector = Detector.docParse(xcp, hit.getId(), hit.getVersion());
                                 joinEngine.onSearchDetectorResponse(detector, finding);
-                            } catch (ArrayIndexOutOfBoundsException e) {
-                                log.error("ArrayIndexOutOfBoundsException for request {}", searchRequest.toString(), e);
-                                onFailures(new OpenSearchStatusException("detector not found given monitor id", RestStatus.INTERNAL_SERVER_ERROR));
                             } catch (IOException e) {
+                                log.error("IOException for request {}", searchRequest.toString(), e);
                                 onFailures(e);
                             }
                         } else {


### PR DESCRIPTION
### Description
Fixes the following issues:
1. In case the detector search request returns empty hits, the exception should be gracefully handled and checked before.
2. Case when multiple detectors are present and we are fetching only one detector.
 
### Issues Resolved
#842  
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
