### PR TITLE
[Backport 2.x] Add throw for empty strings in rules with modifier contains, startwith, and endswith (#860)

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/rules/objects/SigmaDetectionItem.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/objects/SigmaDetectionItem.java
@@ -18,6 +18,7 @@ import org.opensearch.securityanalytics.rules.modifiers.SigmaModifier;
 import org.opensearch.securityanalytics.rules.modifiers.SigmaModifierFacade;
 import org.opensearch.securityanalytics.rules.modifiers.SigmaValueModifier;
 import org.opensearch.securityanalytics.rules.types.SigmaNull;
+import org.opensearch.securityanalytics.rules.types.SigmaString;
 import org.opensearch.securityanalytics.rules.types.SigmaType;
 import org.opensearch.securityanalytics.rules.types.SigmaTypeFacade;
 import org.opensearch.securityanalytics.rules.utils.AnyOneOf;
@@ -111,7 +112,14 @@ public class SigmaDetectionItem {
 
         List<SigmaType> sigmaTypes = new ArrayList<>();
         for (T v: values) {
-            sigmaTypes.add(SigmaTypeFacade.sigmaType(v));
+            SigmaType sigmaType = SigmaTypeFacade.sigmaType(v);
+            // throws an error if sigmaType is an empty string and the modifier is "contains" or "startswith" or "endswith"
+            boolean invalidModifierWithEmptyString = modifierIds.contains("contains") || modifierIds.contains("startswith") || modifierIds.contains("endswith");
+            if (sigmaType.getClass().equals(SigmaString.class) && v.toString().isEmpty() && invalidModifierWithEmptyString) {
+                throw new SigmaValueError("Cannot create rule with empty string and given modifier(s): " + modifierIds);
+            } else {
+                sigmaTypes.add(sigmaType);
+            }
         }
 
         return new SigmaDetectionItem(field, modifiers, sigmaTypes, null, null, true);

--- a/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
@@ -907,6 +907,78 @@ public class QueryBackendTests extends OpenSearchTestCase {
         Assert.assertEquals("((mappedA: \"value1\") OR (mappedA: \"value2\") OR (mappedA: \"value3\")) OR (test*)", queries.get(0).toString());
     }
 
+    public void testConvertSkipEmptyStringStartsWithModifier() throws IOException, SigmaError {
+        OSQueryBackend queryBackend = testBackend();
+        Assert.assertThrows(SigmaValueError.class, () -> {
+            queryBackend.convertRule(SigmaRule.fromYaml(
+                    "            title: Test\n" +
+                            "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
+                            "            status: test\n" +
+                            "            level: critical\n" +
+                            "            description: Detects QuarksPwDump clearing access history in hive\n" +
+                            "            author: Florian Roth\n" +
+                            "            date: 2017/05/15\n" +
+                            "            logsource:\n" +
+                            "                category: test_category\n" +
+                            "                product: test_product\n" +
+                            "            detection:\n" +
+                            "                sel:\n" +
+                            "                    fieldA1|startswith: \n" +
+                            "                        - value1\n" +
+                            "                        - value2\n" +
+                            "                        - ''\n" +
+                            "                condition: sel", false));
+        });
+    }
+
+    public void testConvertSkipEmptyStringEndsWithModifier() throws IOException, SigmaError {
+        OSQueryBackend queryBackend = testBackend();
+        Assert.assertThrows(SigmaValueError.class, () -> {
+            queryBackend.convertRule(SigmaRule.fromYaml(
+                    "            title: Test\n" +
+                            "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
+                            "            status: test\n" +
+                            "            level: critical\n" +
+                            "            description: Detects QuarksPwDump clearing access history in hive\n" +
+                            "            author: Florian Roth\n" +
+                            "            date: 2017/05/15\n" +
+                            "            logsource:\n" +
+                            "                category: test_category\n" +
+                            "                product: test_product\n" +
+                            "            detection:\n" +
+                            "                sel:\n" +
+                            "                    fieldA1|endswith: \n" +
+                            "                        - value1\n" +
+                            "                        - value2\n" +
+                            "                        - ''\n" +
+                            "                condition: sel", false));
+        });
+    }
+
+    public void testConvertSkipEmptyStringContainsModifier() throws IOException, SigmaError {
+        OSQueryBackend queryBackend = testBackend();
+        Assert.assertThrows(SigmaValueError.class, () -> {
+            queryBackend.convertRule(SigmaRule.fromYaml(
+                    "            title: Test\n" +
+                            "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
+                            "            status: test\n" +
+                            "            level: critical\n" +
+                            "            description: Detects QuarksPwDump clearing access history in hive\n" +
+                            "            author: Florian Roth\n" +
+                            "            date: 2017/05/15\n" +
+                            "            logsource:\n" +
+                            "                category: test_category\n" +
+                            "                product: test_product\n" +
+                            "            detection:\n" +
+                            "                sel:\n" +
+                            "                    fieldA1|contains: \n" +
+                            "                        - value1\n" +
+                            "                        - value2\n" +
+                            "                        - ''\n" +
+                            "                condition: sel", false));
+        });
+    }
+
     private OSQueryBackend testBackend() throws IOException {
         return new OSQueryBackend(testFieldMapping, false, true);
     }


### PR DESCRIPTION
Manual backport of #860 to 2.x

---------

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
