### PR TITLE
Add search request timeouts for correlations workflows

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
@@ -133,7 +133,7 @@ public class JoinEngine {
                 searchRequest.indices(DetectorMonitorConfig.getAllFindingsIndicesPattern(logTypeName));
                 searchRequest.source(sourceBuilder);
                 searchRequest.preference(Preference.PRIMARY_FIRST.type());
-                searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+                searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
                 mSearchRequest.add(searchRequest);
             }
 
@@ -216,7 +216,7 @@ public class JoinEngine {
         searchRequest.indices(CorrelationRule.CORRELATION_RULE_INDEX);
         searchRequest.source(searchSourceBuilder);
         searchRequest.preference(Preference.PRIMARY_FIRST.type());
-        searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+        searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
 
         client.search(searchRequest, ActionListener.wrap(response -> {
             if (response.isTimedOut()) {
@@ -280,7 +280,7 @@ public class JoinEngine {
                 searchRequest.indices(indices.toArray(new String[]{}));
                 searchRequest.source(searchSourceBuilder);
                 searchRequest.preference(Preference.PRIMARY_FIRST.type());
-                searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+                searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
 
                 validCorrelationRules.add(rule);
                 validFields.add(query.get().getField());
@@ -381,7 +381,7 @@ public class JoinEngine {
             searchRequest.indices(DetectorMonitorConfig.getAllFindingsIndicesPattern(categoryToQueries.getKey()));
             searchRequest.source(searchSourceBuilder);
             searchRequest.preference(Preference.PRIMARY_FIRST.type());
-            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
             mSearchRequest.add(searchRequest);
             categoryToQueriesPairs.add(Pair.of(categoryToQueries.getKey(), categoryToQueries.getValue()));
         }
@@ -446,7 +446,7 @@ public class JoinEngine {
             searchRequest.indices(docSearchCriteria.getValue().indices.toArray(new String[]{}));
             searchRequest.source(searchSourceBuilder);
             searchRequest.preference(Preference.PRIMARY_FIRST.type());
-            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
 
             categories.add(docSearchCriteria.getKey());
             mSearchRequest.add(searchRequest);
@@ -508,7 +508,7 @@ public class JoinEngine {
             searchRequest.indices(DetectorMonitorConfig.getAllFindingsIndicesPattern(relatedDocIds.getKey()));
             searchRequest.source(searchSourceBuilder);
             searchRequest.preference(Preference.PRIMARY_FIRST.type());
-            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
 
             categories.add(relatedDocIds.getKey());
             mSearchRequest.add(searchRequest);

--- a/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.cluster.routing.Preference;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.commons.alerting.model.DocLevelQuery;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.search.MultiSearchRequest;
@@ -132,6 +133,7 @@ public class JoinEngine {
                 searchRequest.indices(DetectorMonitorConfig.getAllFindingsIndicesPattern(logTypeName));
                 searchRequest.source(sourceBuilder);
                 searchRequest.preference(Preference.PRIMARY_FIRST.type());
+                searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
                 mSearchRequest.add(searchRequest);
             }
 
@@ -214,6 +216,7 @@ public class JoinEngine {
         searchRequest.indices(CorrelationRule.CORRELATION_RULE_INDEX);
         searchRequest.source(searchSourceBuilder);
         searchRequest.preference(Preference.PRIMARY_FIRST.type());
+        searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
 
         client.search(searchRequest, ActionListener.wrap(response -> {
             if (response.isTimedOut()) {
@@ -277,6 +280,7 @@ public class JoinEngine {
                 searchRequest.indices(indices.toArray(new String[]{}));
                 searchRequest.source(searchSourceBuilder);
                 searchRequest.preference(Preference.PRIMARY_FIRST.type());
+                searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
 
                 validCorrelationRules.add(rule);
                 validFields.add(query.get().getField());
@@ -377,6 +381,7 @@ public class JoinEngine {
             searchRequest.indices(DetectorMonitorConfig.getAllFindingsIndicesPattern(categoryToQueries.getKey()));
             searchRequest.source(searchSourceBuilder);
             searchRequest.preference(Preference.PRIMARY_FIRST.type());
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
             mSearchRequest.add(searchRequest);
             categoryToQueriesPairs.add(Pair.of(categoryToQueries.getKey(), categoryToQueries.getValue()));
         }
@@ -441,6 +446,7 @@ public class JoinEngine {
             searchRequest.indices(docSearchCriteria.getValue().indices.toArray(new String[]{}));
             searchRequest.source(searchSourceBuilder);
             searchRequest.preference(Preference.PRIMARY_FIRST.type());
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
 
             categories.add(docSearchCriteria.getKey());
             mSearchRequest.add(searchRequest);
@@ -502,6 +508,7 @@ public class JoinEngine {
             searchRequest.indices(DetectorMonitorConfig.getAllFindingsIndicesPattern(relatedDocIds.getKey()));
             searchRequest.source(searchSourceBuilder);
             searchRequest.preference(Preference.PRIMARY_FIRST.type());
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
 
             categories.add(relatedDocIds.getKey());
             mSearchRequest.add(searchRequest);

--- a/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
@@ -195,6 +195,14 @@ public class VectorEmbeddingsEngine {
     }
 
     public void insertOrphanFindings(String detectorType, Finding finding, float timestampFeature, Map<String, CustomLogType> logTypes) {
+        if (logTypes.get(detectorType) == null ) {
+            log.error("[PERF-DEBUG] insertOrphanFindings detector type {} {}", detectorType, finding.getId());
+            for (String key : logTypes.keySet()) {
+                log.error("[PERF-DEBUG] keys {}", key);
+            }
+            onFailure(new OpenSearchStatusException("insertOrphanFindings null log types for detector type: " + detectorType, RestStatus.INTERNAL_SERVER_ERROR));
+        }
+
         SearchRequest searchRequest = getSearchMetadataIndexRequest(detectorType, finding, logTypes);
         Map<String, Object> tags = logTypes.get(detectorType).getTags();
         String correlationId = tags.get("correlation_id").toString();
@@ -407,6 +415,8 @@ public class VectorEmbeddingsEngine {
                                             } catch (Exception ex) {
                                                 onFailure(ex);
                                             }
+                                        } else {
+                                            onFailure(new OpenSearchStatusException("Indexing failed", RestStatus.INTERNAL_SERVER_ERROR));
                                         }
                                     }, this::onFailure));
                                 } catch (Exception ex) {

--- a/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
@@ -32,6 +32,7 @@ import org.opensearch.securityanalytics.model.CustomLogType;
 import org.opensearch.securityanalytics.transport.TransportCorrelateFindingAction;
 import org.opensearch.securityanalytics.util.CorrelationIndices;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -197,10 +198,8 @@ public class VectorEmbeddingsEngine {
 
     public void insertOrphanFindings(String detectorType, Finding finding, float timestampFeature, Map<String, CustomLogType> logTypes) {
         if (logTypes.get(detectorType) == null ) {
-            log.debug("[PERF-DEBUG] insertOrphanFindings detector type {} {}", detectorType, finding.getId());
-            for (String key : logTypes.keySet()) {
-                log.debug("[PERF-DEBUG] keys {}", key);
-            }
+            log.debug("Missing detector type {} in the log types index for finding id {}. Keys in the index: {}",
+                    detectorType, finding.getId(), Arrays.toString(logTypes.keySet().toArray()));
             onFailure(new OpenSearchStatusException("insertOrphanFindings null log types for detector type: " + detectorType, RestStatus.INTERNAL_SERVER_ERROR));
         }
 
@@ -260,7 +259,8 @@ public class VectorEmbeddingsEngine {
                                 onFailure(ex);
                             }
                         } else {
-                            onFailure(new OpenSearchStatusException(indexResponse.toString(), RestStatus.INTERNAL_SERVER_ERROR));
+                            onFailure(new OpenSearchStatusException("Indexing failed with response {} ",
+                                    indexResponse.status(), indexResponse.toString()));
                         }
                     }, this::onFailure));
                 } else {
@@ -306,7 +306,8 @@ public class VectorEmbeddingsEngine {
                                     onFailure(ex);
                                 }
                             } else {
-                                onFailure(new OpenSearchStatusException(indexResponse.toString(), RestStatus.INTERNAL_SERVER_ERROR));
+                                onFailure(new OpenSearchStatusException("Indexing failed with response {} ",
+                                        indexResponse.status(), indexResponse.toString()));
                             }
                         }, this::onFailure));
                     } else {
@@ -418,7 +419,8 @@ public class VectorEmbeddingsEngine {
                                                 onFailure(ex);
                                             }
                                         } else {
-                                            onFailure(new OpenSearchStatusException("Indexing failed", RestStatus.INTERNAL_SERVER_ERROR));
+                                            onFailure(new OpenSearchStatusException("Indexing failed with response {} ",
+                                                    indexResponse.status(), indexResponse.toString()));
                                         }
                                     }, this::onFailure));
                                 } catch (Exception ex) {
@@ -444,7 +446,7 @@ public class VectorEmbeddingsEngine {
             if (response.status().equals(RestStatus.CREATED)) {
                 correlateFindingAction.onOperation();
             } else {
-                onFailure(new OpenSearchStatusException(response.toString(), RestStatus.INTERNAL_SERVER_ERROR));
+                onFailure(new OpenSearchStatusException("Indexing failed with response {} ", response.status(), response.toString()));
             }
         }, this::onFailure));
     }

