### PR TITLE
Refactor invocation of Action listeners in correlations

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
@@ -91,7 +91,7 @@ public class JoinEngine {
                 onAutoCorrelations(detector, finding, Map.of());
             }
         } catch (IOException ex) {
-            correlateFindingAction.onFailures(ex);
+            onFailure(ex);
         }
     }
 
@@ -114,102 +114,86 @@ public class JoinEngine {
 
         SearchRequest request = new SearchRequest();
         request.source(searchSourceBuilder);
-        logTypeService.searchLogTypes(request, new ActionListener<>() {
-            @Override
-            public void onResponse(SearchResponse response) {
-                MultiSearchRequest mSearchRequest = new MultiSearchRequest();
-                SearchHit[] logTypes = response.getHits().getHits();
-                List<String> logTypeNames = new ArrayList<>();
-                for (SearchHit logType: logTypes) {
-                    String logTypeName = logType.getSourceAsMap().get("name").toString();
-                    logTypeNames.add(logTypeName);
+        logTypeService.searchLogTypes(request, ActionListener.wrap(response -> {
+            MultiSearchRequest mSearchRequest = new MultiSearchRequest();
+            SearchHit[] logTypes = response.getHits().getHits();
+            List<String> logTypeNames = new ArrayList<>();
+            for (SearchHit logType: logTypes) {
+                String logTypeName = logType.getSourceAsMap().get("name").toString();
+                logTypeNames.add(logTypeName);
 
-                    RangeQueryBuilder queryBuilder = QueryBuilders.rangeQuery("timestamp")
-                            .gte(findingTimestamp - corrTimeWindow)
-                            .lte(findingTimestamp + corrTimeWindow);
+                RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery("timestamp")
+                        .gte(findingTimestamp - corrTimeWindow)
+                        .lte(findingTimestamp + corrTimeWindow);
 
-                    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-                    searchSourceBuilder.query(queryBuilder);
-                    searchSourceBuilder.size(10000);
-                    searchSourceBuilder.fetchField("queries");
-                    SearchRequest searchRequest = new SearchRequest();
-                    searchRequest.indices(DetectorMonitorConfig.getAllFindingsIndicesPattern(logTypeName));
-                    searchRequest.source(searchSourceBuilder);
-                    searchRequest.preference(Preference.PRIMARY_FIRST.type());
-                    mSearchRequest.add(searchRequest);
-                }
+                SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+                sourceBuilder.query(rangeQueryBuilder);
+                sourceBuilder.size(10000);
+                sourceBuilder.fetchField("queries");
+                SearchRequest searchRequest = new SearchRequest();
+                searchRequest.indices(DetectorMonitorConfig.getAllFindingsIndicesPattern(logTypeName));
+                searchRequest.source(sourceBuilder);
+                searchRequest.preference(Preference.PRIMARY_FIRST.type());
+                mSearchRequest.add(searchRequest);
+            }
 
-                if (!mSearchRequest.requests().isEmpty()) {
-                    client.multiSearch(mSearchRequest, new ActionListener<>() {
-                        @Override
-                        public void onResponse(MultiSearchResponse items) {
-                            MultiSearchResponse.Item[] responses = items.getResponses();
+            if (!mSearchRequest.requests().isEmpty()) {
+                client.multiSearch(mSearchRequest, ActionListener.wrap(items -> {
+                    MultiSearchResponse.Item[] responses = items.getResponses();
 
-                            Map<String, List<String>> autoCorrelationsMap = new HashMap<>();
-                            int idx = 0;
-                            for (MultiSearchResponse.Item response : responses) {
-                                if (response.isFailure()) {
-                                    log.info(response.getFailureMessage());
-                                    continue;
+                    Map<String, List<String>> autoCorrelationsMap = new HashMap<>();
+                    int idx = 0;
+                    for (MultiSearchResponse.Item item : responses) {
+                        if (item.isFailure()) {
+                            log.info(item.getFailureMessage());
+                            continue;
+                        }
+                        String logTypeName = logTypeNames.get(idx);
+
+                        SearchHit[] findings = item.getResponse().getHits().getHits();
+
+                        for (SearchHit foundFinding : findings) {
+                            if (!foundFinding.getId().equals(finding.getId())) {
+                                Set<String> findingTags = new HashSet<>();
+                                List<Map<String, Object>> queries = (List<Map<String, Object>>) foundFinding.getSourceAsMap().get("queries");
+                                for (Map<String, Object> query : queries) {
+                                    List<String> queryTags = (List<String>) query.get("tags");
+                                    findingTags.addAll(queryTags.stream().filter(queryTag -> queryTag.startsWith("attack.")).collect(Collectors.toList()));
                                 }
-                                String logTypeName = logTypeNames.get(idx);
 
-                                SearchHit[] findings = response.getResponse().getHits().getHits();
-
-                                for (SearchHit foundFinding : findings) {
-                                    if (!foundFinding.getId().equals(finding.getId())) {
-                                        Set<String> findingTags = new HashSet<>();
-                                        List<Map<String, Object>> queries = (List<Map<String, Object>>) foundFinding.getSourceAsMap().get("queries");
-                                        for (Map<String, Object> query : queries) {
-                                            List<String> queryTags = (List<String>) query.get("tags");
-                                            findingTags.addAll(queryTags.stream().filter(queryTag -> queryTag.startsWith("attack.")).collect(Collectors.toList()));
-                                        }
-
-                                        boolean canCorrelate = false;
-                                        for (String tag: tags) {
-                                            if (findingTags.contains(tag)) {
-                                                canCorrelate = true;
-                                                break;
-                                            }
-                                        }
-
-                                        Set<String> foundIntrusionSets = AutoCorrelationsRepo.validIntrusionSets(autoCorrelations, findingTags);
-                                        for (String validIntrusionSet: validIntrusionSets) {
-                                            if (foundIntrusionSets.contains(validIntrusionSet)) {
-                                                canCorrelate = true;
-                                                break;
-                                            }
-                                        }
-
-                                        if (canCorrelate) {
-                                            if (autoCorrelationsMap.containsKey(logTypeName)) {
-                                                autoCorrelationsMap.get(logTypeName).add(foundFinding.getId());
-                                            } else {
-                                                List<String> autoCorrelatedFindings = new ArrayList<>();
-                                                autoCorrelatedFindings.add(foundFinding.getId());
-                                                autoCorrelationsMap.put(logTypeName, autoCorrelatedFindings);
-                                            }
-                                        }
+                                boolean canCorrelate = false;
+                                for (String tag: tags) {
+                                    if (findingTags.contains(tag)) {
+                                        canCorrelate = true;
+                                        break;
                                     }
                                 }
-                                ++idx;
+
+                                Set<String> foundIntrusionSets = AutoCorrelationsRepo.validIntrusionSets(autoCorrelations, findingTags);
+                                for (String validIntrusionSet: validIntrusionSets) {
+                                    if (foundIntrusionSets.contains(validIntrusionSet)) {
+                                        canCorrelate = true;
+                                        break;
+                                    }
+                                }
+
+                                if (canCorrelate) {
+                                    if (autoCorrelationsMap.containsKey(logTypeName)) {
+                                        autoCorrelationsMap.get(logTypeName).add(foundFinding.getId());
+                                    } else {
+                                        List<String> autoCorrelatedFindings = new ArrayList<>();
+                                        autoCorrelatedFindings.add(foundFinding.getId());
+                                        autoCorrelationsMap.put(logTypeName, autoCorrelatedFindings);
+                                    }
+                                }
                             }
-                            onAutoCorrelations(detector, finding, autoCorrelationsMap);
                         }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            correlateFindingAction.onFailures(e);
-                        }
-                    });
-                }
+                        ++idx;
+                    }
+                    onAutoCorrelations(detector, finding, autoCorrelationsMap);
+                }, this::onFailure));
             }
-
-            @Override
-            public void onFailure(Exception e) {
-                correlateFindingAction.onFailures(e);
-            }
-        });
+        }, this::onFailure));
     }
 
     private void onAutoCorrelations(Detector detector, Finding finding, Map<String, List<String>> autoCorrelations) {
@@ -231,39 +215,34 @@ public class JoinEngine {
         searchRequest.source(searchSourceBuilder);
         searchRequest.preference(Preference.PRIMARY_FIRST.type());
 
-        client.search(searchRequest, new ActionListener<>() {
-            @Override
-            public void onResponse(SearchResponse response) {
-                if (response.isTimedOut()) {
-                    correlateFindingAction.onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
-                }
-
-                Iterator<SearchHit> hits = response.getHits().iterator();
-                List<CorrelationRule> correlationRules = new ArrayList<>();
-                while (hits.hasNext()) {
-                    try {
-                        SearchHit hit = hits.next();
-
-                        XContentParser xcp = XContentType.JSON.xContent().createParser(
-                                xContentRegistry,
-                                LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString()
-                        );
-
-                        CorrelationRule rule = CorrelationRule.parse(xcp, hit.getId(), hit.getVersion());
-                        correlationRules.add(rule);
-                    } catch (IOException e) {
-                        correlateFindingAction.onFailures(e);
-                    }
-                }
-
-                getValidDocuments(detectorType, indices, correlationRules, relatedDocIds, autoCorrelations);
+        client.search(searchRequest, ActionListener.wrap(response -> {
+            if (response.isTimedOut()) {
+                onFailure(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
             }
 
-            @Override
-            public void onFailure(Exception e) {
-                getValidDocuments(detectorType, indices, List.of(), List.of(), autoCorrelations);
+            Iterator<SearchHit> hits = response.getHits().iterator();
+            List<CorrelationRule> correlationRules = new ArrayList<>();
+            while (hits.hasNext()) {
+                try {
+                    SearchHit hit = hits.next();
+
+                    XContentParser xcp = XContentType.JSON.xContent().createParser(
+                            xContentRegistry,
+                            LoggingDeprecationHandler.INSTANCE,
+                            hit.getSourceAsString());
+
+                    CorrelationRule rule = CorrelationRule.parse(xcp, hit.getId(), hit.getVersion());
+                    correlationRules.add(rule);
+                } catch (IOException e) {
+                    onFailure(e);
+                }
             }
-        });
+            getValidDocuments(detectorType, indices, correlationRules, relatedDocIds, autoCorrelations);
+        }, e -> {
+            log.error("[CORRELATIONS] Exception encountered while searching correlation rule index for finding id {}",
+                    finding.getId(), e);
+            getValidDocuments(detectorType, indices, List.of(), List.of(), autoCorrelations);
+        }));
     }
 
     /**
@@ -306,84 +285,72 @@ public class JoinEngine {
         }
 
         if (!mSearchRequest.requests().isEmpty()) {
-            client.multiSearch(mSearchRequest, new ActionListener<>() {
-                @Override
-                public void onResponse(MultiSearchResponse items) {
-                    MultiSearchResponse.Item[] responses = items.getResponses();
-                    List<FilteredCorrelationRule> filteredCorrelationRules = new ArrayList<>();
+            client.multiSearch(mSearchRequest, ActionListener.wrap(items -> {
+                MultiSearchResponse.Item[] responses = items.getResponses();
+                List<FilteredCorrelationRule> filteredCorrelationRules = new ArrayList<>();
 
-                    int idx = 0;
-                    for (MultiSearchResponse.Item response : responses) {
-                        if (response.isFailure()) {
-                            log.info(response.getFailureMessage());
-                            continue;
-                        }
-
-                        if (response.getResponse().getHits().getTotalHits().value > 0L) {
-                            filteredCorrelationRules.add(new FilteredCorrelationRule(validCorrelationRules.get(idx),
-                                    response.getResponse().getHits().getHits(), validFields.get(idx)));
-                        }
-                        ++idx;
+                int idx = 0;
+                for (MultiSearchResponse.Item response : responses) {
+                    if (response.isFailure()) {
+                        log.info(response.getFailureMessage());
+                        continue;
                     }
 
-                    Map<String, List<CorrelationQuery>> categoryToQueriesMap = new HashMap<>();
-                    Map<String, Long> categoryToTimeWindowMap = new HashMap<>();
-                    for (FilteredCorrelationRule rule: filteredCorrelationRules) {
-                        List<CorrelationQuery> queries = rule.correlationRule.getCorrelationQueries();
-                        Long timeWindow = rule.correlationRule.getCorrTimeWindow();
-
-                        for (CorrelationQuery query: queries) {
-                            List<CorrelationQuery> correlationQueries;
-                            if (categoryToQueriesMap.containsKey(query.getCategory())) {
-                                correlationQueries = categoryToQueriesMap.get(query.getCategory());
-                            } else {
-                                correlationQueries = new ArrayList<>();
-                            }
-                            if (categoryToTimeWindowMap.containsKey(query.getCategory())) {
-                                categoryToTimeWindowMap.put(query.getCategory(), Math.max(timeWindow, categoryToTimeWindowMap.get(query.getCategory())));
-                            } else {
-                                categoryToTimeWindowMap.put(query.getCategory(), timeWindow);
-                            }
-
-                            if (query.getField() == null) {
-                                correlationQueries.add(query);
-                            } else {
-                                SearchHit[] hits = rule.filteredDocs;
-                                StringBuilder qb = new StringBuilder(query.getField()).append(":(");
-                                for (int i = 0; i < hits.length; ++i) {
-                                    String value = hits[i].field(rule.field).getValue();
-                                    qb.append(value);
-                                    if (i < hits.length-1) {
-                                        qb.append(" OR ");
-                                    } else {
-                                        qb.append(")");
-                                    }
-                                }
-                                if (query.getQuery() != null) {
-                                    qb.append(" AND ").append(query.getQuery());
-                                }
-                                correlationQueries.add(new CorrelationQuery(query.getIndex(), qb.toString(), query.getCategory(), null));
-                            }
-                            categoryToQueriesMap.put(query.getCategory(), correlationQueries);
-                        }
+                    if (response.getResponse().getHits().getTotalHits().value > 0L) {
+                        filteredCorrelationRules.add(new FilteredCorrelationRule(validCorrelationRules.get(idx),
+                                response.getResponse().getHits().getHits(), validFields.get(idx)));
                     }
-                    searchFindingsByTimestamp(detectorType, categoryToQueriesMap, categoryToTimeWindowMap,
-                            filteredCorrelationRules.stream().map(it -> it.correlationRule).map(CorrelationRule::getId).collect(Collectors.toList()),
-                            autoCorrelations
-                    );
+                    ++idx;
                 }
 
-                @Override
-                public void onFailure(Exception e) {
-                    correlateFindingAction.onFailures(e);
+                Map<String, List<CorrelationQuery>> categoryToQueriesMap = new HashMap<>();
+                Map<String, Long> categoryToTimeWindowMap = new HashMap<>();
+                for (FilteredCorrelationRule rule: filteredCorrelationRules) {
+                    List<CorrelationQuery> queries = rule.correlationRule.getCorrelationQueries();
+                    Long timeWindow = rule.correlationRule.getCorrTimeWindow();
+
+                    for (CorrelationQuery query: queries) {
+                        List<CorrelationQuery> correlationQueries;
+                        if (categoryToQueriesMap.containsKey(query.getCategory())) {
+                            correlationQueries = categoryToQueriesMap.get(query.getCategory());
+                        } else {
+                            correlationQueries = new ArrayList<>();
+                        }
+                        if (categoryToTimeWindowMap.containsKey(query.getCategory())) {
+                            categoryToTimeWindowMap.put(query.getCategory(), Math.max(timeWindow, categoryToTimeWindowMap.get(query.getCategory())));
+                        } else {
+                            categoryToTimeWindowMap.put(query.getCategory(), timeWindow);
+                        }
+
+                        if (query.getField() == null) {
+                            correlationQueries.add(query);
+                        } else {
+                            SearchHit[] hits = rule.filteredDocs;
+                            StringBuilder qb = new StringBuilder(query.getField()).append(":(");
+                            for (int i = 0; i < hits.length; ++i) {
+                                String value = hits[i].field(rule.field).getValue();
+                                qb.append(value);
+                                if (i < hits.length-1) {
+                                    qb.append(" OR ");
+                                } else {
+                                    qb.append(")");
+                                }
+                            }
+                            if (query.getQuery() != null) {
+                                qb.append(" AND ").append(query.getQuery());
+                            }
+                            correlationQueries.add(new CorrelationQuery(query.getIndex(), qb.toString(), query.getCategory(), null));
+                        }
+                        categoryToQueriesMap.put(query.getCategory(), correlationQueries);
+                    }
                 }
-            });
+                searchFindingsByTimestamp(detectorType, categoryToQueriesMap, categoryToTimeWindowMap,
+                        filteredCorrelationRules.stream().map(it -> it.correlationRule).map(CorrelationRule::getId).collect(Collectors.toList()),
+                        autoCorrelations
+                );
+            }, this::onFailure));
         } else {
-            if (!autoCorrelations.isEmpty()) {
-                correlateFindingAction.getTimestampFeature(detectorType, autoCorrelations, null, List.of());
-            } else {
-                correlateFindingAction.getTimestampFeature(detectorType, null, request.getFinding(), List.of());
-            }
+            getTimestampFeature(detectorType, List.of(), autoCorrelations);
         }
     }
 
@@ -415,50 +382,38 @@ public class JoinEngine {
         }
 
         if (!mSearchRequest.requests().isEmpty()) {
-            client.multiSearch(mSearchRequest, new ActionListener<>() {
-                @Override
-                public void onResponse(MultiSearchResponse items) {
-                    MultiSearchResponse.Item[] responses = items.getResponses();
-                    Map<String, DocSearchCriteria> relatedDocsMap = new HashMap<>();
+            client.multiSearch(mSearchRequest, ActionListener.wrap(items -> {
+                MultiSearchResponse.Item[] responses = items.getResponses();
+                Map<String, DocSearchCriteria> relatedDocsMap = new HashMap<>();
 
-                    int idx = 0;
-                    for (MultiSearchResponse.Item response : responses) {
-                        if (response.isFailure()) {
-                            log.info(response.getFailureMessage());
-                            continue;
-                        }
-
-                        List<String> relatedDocIds = new ArrayList<>();
-                        SearchHit[] hits = response.getResponse().getHits().getHits();
-                        for (SearchHit hit : hits) {
-                            relatedDocIds.addAll(hit.getFields().get("correlated_doc_ids").getValues().stream()
-                                    .map(Object::toString).collect(Collectors.toList()));
-                        }
-
-                        List<CorrelationQuery> correlationQueries = categoryToQueriesPairs.get(idx).getValue();
-                        List<String> indices = correlationQueries.stream().map(CorrelationQuery::getIndex).collect(Collectors.toList());
-                        List<String> queries = correlationQueries.stream().map(CorrelationQuery::getQuery).collect(Collectors.toList());
-                        relatedDocsMap.put(categoryToQueriesPairs.get(idx).getKey(),
-                                new DocSearchCriteria(
-                                        indices,
-                                        queries,
-                                        relatedDocIds));
-                        ++idx;
+                int idx = 0;
+                for (MultiSearchResponse.Item response : responses) {
+                    if (response.isFailure()) {
+                        log.info(response.getFailureMessage());
+                        continue;
                     }
-                    searchDocsWithFilterKeys(detectorType, relatedDocsMap, categoryToTimeWindowMap, correlationRules, autoCorrelations);
-                }
 
-                @Override
-                public void onFailure(Exception e) {
-                    correlateFindingAction.onFailures(e);
+                    List<String> relatedDocIds = new ArrayList<>();
+                    SearchHit[] hits = response.getResponse().getHits().getHits();
+                    for (SearchHit hit : hits) {
+                        relatedDocIds.addAll(hit.getFields().get("correlated_doc_ids").getValues().stream()
+                                .map(Object::toString).collect(Collectors.toList()));
+                    }
+
+                    List<CorrelationQuery> correlationQueries = categoryToQueriesPairs.get(idx).getValue();
+                    List<String> indices = correlationQueries.stream().map(CorrelationQuery::getIndex).collect(Collectors.toList());
+                    List<String> queries = correlationQueries.stream().map(CorrelationQuery::getQuery).collect(Collectors.toList());
+                    relatedDocsMap.put(categoryToQueriesPairs.get(idx).getKey(),
+                            new DocSearchCriteria(
+                                    indices,
+                                    queries,
+                                    relatedDocIds));
+                    ++idx;
                 }
-            });
+                searchDocsWithFilterKeys(detectorType, relatedDocsMap, categoryToTimeWindowMap, correlationRules, autoCorrelations);
+            }, this::onFailure));
         } else {
-            if (!autoCorrelations.isEmpty()) {
-                correlateFindingAction.getTimestampFeature(detectorType, autoCorrelations, null, List.of());
-            } else {
-                correlateFindingAction.getTimestampFeature(detectorType, null, request.getFinding(), correlationRules);
-            }
+            getTimestampFeature(detectorType, correlationRules, autoCorrelations);
         }
     }
 
@@ -492,42 +447,30 @@ public class JoinEngine {
         }
 
         if (!mSearchRequest.requests().isEmpty()) {
-            client.multiSearch(mSearchRequest, new ActionListener<>() {
-                @Override
-                public void onResponse(MultiSearchResponse items) {
-                    MultiSearchResponse.Item[] responses = items.getResponses();
-                    Map<String, List<String>> filteredRelatedDocIds = new HashMap<>();
+            client.multiSearch(mSearchRequest, ActionListener.wrap( items -> {
+                MultiSearchResponse.Item[] responses = items.getResponses();
+                Map<String, List<String>> filteredRelatedDocIds = new HashMap<>();
 
-                    int idx = 0;
-                    for (MultiSearchResponse.Item response : responses) {
-                        if (response.isFailure()) {
-                            log.info(response.getFailureMessage());
-                            continue;
-                        }
-
-                        SearchHit[] hits = response.getResponse().getHits().getHits();
-                        List<String> docIds = new ArrayList<>();
-
-                        for (SearchHit hit : hits) {
-                            docIds.add(hit.getId());
-                        }
-                        filteredRelatedDocIds.put(categories.get(idx), docIds);
-                        ++idx;
+                int idx = 0;
+                for (MultiSearchResponse.Item response : responses) {
+                    if (response.isFailure()) {
+                        log.info(response.getFailureMessage());
+                        continue;
                     }
-                    getCorrelatedFindings(detectorType, filteredRelatedDocIds, categoryToTimeWindowMap, correlationRules, autoCorrelations);
-                }
 
-                @Override
-                public void onFailure(Exception e) {
-                    correlateFindingAction.onFailures(e);
+                    SearchHit[] hits = response.getResponse().getHits().getHits();
+                    List<String> docIds = new ArrayList<>();
+
+                    for (SearchHit hit : hits) {
+                        docIds.add(hit.getId());
+                    }
+                    filteredRelatedDocIds.put(categories.get(idx), docIds);
+                    ++idx;
                 }
-            });
+                getCorrelatedFindings(detectorType, filteredRelatedDocIds, categoryToTimeWindowMap, correlationRules, autoCorrelations);
+            }, this::onFailure));
         } else {
-            if (!autoCorrelations.isEmpty()) {
-                correlateFindingAction.getTimestampFeature(detectorType, autoCorrelations, null, List.of());
-            } else {
-                correlateFindingAction.getTimestampFeature(detectorType, null, request.getFinding(), correlationRules);
-            }
+            getTimestampFeature(detectorType, correlationRules, autoCorrelations);
         }
     }
 
@@ -565,57 +508,57 @@ public class JoinEngine {
         }
 
         if (!mSearchRequest.requests().isEmpty()) {
-            client.multiSearch(mSearchRequest, new ActionListener<>() {
-                @Override
-                public void onResponse(MultiSearchResponse items) {
-                    MultiSearchResponse.Item[] responses = items.getResponses();
-                    Map<String, List<String>> correlatedFindings = new HashMap<>();
+            client.multiSearch(mSearchRequest, ActionListener.wrap(items -> {
+                MultiSearchResponse.Item[] responses = items.getResponses();
+                Map<String, List<String>> correlatedFindings = new HashMap<>();
 
-                    int idx = 0;
-                    for (MultiSearchResponse.Item response : responses) {
-                        if (response.isFailure()) {
-                            log.info(response.getFailureMessage());
-                            ++idx;
-                            continue;
-                        }
-
-                        SearchHit[] hits = response.getResponse().getHits().getHits();
-                        List<String> findings = new ArrayList<>();
-
-                        for (SearchHit hit : hits) {
-                            findings.add(hit.getId());
-                        }
-
-                        if (!findings.isEmpty()) {
-                            correlatedFindings.put(categories.get(idx), findings);
-                        }
+                int idx = 0;
+                for (MultiSearchResponse.Item response : responses) {
+                    if (response.isFailure()) {
+                        log.info(response.getFailureMessage());
                         ++idx;
+                        continue;
                     }
 
-                    for (Map.Entry<String, List<String>> autoCorrelation: autoCorrelations.entrySet()) {
-                        if (correlatedFindings.containsKey(autoCorrelation.getKey())) {
-                            Set<String> alreadyCorrelatedFindings = new HashSet<>(correlatedFindings.get(autoCorrelation.getKey()));
-                            alreadyCorrelatedFindings.addAll(autoCorrelation.getValue());
-                            correlatedFindings.put(autoCorrelation.getKey(), new ArrayList<>(alreadyCorrelatedFindings));
-                        } else {
-                            correlatedFindings.put(autoCorrelation.getKey(), autoCorrelation.getValue());
-                        }
+                    SearchHit[] hits = response.getResponse().getHits().getHits();
+                    List<String> findings = new ArrayList<>();
+
+                    for (SearchHit hit : hits) {
+                        findings.add(hit.getId());
                     }
-                    correlateFindingAction.initCorrelationIndex(detectorType, correlatedFindings, correlationRules);
+
+                    if (!findings.isEmpty()) {
+                        correlatedFindings.put(categories.get(idx), findings);
+                    }
+                    ++idx;
                 }
 
-                @Override
-                public void onFailure(Exception e) {
-                    correlateFindingAction.onFailures(e);
+                for (Map.Entry<String, List<String>> autoCorrelation: autoCorrelations.entrySet()) {
+                    if (correlatedFindings.containsKey(autoCorrelation.getKey())) {
+                        Set<String> alreadyCorrelatedFindings = new HashSet<>(correlatedFindings.get(autoCorrelation.getKey()));
+                        alreadyCorrelatedFindings.addAll(autoCorrelation.getValue());
+                        correlatedFindings.put(autoCorrelation.getKey(), new ArrayList<>(alreadyCorrelatedFindings));
+                    } else {
+                        correlatedFindings.put(autoCorrelation.getKey(), autoCorrelation.getValue());
+                    }
                 }
-            });
+                correlateFindingAction.initCorrelationIndex(detectorType, correlatedFindings, correlationRules);
+            }, this::onFailure));
         } else {
-            if (!autoCorrelations.isEmpty()) {
-                correlateFindingAction.getTimestampFeature(detectorType, autoCorrelations, null, List.of());
-            } else {
-                correlateFindingAction.getTimestampFeature(detectorType, null, request.getFinding(), correlationRules);
-            }
+            getTimestampFeature(detectorType, correlationRules, autoCorrelations);
         }
+    }
+
+    private void getTimestampFeature(String detectorType, List<String> correlationRules, Map<String, List<String>> autoCorrelations) {
+        if (!autoCorrelations.isEmpty()) {
+            correlateFindingAction.getTimestampFeature(detectorType, autoCorrelations, null, List.of());
+        } else {
+            correlateFindingAction.getTimestampFeature(detectorType, null, request.getFinding(), correlationRules);
+        }
+    }
+
+    private void onFailure(Exception e) {
+        correlateFindingAction.onFailures(e);
     }
 
     static class DocSearchCriteria {

--- a/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
@@ -11,13 +11,10 @@ import org.opensearch.ResourceNotFoundException;
 import org.opensearch.cluster.routing.Preference;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.bulk.BulkRequest;
-import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.index.IndexRequest;
-import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
 import org.opensearch.common.unit.TimeValue;
@@ -32,7 +29,6 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.securityanalytics.correlation.index.query.CorrelationQueryBuilder;
 import org.opensearch.securityanalytics.model.CustomLogType;
-import org.opensearch.securityanalytics.model.Detector;
 import org.opensearch.securityanalytics.transport.TransportCorrelateFindingAction;
 import org.opensearch.securityanalytics.util.CorrelationIndices;
 
@@ -62,213 +58,203 @@ public class VectorEmbeddingsEngine {
     }
 
     public void insertCorrelatedFindings(String detectorType, Finding finding, String logType, List<String> correlatedFindings, float timestampFeature, List<String> correlationRules, Map<String, CustomLogType> logTypes) {
+        SearchRequest searchRequest = getSearchMetadataIndexRequest(detectorType, finding, logTypes);
         Map<String, Object> tags = logTypes.get(detectorType).getTags();
         String correlationId = tags.get("correlation_id").toString();
 
         long findingTimestamp = finding.getTimestamp().toEpochMilli();
-        MatchQueryBuilder queryBuilder = QueryBuilders.matchQuery(
-                "root", true
-        );
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchSourceBuilder.query(queryBuilder);
-        searchSourceBuilder.fetchSource(true);
-        searchSourceBuilder.size(1);
-        SearchRequest searchRequest = new SearchRequest();
-        searchRequest.indices(CorrelationIndices.CORRELATION_METADATA_INDEX);
-        searchRequest.source(searchSourceBuilder);
-        searchRequest.preference(Preference.PRIMARY_FIRST.type());
-
-        client.search(searchRequest, new ActionListener<>() {
-            @Override
-            public void onResponse(SearchResponse response) {
-                if (response.isTimedOut()) {
-                    correlateFindingAction.onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
-                }
-
-                if (response.getHits().getHits().length == 0) {
-                    correlateFindingAction.onFailures(
-                            new ResourceNotFoundException("Failed to find hits in metadata index for finding id {}", finding.getId()));
-                }
-
-                Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
-                long counter = Long.parseLong(hitSource.get("counter").toString());
-
-                MultiSearchRequest mSearchRequest = new MultiSearchRequest();
-
-                for (String correlatedFinding: correlatedFindings) {
-                    BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery()
-                            .must(QueryBuilders.matchQuery(
-                                    "finding1", correlatedFinding
-                            )).must(QueryBuilders.matchQuery(
-                                    "finding2", ""
-                            ))/*.must(QueryBuilders.matchQuery(
-                                    "counter", counter
-                            ))*/;
-                    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-                    searchSourceBuilder.query(queryBuilder);
-                    searchSourceBuilder.fetchSource(true);
-                    searchSourceBuilder.size(10000);
-                    SearchRequest searchRequest = new SearchRequest();
-                    searchRequest.indices(CorrelationIndices.CORRELATION_HISTORY_INDEX_PATTERN_REGEXP);
-                    searchRequest.source(searchSourceBuilder);
-                    searchRequest.preference(Preference.PRIMARY_FIRST.type());
-
-                    mSearchRequest.add(searchRequest);
-                }
-
-                client.multiSearch(mSearchRequest, new ActionListener<>() {
-                    @Override
-                    public void onResponse(MultiSearchResponse items) {
-                        MultiSearchResponse.Item[] responses = items.getResponses();
-                        BulkRequest bulkRequest = new BulkRequest();
-                        bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-
-                        long prevCounter = -1L;
-                        long totalNeighbors = 0L;
-                        for (MultiSearchResponse.Item response: responses) {
-                            if (response.isFailure()) {
-                                log.info(response.getFailureMessage());
-                                continue;
-                            }
-
-                            long totalHits = response.getResponse().getHits().getHits().length;
-                            totalNeighbors += totalHits;
-
-                            for (int idx = 0; idx < totalHits; ++idx) {
-                                SearchHit hit = response.getResponse().getHits().getHits()[idx];
-                                Map<String, Object> hitSource = hit.getSourceAsMap();
-                                long neighborCounter = Long.parseLong(hitSource.get("counter").toString());
-                                String correlatedFinding = hitSource.get("finding1").toString();
-
-                                try {
-                                    float[] corrVector = new float[3];
-                                    if (counter != prevCounter) {
-                                        for (int i = 0; i < 2; ++i) {
-                                            corrVector[i] = ((float) counter) - 50.0f;
-                                        }
-
-                                        corrVector[0] = (float) counter;
-                                        corrVector[2] = timestampFeature;
-
-                                        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-                                        builder.field("root", false);
-                                        builder.field("counter", counter);
-                                        builder.field("finding1", finding.getId());
-                                        builder.field("finding2", "");
-                                        builder.field("logType", correlationId);
-                                        builder.field("timestamp", findingTimestamp);
-                                        builder.field("corr_vector", corrVector);
-                                        builder.field("recordType", "finding");
-                                        builder.field("scoreTimestamp", 0L);
-                                        builder.endObject();
-
-                                        IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_HISTORY_WRITE_INDEX)
-                                                .source(builder)
-                                                .timeout(indexTimeout);
-                                        bulkRequest.add(indexRequest);
-                                    }
-
-                                    corrVector = new float[3];
-                                    for (int i = 0; i < 2; ++i) {
-                                        corrVector[i] = ((float) counter) - 50.0f;
-                                    }
-                                    corrVector[0] = (2.0f * ((float) counter) - 50.0f) / 2.0f;
-                                    corrVector[1] = (2.0f * ((float) neighborCounter) - 50.0f) / 2.0f;
-                                    corrVector[2] = timestampFeature;
-
-                                    XContentBuilder corrBuilder = XContentFactory.jsonBuilder().startObject();
-                                    corrBuilder.field("root", false);
-                                    corrBuilder.field("counter", (long) ((2.0f * ((float) counter) - 50.0f) / 2.0f));
-                                    corrBuilder.field("finding1", finding.getId());
-                                    corrBuilder.field("finding2", correlatedFinding);
-                                    corrBuilder.field("logType", String.format(Locale.ROOT, "%s-%s", detectorType, logType));
-                                    corrBuilder.field("timestamp", findingTimestamp);
-                                    corrBuilder.field("corr_vector", corrVector);
-                                    corrBuilder.field("recordType", "finding-finding");
-                                    corrBuilder.field("scoreTimestamp", 0L);
-                                    corrBuilder.field("corrRules", correlationRules);
-                                    corrBuilder.endObject();
-
-                                    IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_HISTORY_WRITE_INDEX)
-                                            .source(corrBuilder)
-                                            .timeout(indexTimeout);
-                                    bulkRequest.add(indexRequest);
-                                } catch (IOException ex) {
-                                    correlateFindingAction.onFailures(ex);
-                                }
-                                prevCounter = counter;
-                            }
-                        }
-
-                        if (totalNeighbors > 0L) {
-                            client.bulk(bulkRequest, new ActionListener<>() {
-                                @Override
-                                public void onResponse(BulkResponse response) {
-                                    if (response.hasFailures()) {
-                                        correlateFindingAction.onFailures(new OpenSearchStatusException("Correlation of finding failed", RestStatus.INTERNAL_SERVER_ERROR));
-                                    }
-                                    correlateFindingAction.onOperation();
-                                }
-
-                                @Override
-                                public void onFailure(Exception e) {
-                                    correlateFindingAction.onFailures(e);
-                                }
-                            });
-                        } else {
-                            insertOrphanFindings(detectorType, finding, timestampFeature, logTypes);
-                        }
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        correlateFindingAction.onFailures(e);
-                    }
-                });
+        client.search(searchRequest, ActionListener.wrap(response -> {
+            if (response.isTimedOut()) {
+                onFailure(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
             }
 
-            @Override
-            public void onFailure(Exception e) {
-                correlateFindingAction.onFailures(e);
+            if (response.getHits().getHits().length == 0) {
+                onFailure(
+                        new ResourceNotFoundException("Failed to find hits in metadata index for finding id {}", finding.getId()));
             }
-        });
+
+            Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
+            long counter = Long.parseLong(hitSource.get("counter").toString());
+
+            MultiSearchRequest mSearchRequest = new MultiSearchRequest();
+
+            for (String correlatedFinding: correlatedFindings) {
+                BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery()
+                        .must(QueryBuilders.matchQuery(
+                                "finding1", correlatedFinding
+                        )).must(QueryBuilders.matchQuery(
+                                "finding2", ""
+                        ))/*.must(QueryBuilders.matchQuery(
+                                "counter", counter
+                        ))*/;
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+                searchSourceBuilder.query(queryBuilder);
+                searchSourceBuilder.fetchSource(true);
+                searchSourceBuilder.size(10000);
+                SearchRequest request = new SearchRequest();
+                request.indices(CorrelationIndices.CORRELATION_HISTORY_INDEX_PATTERN_REGEXP);
+                request.source(searchSourceBuilder);
+                request.preference(Preference.PRIMARY_FIRST.type());
+
+                mSearchRequest.add(request);
+            }
+
+            client.multiSearch(mSearchRequest, ActionListener.wrap(items -> {
+                MultiSearchResponse.Item[] responses = items.getResponses();
+                BulkRequest bulkRequest = new BulkRequest();
+                bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+                long prevCounter = -1L;
+                long totalNeighbors = 0L;
+                for (MultiSearchResponse.Item item: responses) {
+                    if (item.isFailure()) {
+                        log.info(item.getFailureMessage());
+                        continue;
+                    }
+
+                    long totalHits = item.getResponse().getHits().getHits().length;
+                    totalNeighbors += totalHits;
+
+                    for (int idx = 0; idx < totalHits; ++idx) {
+                        SearchHit hit = item.getResponse().getHits().getHits()[idx];
+                        Map<String, Object> sourceAsMap = hit.getSourceAsMap();
+                        long neighborCounter = Long.parseLong(sourceAsMap.get("counter").toString());
+                        String correlatedFinding = sourceAsMap.get("finding1").toString();
+
+                        try {
+                            float[] corrVector = new float[3];
+                            if (counter != prevCounter) {
+                                for (int i = 0; i < 2; ++i) {
+                                    corrVector[i] = ((float) counter) - 50.0f;
+                                }
+
+                                corrVector[0] = (float) counter;
+                                corrVector[2] = timestampFeature;
+
+                                XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+                                builder.field("root", false);
+                                builder.field("counter", counter);
+                                builder.field("finding1", finding.getId());
+                                builder.field("finding2", "");
+                                builder.field("logType", correlationId);
+                                builder.field("timestamp", findingTimestamp);
+                                builder.field("corr_vector", corrVector);
+                                builder.field("recordType", "finding");
+                                builder.field("scoreTimestamp", 0L);
+                                builder.endObject();
+
+                                IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_HISTORY_WRITE_INDEX)
+                                        .source(builder)
+                                        .timeout(indexTimeout);
+                                bulkRequest.add(indexRequest);
+                            }
+
+                            corrVector = new float[3];
+                            for (int i = 0; i < 2; ++i) {
+                                corrVector[i] = ((float) counter) - 50.0f;
+                            }
+                            corrVector[0] = (2.0f * ((float) counter) - 50.0f) / 2.0f;
+                            corrVector[1] = (2.0f * ((float) neighborCounter) - 50.0f) / 2.0f;
+                            corrVector[2] = timestampFeature;
+
+                            XContentBuilder corrBuilder = XContentFactory.jsonBuilder().startObject();
+                            corrBuilder.field("root", false);
+                            corrBuilder.field("counter", (long) ((2.0f * ((float) counter) - 50.0f) / 2.0f));
+                            corrBuilder.field("finding1", finding.getId());
+                            corrBuilder.field("finding2", correlatedFinding);
+                            corrBuilder.field("logType", String.format(Locale.ROOT, "%s-%s", detectorType, logType));
+                            corrBuilder.field("timestamp", findingTimestamp);
+                            corrBuilder.field("corr_vector", corrVector);
+                            corrBuilder.field("recordType", "finding-finding");
+                            corrBuilder.field("scoreTimestamp", 0L);
+                            corrBuilder.field("corrRules", correlationRules);
+                            corrBuilder.endObject();
+
+                            IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_HISTORY_WRITE_INDEX)
+                                    .source(corrBuilder)
+                                    .timeout(indexTimeout);
+                            bulkRequest.add(indexRequest);
+                        } catch (IOException ex) {
+                            onFailure(ex);
+                        }
+                        prevCounter = counter;
+                    }
+                }
+
+                if (totalNeighbors > 0L) {
+                    client.bulk(bulkRequest, ActionListener.wrap( bulkResponse -> {
+                        if (bulkResponse.hasFailures()) {
+                            onFailure(new OpenSearchStatusException("Correlation of finding failed", RestStatus.INTERNAL_SERVER_ERROR));
+                        }
+                        correlateFindingAction.onOperation();
+                    }, this::onFailure));
+                } else {
+                    insertOrphanFindings(detectorType, finding, timestampFeature, logTypes);
+                }
+            }, this::onFailure));
+        }, this::onFailure));
     }
 
     public void insertOrphanFindings(String detectorType, Finding finding, float timestampFeature, Map<String, CustomLogType> logTypes) {
-        if (logTypes.get(detectorType) == null) {
-            log.error("LogTypes Index is missing the detector type {}", detectorType);
-            correlateFindingAction.onFailures(new OpenSearchStatusException("LogTypes Index is missing the detector type", RestStatus.INTERNAL_SERVER_ERROR));
-        }
-
+        SearchRequest searchRequest = getSearchMetadataIndexRequest(detectorType, finding, logTypes);
         Map<String, Object> tags = logTypes.get(detectorType).getTags();
         String correlationId = tags.get("correlation_id").toString();
-
         long findingTimestamp = finding.getTimestamp().toEpochMilli();
-        MatchQueryBuilder queryBuilder = QueryBuilders.matchQuery(
-                "root", true
-        );
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchSourceBuilder.query(queryBuilder);
-        searchSourceBuilder.fetchSource(true);
-        searchSourceBuilder.size(1);
-        SearchRequest searchRequest = new SearchRequest();
-        searchRequest.indices(CorrelationIndices.CORRELATION_METADATA_INDEX);
-        searchRequest.source(searchSourceBuilder);
-        searchRequest.preference(Preference.PRIMARY_FIRST.type());
 
-        client.search(searchRequest, new ActionListener<>() {
-            @Override
-            public void onResponse(SearchResponse response) {
-                if (response.isTimedOut()) {
-                    correlateFindingAction.onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
-                }
+        client.search(searchRequest, ActionListener.wrap(response -> {
+            if (response.isTimedOut()) {
+                onFailure(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
+            }
 
-                try {
-                    Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
-                    String id = response.getHits().getHits()[0].getId();
-                    long counter = Long.parseLong(hitSource.get("counter").toString());
-                    long timestamp = Long.parseLong(hitSource.get("timestamp").toString());
-                    if (counter == 0L) {
+            try {
+                Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
+                String id = response.getHits().getHits()[0].getId();
+                long counter = Long.parseLong(hitSource.get("counter").toString());
+                long timestamp = Long.parseLong(hitSource.get("timestamp").toString());
+                if (counter == 0L) {
+                    XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+                    builder.field("root", true);
+                    builder.field("counter", 50L);
+                    builder.field("finding1", "");
+                    builder.field("finding2", "");
+                    builder.field("logType", "");
+                    builder.field("timestamp", findingTimestamp);
+                    builder.field("scoreTimestamp", 0L);
+                    builder.endObject();
+
+                    IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_METADATA_INDEX)
+                            .id(id)
+                            .source(builder)
+                            .timeout(indexTimeout)
+                            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+                    client.index(indexRequest, ActionListener.wrap(indexResponse -> {
+                        if (indexResponse.status().equals(RestStatus.OK)) {
+                            try {
+                                float[] corrVector = new float[3];
+                                corrVector[0] = 50.0f;
+                                corrVector[2] = timestampFeature;
+
+                                XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject();
+                                xContentBuilder.field("root", false);
+                                xContentBuilder.field("counter", 50L);
+                                xContentBuilder.field("finding1", finding.getId());
+                                xContentBuilder.field("finding2", "");
+                                xContentBuilder.field("logType", correlationId);
+                                xContentBuilder.field("timestamp", findingTimestamp);
+                                xContentBuilder.field("corr_vector", corrVector);
+                                xContentBuilder.field("recordType", "finding");
+                                xContentBuilder.field("scoreTimestamp", 0L);
+                                xContentBuilder.endObject();
+
+                                indexCorrelatedFindings(xContentBuilder);
+                            } catch (IOException ex) {
+                                onFailure(ex);
+                            }
+                        }
+                    }, this::onFailure));
+                } else {
+                    if (findingTimestamp - timestamp > corrTimeWindow) {
                         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
                         builder.field("root", true);
                         builder.field("counter", 50L);
@@ -285,308 +271,190 @@ public class VectorEmbeddingsEngine {
                                 .timeout(indexTimeout)
                                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
-                        client.index(indexRequest, new ActionListener<>() {
-                            @Override
-                            public void onResponse(IndexResponse response) {
-                                if (response.status().equals(RestStatus.OK)) {
-                                    try {
-                                        float[] corrVector = new float[3];
-                                        corrVector[0] = 50.0f;
-                                        corrVector[2] = timestampFeature;
+                        client.index(indexRequest, ActionListener.wrap(indexResponse -> {
+                            if (indexResponse.status().equals(RestStatus.OK)) {
+                                correlateFindingAction.onOperation();
+                                try {
+                                    float[] corrVector = new float[3];
+                                    corrVector[0] = 50.0f;
+                                    corrVector[2] = timestampFeature;
 
-                                        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-                                        builder.field("root", false);
-                                        builder.field("counter", 50L);
-                                        builder.field("finding1", finding.getId());
-                                        builder.field("finding2", "");
-                                        builder.field("logType", correlationId);
-                                        builder.field("timestamp", findingTimestamp);
-                                        builder.field("corr_vector", corrVector);
-                                        builder.field("recordType", "finding");
-                                        builder.field("scoreTimestamp", 0L);
-                                        builder.endObject();
+                                    XContentBuilder contentBuilder = XContentFactory.jsonBuilder().startObject();
+                                    contentBuilder.field("root", false);
+                                    contentBuilder.field("counter", 50L);
+                                    contentBuilder.field("finding1", finding.getId());
+                                    contentBuilder.field("finding2", "");
+                                    contentBuilder.field("logType", Integer.valueOf(logTypes.get(detectorType).getTags().get("correlation_id").toString()).toString());
+                                    contentBuilder.field("timestamp", findingTimestamp);
+                                    contentBuilder.field("corr_vector", corrVector);
+                                    contentBuilder.field("recordType", "finding");
+                                    contentBuilder.field("scoreTimestamp", 0L);
+                                    contentBuilder.endObject();
 
-                                        IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_HISTORY_WRITE_INDEX)
-                                                .source(builder)
-                                                .timeout(indexTimeout)
-                                                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-
-                                        client.index(indexRequest, new ActionListener<>() {
-                                            @Override
-                                            public void onResponse(IndexResponse response) {
-                                                if (response.status().equals(RestStatus.CREATED)) {
-                                                    correlateFindingAction.onOperation();
-                                                } else {
-                                                    correlateFindingAction.onFailures(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
-                                                }
-                                            }
-
-                                            @Override
-                                            public void onFailure(Exception e) {
-                                                correlateFindingAction.onFailures(e);
-                                            }
-                                        });
-                                    } catch (IOException ex) {
-                                        correlateFindingAction.onFailures(ex);
-                                    }
+                                    indexCorrelatedFindings(contentBuilder);
+                                } catch (IOException ex) {
+                                    onFailure(ex);
                                 }
                             }
-
-                            @Override
-                            public void onFailure(Exception e) {
-                                correlateFindingAction.onFailures(e);
-                            }
-                        });
+                        }, this::onFailure));
                     } else {
-                        if (findingTimestamp - timestamp > corrTimeWindow) {
-                            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-                            builder.field("root", true);
-                            builder.field("counter", 50L);
-                            builder.field("finding1", "");
-                            builder.field("finding2", "");
-                            builder.field("logType", "");
-                            builder.field("timestamp", findingTimestamp);
-                            builder.field("scoreTimestamp", 0L);
-                            builder.endObject();
-
-                            IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_METADATA_INDEX)
-                                    .id(id)
-                                    .source(builder)
-                                    .timeout(indexTimeout)
-                                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-
-                            client.index(indexRequest, new ActionListener<>() {
-                                @Override
-                                public void onResponse(IndexResponse response) {
-                                    if (response.status().equals(RestStatus.OK)) {
-                                        correlateFindingAction.onOperation();
-                                        try {
-                                            float[] corrVector = new float[3];
-                                            corrVector[0] = 50.0f;
-                                            corrVector[2] = timestampFeature;
-
-                                            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-                                            builder.field("root", false);
-                                            builder.field("counter", 50L);
-                                            builder.field("finding1", finding.getId());
-                                            builder.field("finding2", "");
-                                            builder.field("logType", Integer.valueOf(logTypes.get(detectorType).getTags().get("correlation_id").toString()).toString());
-                                            builder.field("timestamp", findingTimestamp);
-                                            builder.field("corr_vector", corrVector);
-                                            builder.field("recordType", "finding");
-                                            builder.field("scoreTimestamp", 0L);
-                                            builder.endObject();
-
-                                            IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_HISTORY_WRITE_INDEX)
-                                                    .source(builder)
-                                                    .timeout(indexTimeout)
-                                                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-
-                                            client.index(indexRequest, new ActionListener<>() {
-                                                @Override
-                                                public void onResponse(IndexResponse response) {
-                                                    if (response.status().equals(RestStatus.CREATED)) {
-                                                        correlateFindingAction.onOperation();
-                                                    } else {
-                                                        correlateFindingAction.onFailures(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
-                                                    }
-                                                }
-
-                                                @Override
-                                                public void onFailure(Exception e) {
-                                                    correlateFindingAction.onFailures(e);
-                                                }
-                                            });
-                                        } catch (IOException ex) {
-                                            correlateFindingAction.onFailures(ex);
-                                        }
-                                    }
-                                }
-
-                                @Override
-                                public void onFailure(Exception e) {
-                                    correlateFindingAction.onFailures(e);
-                                }
-                            });
-                        } else {
-                            float[] query = new float[3];
-                            for (int i = 0; i < 2; ++i) {
-                                query[i] = (2.0f * ((float) counter) - 50.0f) / 2.0f;
-                            }
-                            query[2] = timestampFeature;
-
-                            CorrelationQueryBuilder correlationQueryBuilder = new CorrelationQueryBuilder("corr_vector", query, 100, QueryBuilders.boolQuery()
-                                    .mustNot(QueryBuilders.matchQuery(
-                                            "finding1", ""
-                                    )).mustNot(QueryBuilders.matchQuery(
-                                            "finding2", ""
-                                    )).filter(QueryBuilders.rangeQuery("timestamp")
-                                            .gte(findingTimestamp - corrTimeWindow)
-                                            .lte(findingTimestamp + corrTimeWindow)));
-                            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-                            searchSourceBuilder.query(correlationQueryBuilder);
-                            searchSourceBuilder.fetchSource(true);
-                            searchSourceBuilder.size(1);
-                            SearchRequest searchRequest = new SearchRequest();
-                            searchRequest.indices(CorrelationIndices.CORRELATION_HISTORY_INDEX_PATTERN_REGEXP);
-                            searchRequest.source(searchSourceBuilder);
-                            searchRequest.preference(Preference.PRIMARY_FIRST.type());
-
-                            client.search(searchRequest, new ActionListener<>() {
-                                @Override
-                                public void onResponse(SearchResponse response) {
-                                    if (response.isTimedOut()) {
-                                        correlateFindingAction.onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
-                                    }
-
-                                    long totalHits = response.getHits().getTotalHits().value;
-                                    SearchHit hit = totalHits > 0? response.getHits().getHits()[0]: null;
-                                    long existCounter = 0L;
-
-                                    if (hit != null) {
-                                        Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
-                                        existCounter = Long.parseLong(hitSource.get("counter").toString());
-                                    }
-
-                                    if (totalHits == 0L || existCounter != ((long) (2.0f * ((float) counter) - 50.0f) / 2.0f)) {
-                                        try {
-                                            float[] corrVector = new float[3];
-                                            for (int i = 0; i < 2; ++i) {
-                                                corrVector[i] = ((float) counter) - 50.0f;
-                                            }
-                                            corrVector[0] = (float) counter;
-                                            corrVector[2] = timestampFeature;
-
-                                            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-                                            builder.field("root", false);
-                                            builder.field("counter", counter);
-                                            builder.field("finding1", finding.getId());
-                                            builder.field("finding2", "");
-                                            builder.field("logType", Integer.valueOf(logTypes.get(detectorType).getTags().get("correlation_id").toString()).toString());
-                                            builder.field("timestamp", findingTimestamp);
-                                            builder.field("corr_vector", corrVector);
-                                            builder.field("recordType", "finding");
-                                            builder.field("scoreTimestamp", 0L);
-                                            builder.endObject();
-
-                                            IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_HISTORY_WRITE_INDEX)
-                                                    .source(builder)
-                                                    .timeout(indexTimeout)
-                                                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-
-                                            client.index(indexRequest, new ActionListener<>() {
-                                                @Override
-                                                public void onResponse(IndexResponse response) {
-                                                    if (response.status().equals(RestStatus.CREATED)) {
-                                                        correlateFindingAction.onOperation();
-                                                    } else {
-                                                        correlateFindingAction.onFailures(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
-                                                    }
-                                                }
-
-                                                @Override
-                                                public void onFailure(Exception e) {
-                                                    correlateFindingAction.onFailures(e);
-                                                }
-                                            });
-                                        } catch (IOException ex) {
-                                            correlateFindingAction.onFailures(ex);
-                                        }
-                                    } else {
-                                        try {
-                                            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-                                            builder.field("root", true);
-                                            builder.field("counter", counter + 50L);
-                                            builder.field("finding1", "");
-                                            builder.field("finding2", "");
-                                            builder.field("logType", "");
-                                            builder.field("timestamp", findingTimestamp);
-                                            builder.field("scoreTimestamp", 0L);
-                                            builder.endObject();
-
-                                            IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_METADATA_INDEX)
-                                                    .id(id)
-                                                    .source(builder)
-                                                    .timeout(indexTimeout)
-                                                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-
-                                            client.index(indexRequest, new ActionListener<>() {
-                                                @Override
-                                                public void onResponse(IndexResponse response) {
-                                                    if (response.status().equals(RestStatus.OK)) {
-                                                        try {
-                                                            float[] corrVector = new float[3];
-                                                            for (int i = 0; i < 2; ++i) {
-                                                                corrVector[i] = (float) counter;
-                                                            }
-                                                            corrVector[0] = counter + 50.0f;
-                                                            corrVector[2] = timestampFeature;
-
-                                                            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-                                                            builder.field("root", false);
-                                                            builder.field("counter", counter + 50L);
-                                                            builder.field("finding1", finding.getId());
-                                                            builder.field("finding2", "");
-                                                            builder.field("logType", Integer.valueOf(logTypes.get(detectorType).getTags().get("correlation_id").toString()).toString());
-                                                            builder.field("timestamp", findingTimestamp);
-                                                            builder.field("corr_vector", corrVector);
-                                                            builder.field("recordType", "finding");
-                                                            builder.field("scoreTimestamp", 0L);
-                                                            builder.endObject();
-
-                                                            IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_HISTORY_WRITE_INDEX)
-                                                                    .source(builder)
-                                                                    .timeout(indexTimeout)
-                                                                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-
-                                                            client.index(indexRequest, new ActionListener<>() {
-                                                                @Override
-                                                                public void onResponse(IndexResponse response) {
-                                                                    if (response.status().equals(RestStatus.CREATED)) {
-                                                                        correlateFindingAction.onOperation();
-                                                                    } else {
-                                                                        correlateFindingAction.onFailures(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
-                                                                    }
-                                                                }
-
-                                                                @Override
-                                                                public void onFailure(Exception e) {
-                                                                    correlateFindingAction.onFailures(e);
-                                                                }
-                                                            });
-                                                        } catch (IOException ex) {
-                                                            correlateFindingAction.onFailures(ex);
-                                                        }
-                                                    }
-                                                }
-
-                                                @Override
-                                                public void onFailure(Exception e) {
-                                                    correlateFindingAction.onFailures(e);
-                                                }
-                                            });
-                                        } catch (IOException ex) {
-                                            correlateFindingAction.onFailures(ex);
-                                        }
-                                    }
-                                }
-
-                                @Override
-                                public void onFailure(Exception e) {
-                                    correlateFindingAction.onFailures(e);
-                                }
-                            });
+                        float[] query = new float[3];
+                        for (int i = 0; i < 2; ++i) {
+                            query[i] = (2.0f * ((float) counter) - 50.0f) / 2.0f;
                         }
-                    }
-                } catch (IOException ex) {
-                    correlateFindingAction.onFailures(ex);
-                }
-            }
+                        query[2] = timestampFeature;
 
-            @Override
-            public void onFailure(Exception e) {
-                correlateFindingAction.onFailures(e);
+                        CorrelationQueryBuilder correlationQueryBuilder = new CorrelationQueryBuilder("corr_vector", query, 100, QueryBuilders.boolQuery()
+                                .mustNot(QueryBuilders.matchQuery(
+                                        "finding1", ""
+                                )).mustNot(QueryBuilders.matchQuery(
+                                        "finding2", ""
+                                )).filter(QueryBuilders.rangeQuery("timestamp")
+                                        .gte(findingTimestamp - corrTimeWindow)
+                                        .lte(findingTimestamp + corrTimeWindow)));
+                        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+                        searchSourceBuilder.query(correlationQueryBuilder);
+                        searchSourceBuilder.fetchSource(true);
+                        searchSourceBuilder.size(1);
+                        SearchRequest request = new SearchRequest();
+                        request.indices(CorrelationIndices.CORRELATION_HISTORY_INDEX_PATTERN_REGEXP);
+                        request.source(searchSourceBuilder);
+                        request.preference(Preference.PRIMARY_FIRST.type());
+
+                        client.search(request, ActionListener.wrap(searchResponse -> {
+                            if (searchResponse.isTimedOut()) {
+                                onFailure(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
+                            }
+
+                            long totalHits = searchResponse.getHits().getTotalHits().value;
+                            SearchHit hit = totalHits > 0? searchResponse.getHits().getHits()[0]: null;
+                            long existCounter = 0L;
+
+                            if (hit != null) {
+                                Map<String, Object> sourceAsMap = searchResponse.getHits().getHits()[0].getSourceAsMap();
+                                existCounter = Long.parseLong(sourceAsMap.get("counter").toString());
+                            }
+
+                            if (totalHits == 0L || existCounter != ((long) (2.0f * ((float) counter) - 50.0f) / 2.0f)) {
+                                try {
+                                    float[] corrVector = new float[3];
+                                    for (int i = 0; i < 2; ++i) {
+                                        corrVector[i] = ((float) counter) - 50.0f;
+                                    }
+                                    corrVector[0] = (float) counter;
+                                    corrVector[2] = timestampFeature;
+
+                                    XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+                                    builder.field("root", false);
+                                    builder.field("counter", counter);
+                                    builder.field("finding1", finding.getId());
+                                    builder.field("finding2", "");
+                                    builder.field("logType", Integer.valueOf(logTypes.get(detectorType).getTags().get("correlation_id").toString()).toString());
+                                    builder.field("timestamp", findingTimestamp);
+                                    builder.field("corr_vector", corrVector);
+                                    builder.field("recordType", "finding");
+                                    builder.field("scoreTimestamp", 0L);
+                                    builder.endObject();
+
+                                    indexCorrelatedFindings(builder);
+                                } catch (IOException ex) {
+                                    onFailure(ex);
+                                }
+                            } else {
+                                try {
+                                    XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+                                    builder.field("root", true);
+                                    builder.field("counter", counter + 50L);
+                                    builder.field("finding1", "");
+                                    builder.field("finding2", "");
+                                    builder.field("logType", "");
+                                    builder.field("timestamp", findingTimestamp);
+                                    builder.field("scoreTimestamp", 0L);
+                                    builder.endObject();
+
+                                    IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_METADATA_INDEX)
+                                            .id(id)
+                                            .source(builder)
+                                            .timeout(indexTimeout)
+                                            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+                                    client.index(indexRequest, ActionListener.wrap(indexResponse -> {
+                                        if (indexResponse.status().equals(RestStatus.OK)) {
+                                            try {
+                                                float[] corrVector = new float[3];
+                                                for (int i = 0; i < 2; ++i) {
+                                                    corrVector[i] = (float) counter;
+                                                }
+                                                corrVector[0] = counter + 50.0f;
+                                                corrVector[2] = timestampFeature;
+
+                                                XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject();
+                                                xContentBuilder.field("root", false);
+                                                xContentBuilder.field("counter", counter + 50L);
+                                                xContentBuilder.field("finding1", finding.getId());
+                                                xContentBuilder.field("finding2", "");
+                                                xContentBuilder.field("logType", Integer.valueOf(logTypes.get(detectorType).getTags().get("correlation_id").toString()).toString());
+                                                xContentBuilder.field("timestamp", findingTimestamp);
+                                                xContentBuilder.field("corr_vector", corrVector);
+                                                xContentBuilder.field("recordType", "finding");
+                                                xContentBuilder.field("scoreTimestamp", 0L);
+                                                xContentBuilder.endObject();
+
+                                                indexCorrelatedFindings(xContentBuilder);
+                                            } catch (IOException ex) {
+                                                onFailure(ex);
+                                            }
+                                        }
+                                    }, this::onFailure));
+                                } catch (IOException ex) {
+                                    onFailure(ex);
+                                }
+                            }
+                        }, this::onFailure));
+                    }
+                }
+            } catch (IOException ex) {
+                onFailure(ex);
             }
-        });
+        }, this::onFailure));
+    }
+
+    private void indexCorrelatedFindings(XContentBuilder builder) {
+        IndexRequest indexRequest = new IndexRequest(CorrelationIndices.CORRELATION_HISTORY_WRITE_INDEX)
+                .source(builder)
+                .timeout(indexTimeout)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        client.index(indexRequest, ActionListener.wrap(response -> {
+            if (response.status().equals(RestStatus.CREATED)) {
+                correlateFindingAction.onOperation();
+            } else {
+                onFailure(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
+            }
+        }, this::onFailure));
+    }
+
+    private SearchRequest getSearchMetadataIndexRequest(String detectorType, Finding finding, Map<String, CustomLogType> logTypes) {
+        if (logTypes.get(detectorType) == null) {
+            throw new OpenSearchStatusException("LogTypes Index is missing the detector type", RestStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        Map<String, Object> tags = logTypes.get(detectorType).getTags();
+        MatchQueryBuilder queryBuilder = QueryBuilders.matchQuery(
+                "root", true
+        );
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(queryBuilder);
+        searchSourceBuilder.fetchSource(true);
+        searchSourceBuilder.size(1);
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.indices(CorrelationIndices.CORRELATION_METADATA_INDEX);
+        searchRequest.source(searchSourceBuilder);
+        searchRequest.preference(Preference.PRIMARY_FIRST.type());
+        return searchRequest;
+    }
+
+    private void onFailure(Exception e) {
+        correlateFindingAction.onFailures(e);
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
@@ -32,7 +32,6 @@ import org.opensearch.securityanalytics.model.CustomLogType;
 import org.opensearch.securityanalytics.transport.TransportCorrelateFindingAction;
 import org.opensearch.securityanalytics.util.CorrelationIndices;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -174,7 +173,7 @@ public class VectorEmbeddingsEngine {
                                     .source(corrBuilder)
                                     .timeout(indexTimeout);
                             bulkRequest.add(indexRequest);
-                        } catch (IOException ex) {
+                        } catch (Exception ex) {
                             onFailure(ex);
                         }
                         prevCounter = counter;
@@ -248,9 +247,11 @@ public class VectorEmbeddingsEngine {
                                 xContentBuilder.endObject();
 
                                 indexCorrelatedFindings(xContentBuilder);
-                            } catch (IOException ex) {
+                            } catch (Exception ex) {
                                 onFailure(ex);
                             }
+                        } else {
+                            onFailure(new OpenSearchStatusException(indexResponse.toString(), RestStatus.INTERNAL_SERVER_ERROR));
                         }
                     }, this::onFailure));
                 } else {
@@ -292,9 +293,11 @@ public class VectorEmbeddingsEngine {
                                     contentBuilder.endObject();
 
                                     indexCorrelatedFindings(contentBuilder);
-                                } catch (IOException ex) {
+                                } catch (Exception ex) {
                                     onFailure(ex);
                                 }
+                            } else {
+                                onFailure(new OpenSearchStatusException(indexResponse.toString(), RestStatus.INTERNAL_SERVER_ERROR));
                             }
                         }, this::onFailure));
                     } else {
@@ -326,7 +329,7 @@ public class VectorEmbeddingsEngine {
                                 onFailure(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                             }
 
-                            long totalHits = searchResponse.getHits().getTotalHits().value;
+                            long totalHits = searchResponse.getHits().getHits().length;
                             SearchHit hit = totalHits > 0? searchResponse.getHits().getHits()[0]: null;
                             long existCounter = 0L;
 
@@ -357,7 +360,7 @@ public class VectorEmbeddingsEngine {
                                     builder.endObject();
 
                                     indexCorrelatedFindings(builder);
-                                } catch (IOException ex) {
+                                } catch (Exception ex) {
                                     onFailure(ex);
                                 }
                             } else {
@@ -401,19 +404,19 @@ public class VectorEmbeddingsEngine {
                                                 xContentBuilder.endObject();
 
                                                 indexCorrelatedFindings(xContentBuilder);
-                                            } catch (IOException ex) {
+                                            } catch (Exception ex) {
                                                 onFailure(ex);
                                             }
                                         }
                                     }, this::onFailure));
