### PR TITLE
Test for curl version 7.87 or greater

### DIFF
--- a/.github/workflows/test-curl-version-security-test-workflow.yml
+++ b/.github/workflows/test-curl-version-security-test-workflow.yml
@@ -1,0 +1,92 @@
+name: Security Test Workflow
+# This workflow is triggered on pull requests and pushes to main or an OpenSearch release branch
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "*"
+env:
+  OPENSEARCH_INITIAL_ADMIN_PASSWORD: myStrongPassword123!
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [ 11, 17, 21 ]
+    # Job name
+    name: Build and test SecurityAnalytics
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      # This step uses the checkout Github action: https://github.com/actions/checkout
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build SecurityAnalytics
+        # Only assembling since the full build is governed by other workflows
+        run: ./gradlew assemble
+
+      - name: Pull and Run Docker
+        run: |
+          plugin=`basename $(ls build/distributions/*.zip)`
+          list_of_files=`ls`
+          list_of_all_files=`ls build/distributions/`
+          version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
+          qualifier=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`
+          candidate_version=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
+          docker_version=$version
+
+          [[ -z $candidate_version ]] && candidate_version=$qualifier && qualifier=""
+
+          echo plugin version plugin_version qualifier candidate_version docker_version
+          echo "($plugin) ($version) ($plugin_version) ($qualifier) ($candidate_version) ($docker_version)"
+          echo $ls $list_of_all_files
+
+          if docker pull opensearchstaging/opensearch:$docker_version
+          then
+            echo "FROM opensearchstaging/opensearch:$docker_version" >> Dockerfile
+            echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-security-analytics ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security-analytics; fi" >> Dockerfile
+            echo "ADD build/distributions/$plugin /tmp/" >> Dockerfile
+            echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/$plugin" >> Dockerfile
+
+            docker build -t opensearch-security-analytics:test .
+            echo "imagePresent=true" >> $GITHUB_ENV
+          else
+            echo "imagePresent=false" >> $GITHUB_ENV
+          fi
+
+      - name: Run Docker Image
+        if: env.imagePresent == 'true'
+        run: |
+          cd ..
+          docker run -p 9200:9200 -d -p 9600:9600 -e OPENSEARCH_INITIAL_ADMIN_PASSWORD=${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} -e "discovery.type=single-node" opensearch-security-analytics:test
+          sleep 120
+
+      - name: Run SecurityAnalytics Test for security enabled test cases
+        if: env.imagePresent == 'true'
+        run: |
+          curl_version=`curl --version`
+          echo "The curl version is " $curl_version
+          cluster_running=`curl -XGET https://localhost:9200/_cat/plugins -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} --insecure`
+          echo $cluster_running
+          security=`curl -XGET https://localhost:9200/_cat/plugins -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} --insecure |grep opensearch-security|wc -l`
+          echo $security
+          if [ $security -gt 0 ]
+          then
+            echo "Security plugin is available"
+            ./gradlew :integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Dhttps=true -Duser=admin -Dpassword=${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
+          else
+            echo "Security plugin is NOT available skipping this run as tests without security have already been run"
+          fi


### PR DESCRIPTION
### Description
Test PR for checking the curl --version due to security tests workflow failing with an error
curl: (35) error:0A00010B:SSL routines::wrong version number
https://github.com/curl/curl/issues/9931
 
### Issues Resolved
Check for curl version as there's a known bug in curl 7.86
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