--- a/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
@@ -95,7 +95,7 @@ public class VectorEmbeddingsEngine {
                 request.indices(CorrelationIndices.CORRELATION_HISTORY_INDEX_PATTERN_REGEXP);
                 request.source(searchSourceBuilder);
                 request.preference(Preference.PRIMARY_FIRST.type());
-                request.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+                request.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
 
                 mSearchRequest.add(request);
             }
@@ -333,7 +333,7 @@ public class VectorEmbeddingsEngine {
                         request.indices(CorrelationIndices.CORRELATION_HISTORY_INDEX_PATTERN_REGEXP);
                         request.source(searchSourceBuilder);
                         request.preference(Preference.PRIMARY_FIRST.type());
-                        request.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+                        request.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
 
                         client.search(request, ActionListener.wrap(searchResponse -> {
                             if (searchResponse.isTimedOut()) {
@@ -468,7 +468,7 @@ public class VectorEmbeddingsEngine {
         searchRequest.indices(CorrelationIndices.CORRELATION_METADATA_INDEX);
         searchRequest.source(searchSourceBuilder);
         searchRequest.preference(Preference.PRIMARY_FIRST.type());
-        searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+        searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
         return searchRequest;
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
@@ -94,6 +94,7 @@ public class VectorEmbeddingsEngine {
                 request.indices(CorrelationIndices.CORRELATION_HISTORY_INDEX_PATTERN_REGEXP);
                 request.source(searchSourceBuilder);
                 request.preference(Preference.PRIMARY_FIRST.type());
+                request.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
 
                 mSearchRequest.add(request);
             }
@@ -196,9 +197,9 @@ public class VectorEmbeddingsEngine {
 
     public void insertOrphanFindings(String detectorType, Finding finding, float timestampFeature, Map<String, CustomLogType> logTypes) {
         if (logTypes.get(detectorType) == null ) {
-            log.error("[PERF-DEBUG] insertOrphanFindings detector type {} {}", detectorType, finding.getId());
+            log.debug("[PERF-DEBUG] insertOrphanFindings detector type {} {}", detectorType, finding.getId());
             for (String key : logTypes.keySet()) {
-                log.error("[PERF-DEBUG] keys {}", key);
+                log.debug("[PERF-DEBUG] keys {}", key);
             }
             onFailure(new OpenSearchStatusException("insertOrphanFindings null log types for detector type: " + detectorType, RestStatus.INTERNAL_SERVER_ERROR));
         }
@@ -331,6 +332,7 @@ public class VectorEmbeddingsEngine {
                         request.indices(CorrelationIndices.CORRELATION_HISTORY_INDEX_PATTERN_REGEXP);
                         request.source(searchSourceBuilder);
                         request.preference(Preference.PRIMARY_FIRST.type());
+                        request.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
 
                         client.search(request, ActionListener.wrap(searchResponse -> {
                             if (searchResponse.isTimedOut()) {
@@ -464,6 +466,7 @@ public class VectorEmbeddingsEngine {
         searchRequest.indices(CorrelationIndices.CORRELATION_METADATA_INDEX);
         searchRequest.source(searchSourceBuilder);
         searchRequest.preference(Preference.PRIMARY_FIRST.type());
+        searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
         return searchRequest;
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -228,6 +228,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                 searchRequest.indices(Detector.DETECTORS_INDEX);
                 searchRequest.source(searchSourceBuilder);
                 searchRequest.preference(Preference.PRIMARY_FIRST.type());
+                searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
 
                 client.search(searchRequest, ActionListener.wrap(response -> {
                     if (response.isTimedOut()) {
@@ -246,7 +247,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                             Detector detector = Detector.docParse(xcp, hit.getId(), hit.getVersion());
                             joinEngine.onSearchDetectorResponse(detector, finding);
                         } catch (Exception e) {
-                            log.error("IOException for request {}", searchRequest.toString(), e);
+                            log.error("Exception for request {}", searchRequest.toString(), e);
                             onFailures(e);
                         }
                     } else {
@@ -365,54 +366,49 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                         if (response.getHits().getHits().length == 0) {
                             onFailures(new ResourceNotFoundException(
                                     "Failed to find hits in metadata index for finding id {}", request.getFinding().getId()));
-                        }
+                        } else {
+                            String id = response.getHits().getHits()[0].getId();
+                            Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
+                            long scoreTimestamp = (long) hitSource.get("scoreTimestamp");
 
-                        String id = response.getHits().getHits()[0].getId();
-                        Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
-                        long scoreTimestamp = (long) hitSource.get("scoreTimestamp");
-
-                        long newScoreTimestamp = findingTimestamp - CorrelationIndices.FIXED_HISTORICAL_INTERVAL;
-                        if (newScoreTimestamp > scoreTimestamp) {
-                            try {
+                            long newScoreTimestamp = findingTimestamp - CorrelationIndices.FIXED_HISTORICAL_INTERVAL;
+                            if (newScoreTimestamp > scoreTimestamp) {
                                 IndexRequest scoreIndexRequest = getCorrelationMetadataIndexRequest(id, newScoreTimestamp);
 
                                 client.index(scoreIndexRequest, ActionListener.wrap(indexResponse -> {
-                                    SearchRequest searchRequest =  getSearchLogTypeIndexRequest();
+                                    SearchRequest searchRequest = getSearchLogTypeIndexRequest();
 
                                     client.search(searchRequest, ActionListener.wrap(searchResponse -> {
-                                            if (searchResponse.isTimedOut()) {
-                                                onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
-                                            }
+                                        if (searchResponse.isTimedOut()) {
+                                            onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
+                                        }
 
-                                            SearchHit[] hits = searchResponse.getHits().getHits();
-                                            Map<String, CustomLogType> logTypes = new HashMap<>();
-                                            for (SearchHit hit : hits) {
-                                                Map<String, Object> sourceMap = hit.getSourceAsMap();
-                                                logTypes.put(sourceMap.get("name").toString(),
-                                                        new CustomLogType(sourceMap));
-                                            }
+                                        SearchHit[] hits = searchResponse.getHits().getHits();
+                                        Map<String, CustomLogType> logTypes = new HashMap<>();
+                                        for (SearchHit hit : hits) {
+                                            Map<String, Object> sourceMap = hit.getSourceAsMap();
+                                            logTypes.put(sourceMap.get("name").toString(), new CustomLogType(sourceMap));
+                                        }
 
-                                            if (correlatedFindings != null) {
-                                                if (correlatedFindings.isEmpty()) {
-                                                    vectorEmbeddingsEngine.insertOrphanFindings(detectorType, request.getFinding(), Long.valueOf(CorrelationIndices.FIXED_HISTORICAL_INTERVAL / 1000L).floatValue(), logTypes);
-                                                }
-                                                for (Map.Entry<String, List<String>> correlatedFinding : correlatedFindings.entrySet()) {
-                                                    vectorEmbeddingsEngine.insertCorrelatedFindings(detectorType, request.getFinding(), correlatedFinding.getKey(), correlatedFinding.getValue(),
-                                                            Long.valueOf(CorrelationIndices.FIXED_HISTORICAL_INTERVAL / 1000L).floatValue(), correlationRules, logTypes);
-                                                }
-                                            } else {
-                                                vectorEmbeddingsEngine.insertOrphanFindings(detectorType, orphanFinding, Long.valueOf(CorrelationIndices.FIXED_HISTORICAL_INTERVAL / 1000L).floatValue(), logTypes);
+                                        if (correlatedFindings != null) {
+                                            if (correlatedFindings.isEmpty()) {
+                                                vectorEmbeddingsEngine.insertOrphanFindings(detectorType, request.getFinding(), Long.valueOf(CorrelationIndices.FIXED_HISTORICAL_INTERVAL / 1000L).floatValue(), logTypes);
                                             }
-                                        }, this::onFailures));
+                                            for (Map.Entry<String, List<String>> correlatedFinding : correlatedFindings.entrySet()) {
+                                                vectorEmbeddingsEngine.insertCorrelatedFindings(detectorType, request.getFinding(), correlatedFinding.getKey(), correlatedFinding.getValue(),
+                                                        Long.valueOf(CorrelationIndices.FIXED_HISTORICAL_INTERVAL / 1000L).floatValue(), correlationRules, logTypes);
+                                            }
+                                        } else {
+                                            vectorEmbeddingsEngine.insertOrphanFindings(detectorType, orphanFinding, Long.valueOf(CorrelationIndices.FIXED_HISTORICAL_INTERVAL / 1000L).floatValue(), logTypes);
+                                        }
+                                    }, this::onFailures));
                                 }, this::onFailures));
-                            } catch (Exception ex) {
-                                onFailures(ex);
-                            }
-                        } else {
-                            float timestampFeature = Long.valueOf((findingTimestamp - scoreTimestamp) / 1000L).floatValue();
+                            } else {
+                                float timestampFeature = Long.valueOf((findingTimestamp - scoreTimestamp) / 1000L).floatValue();
 
-                            SearchRequest searchRequest = getSearchLogTypeIndexRequest();
-                            insertFindings(timestampFeature, searchRequest, correlatedFindings, detectorType, correlationRules, orphanFinding);
+                                SearchRequest searchRequest = getSearchLogTypeIndexRequest();
+                                insertFindings(timestampFeature, searchRequest, correlatedFindings, detectorType, correlationRules, orphanFinding);
+                            }
                         }
                     }, this::onFailures));
                 }
@@ -431,6 +427,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
             SearchRequest searchRequest = new SearchRequest();
             searchRequest.indices(LogTypeService.LOG_TYPE_INDEX);
             searchRequest.source(searchSourceBuilder);
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
             return searchRequest;
         }
 
@@ -446,6 +443,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                     .timeout(indexTimeout)
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         }
+
         private void insertFindings(float timestampFeature, SearchRequest searchRequest, Map<String, List<String>> correlatedFindings, String detectorType, List<String> correlationRules, Finding orphanFinding) {
             client.search(searchRequest, ActionListener.wrap(response -> {
                 if (response.isTimedOut()) {
@@ -485,6 +483,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
             searchRequest.indices(CorrelationIndices.CORRELATION_METADATA_INDEX);
             searchRequest.source(searchSourceBuilder);
             searchRequest.preference(Preference.PRIMARY_FIRST.type());
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
 
             return searchRequest;
         }

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -228,7 +228,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
                 searchRequest.indices(Detector.DETECTORS_INDEX);
                 searchRequest.source(searchSourceBuilder);
                 searchRequest.preference(Preference.PRIMARY_FIRST.type());
-                searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+                searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
 
                 client.search(searchRequest, ActionListener.wrap(response -> {
                     if (response.isTimedOut()) {
@@ -427,7 +427,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
             SearchRequest searchRequest = new SearchRequest();
             searchRequest.indices(LogTypeService.LOG_TYPE_INDEX);
             searchRequest.source(searchSourceBuilder);
-            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
             return searchRequest;
         }
 
@@ -483,7 +483,7 @@ public class TransportCorrelateFindingAction extends HandledTransportAction<Acti
             searchRequest.indices(CorrelationIndices.CORRELATION_METADATA_INDEX);
             searchRequest.source(searchSourceBuilder);
             searchRequest.preference(Preference.PRIMARY_FIRST.type());
-            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(10L));
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
 
             return searchRequest;
         }


### PR DESCRIPTION
### Description
Add search request timeouts to close hanging tasks for correlations waiting on searches.
 
### Issues Resolved
#879
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