-                                } catch (IOException ex) {
+                                } catch (Exception ex) {
                                     onFailure(ex);
                                 }
                             }
                         }, this::onFailure));
                     }
                 }
-            } catch (IOException ex) {
+            } catch (Exception ex) {
                 onFailure(ex);
             }
         }, this::onFailure));

--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -282,7 +282,7 @@ public class LogTypeService {
                 if (response.isTimedOut()) {
                     listener.onFailure(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                 }
-                if (response.getHits().getTotalHits().value > 0) {
+                if (response.getHits().getHits().length > 0) {
                     listener.onResponse(null);
                 } else {
                     try {

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -497,7 +497,8 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
         }
 
         public void onFailures(Exception t) {
-            log.error("Exception occurred while processing correlations", t);
+            log.error("Exception occurred while processing correlations for monitor id "
+                    + request.getMonitorId() + " and finding id " + request.getFinding().getId(), t);
             if (counter.compareAndSet(false, true)) {
                 finishHim(t);
             }

--- a/src/main/java/org/opensearch/securityanalytics/util/CorrelationIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/CorrelationIndices.java
@@ -6,7 +6,6 @@ package org.opensearch.securityanalytics.util;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -17,15 +16,11 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.ClusterState;
-import org.opensearch.cluster.health.ClusterIndexHealth;
-import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.cluster.routing.IndexRoutingTable;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.core.rest.RestStatus;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -89,7 +84,7 @@ public class CorrelationIndices {
         return clusterState.metadata().hasIndex(CORRELATION_METADATA_INDEX);
     }
 
-    public void setupCorrelationIndex(TimeValue indexTimeout, Long setupTimestamp, ActionListener<BulkResponse> listener) {
+    public void setupCorrelationIndex(TimeValue indexTimeout, Long setupTimestamp, ActionListener<BulkResponse> listener) throws IOException {
         try {
             long currentTimestamp = System.currentTimeMillis();
             XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
@@ -124,6 +119,7 @@ public class CorrelationIndices {
             client.bulk(bulkRequest, listener);
         } catch (IOException ex) {
             log.error(ex);
+            throw ex;
         }
     }
 }


### PR DESCRIPTION
### Description
This PR is intended to fix the hanging tasks observed in _cat/tasks by refactoring the correlation workflow to ensure timely closure of parent action listeners upon successful completion or encountering exceptions, and consolidating exception handling logic into a centralized function. The aim is to optimize task management efficiency and enhance the overall reliability of our system.

This logic has been tested against a high indexing workload ( approx. 1 M docs/ minute) where the issue was observed prominently in a cluster of 3 or more data nodes, and generating findings with the help of a Cloudtrail logs detector running all 32 pre-packaged rules at a frequency of 1 minute. Further, the correlations were generated with the help of a single rule on the same log type for testing, where the findings are generated at a rate of 1~2k per minute.
 
### Issues Resolved
#879
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
