### PR TITLE
Fix get mappings view API incorrectly returning ecs path

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -356,6 +356,9 @@ public class LogTypeService {
                     )) {
                         foundFieldMappingDoc = Optional.of(e);
                     }
+                    // Additional check to see if raw field path + log type combination is already in existingFieldMappings so a new one is not inserted
+                } else if (e.getId().contains(newFieldMapping.getRawField()) && e.getLogTypes().containsAll(newFieldMapping.getLogTypes())) {
+                    foundFieldMappingDoc = Optional.of(e);
                 }
             }
             if (foundFieldMappingDoc.isEmpty()) {

--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -346,19 +346,27 @@ public class LogTypeService {
         List<FieldMappingDoc> newFieldMappings = new ArrayList<>();
         fieldMappingDocs.forEach( newFieldMapping -> {
             Optional<FieldMappingDoc> foundFieldMappingDoc = Optional.empty();
-            for (FieldMappingDoc e: existingFieldMappings) {
-                if (e.getRawField().equals(newFieldMapping.getRawField())) {
+            for (FieldMappingDoc existingFieldMapping: existingFieldMappings) {
+                if (existingFieldMapping.getRawField().equals(newFieldMapping.getRawField())) {
                     if ((
-                            e.get(defaultSchemaField) != null && newFieldMapping.get(defaultSchemaField) != null &&
-                                    e.get(defaultSchemaField).equals(newFieldMapping.get(defaultSchemaField))
+                            existingFieldMapping.get(defaultSchemaField) != null && newFieldMapping.get(defaultSchemaField) != null &&
+                                    existingFieldMapping.get(defaultSchemaField).equals(newFieldMapping.get(defaultSchemaField))
                     ) || (
-                            e.get(defaultSchemaField) == null && newFieldMapping.get(defaultSchemaField) == null
+                            existingFieldMapping.get(defaultSchemaField) == null && newFieldMapping.get(defaultSchemaField) == null
                     )) {
-                        foundFieldMappingDoc = Optional.of(e);
+                        foundFieldMappingDoc = Optional.of(existingFieldMapping);
                     }
-                    // Additional check to see if raw field path + log type combination is already in existingFieldMappings so a new one is not inserted
-                } else if (e.getId().contains(newFieldMapping.getRawField()) && e.getLogTypes().containsAll(newFieldMapping.getLogTypes())) {
-                    foundFieldMappingDoc = Optional.of(e);
+                    // Grabs the right side of the ID with "|" as the delimiter if present representing the ecs field from predefined mappings
+                    // Additional check to see if raw field path + log type combination is already in existingFieldMappings so a new one is not indexed
+                } else {
+                    String id = existingFieldMapping.getId();
+                    int indexOfPipe = id.indexOf("|");
+                    if (indexOfPipe != -1) {
+                        String ecsIdField = id.substring(indexOfPipe + 1);
+                        if (ecsIdField.equals(newFieldMapping.getRawField()) && existingFieldMapping.getLogTypes().containsAll(newFieldMapping.getLogTypes())) {
+                            foundFieldMappingDoc = Optional.of(existingFieldMapping);
+                        }
+                    }
                 }
             }
             if (foundFieldMappingDoc.isEmpty()) {

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -259,6 +259,35 @@ public class TestHelpers {
                 "level: high";
     }
 
+    public static String randomRuleWithRawField() {
+        return "title: Remote Encrypting File System Abuse\n" +
+                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
+                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
+                "references:\n" +
+                "    - https://attack.mitre.org/tactics/TA0008/\n" +
+                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
+                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
+                "    - https://github.com/zeronetworks/rpcfirewall\n" +
+                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
+                "tags:\n" +
+                "    - attack.defense_evasion\n" +
+                "status: experimental\n" +
+                "author: Sagie Dulce, Dekel Paz\n" +
+                "date: 2022/01/01\n" +
+                "modified: 2022/01/01\n" +
+                "logsource:\n" +
+                "    product: rpc_firewall\n" +
+                "    category: application\n" +
+                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
+                "detection:\n" +
+                "    selection:\n" +
+                "        eventName: testinghere\n" +
+                "    condition: selection\n" +
+                "falsepositives:\n" +
+                "    - Legitimate usage of remote file encryption\n" +
+                "level: high";
+    }
+
     public static String randomRuleWithNotCondition() {
         return "title: Remote Encrypting File System Abuse\n" +
                 "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +


### PR DESCRIPTION
### Description
Currently the get mappings view api incorrectly returns the ecs path for logs with ocsf or raw field types if a custom rule is created using a raw field. This is because whenever a new rule is created, the rule field(s) gets indexed into `.opensearch-sap-log-types-config` index along with the log_type (ex. below). However, because there are already preset mappings defined for certain log types like `cloudtrail`, the raw_field, ecs, and ocsf mappings are already defined in this index. Then when the get Mappings view API is called, the new document from the custom rule overwrites the existing predefined mapping which causes the ecs format to be incorrectly returned.

```
{
        "_index": ".opensearch-sap-log-types-config",
        "_id": "aws.cloudtrail.event_name|",
        "_score": 1,
        "_source": {
          "raw_field": "aws.cloudtrail.event_name",
          "log_types": [
            "cloudtrail"
          ]
        }
}
```

This PR performs additional logic to check whether or not the raw field from the custom rule already exists in the `existingFieldMappings` (i.e. if this is a known mapping that is predefined in the index). If it is defined, then it doesn't add a the new mapping into the `.opensearch-sap-log-types-config` index. 

The integ test ensures that the mappings view API returns the same output before and after a custom rule with a raw field is created to verify that the correct path is returned.

### Issues Resolved
#866 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
