### PR TITLE
Fixing hanging tasks for correlations

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.ResourceNotFoundException;
 import org.opensearch.cluster.routing.Preference;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.ActionRequest;
@@ -517,6 +518,11 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                 client.search(searchRequest, new ActionListener<>() {
                     @Override
                     public void onResponse(SearchResponse response) {
+                        if (response.getHits().getHits().length == 0) {
+                            onFailures(new ResourceNotFoundException(
+                                    "Failed to find hits in metadata index for finding id {}", request.getFinding().getId()));
+                        }
+
                         String id = response.getHits().getHits()[0].getId();
                         Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
                         long scoreTimestamp = (long) hitSource.get("scoreTimestamp");
@@ -655,6 +661,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
         }
 
         public void onFailures(Exception t) {
+            log.error("Exception occurred while processing correlations", t);
             if (counter.compareAndSet(false, true)) {
                 finishHim(t);
             }


### PR DESCRIPTION
### Description
While dealing with correlations, we noticed unexpectedly high resource consumption in CPU and JVM, resulting in node drops. Upon closer examination, we found a subset of subscribe/findings tasks consistently in a hanging state throughout the data node's lifecycle until it either dropped or required manual restart. This information can be corroborated through the _cat/tasks API. 

The root cause of these hanging tasks was the way action listeners handle exceptions today, causing the parent listener to not close in some cases, if the exceptions are not caught correctly.

In this specific case, the exception causing the contention of resources was:
`
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
        at org.opensearch.securityanalytics.correlation.VectorEmbeddingsEngine$1$1.onResponse(VectorEmbeddingsEngine.java:142)
        at org.opensearch.securityanalytics.correlation.VectorEmbeddingsEngine$1$1.onResponse(VectorEmbeddingsEngine.java:115)
        at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:113)
        at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:107)
        at org.opensearch.action.search.TransportMultiSearchAction$1.finish(TransportMultiSearchAction.java:209)
        at org.opensearch.action.search.TransportMultiSearchAction$1.handleResponse(TransportMultiSearchAction.java:195)
        at org.opensearch.action.search.TransportMultiSearchAction$1.onResponse(TransportMultiSearchAction.java:183)
        at org.opensearch.action.search.TransportMultiSearchAction$1.onResponse(TransportMultiSearchAction.java:180)
        at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:113)
        at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:107)
        at org.opensearch.performanceanalyzer.action.PerformanceAnalyzerActionListener.onResponse(PerformanceAnalyzerActionListener.java:55)
        at org.opensearch.action.support.TimeoutTaskCancellationUtility$TimeoutRunnableListener.onResponse(TimeoutTaskCancellationUtility.java:132)
`

This will PR will be followed up by two more solutions:
1. Fix the working of child action listeners across Security Analytics to handle the closing of parent listener tasks correctly
2. Analyze and see how the methods 'getHits().length`and `getTotalHits().value` are different and if we need to modify the way the search requests have been created in order to restore this usage in future.

### Issues Resolved
This PR aims to fix the current exception being thrown by using `getHits().length` instead of `getTotalHits().value` as a mitigation to avoid any tasks to hang.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
