### PR TITLE
Fix keywords bug incorrectly adding field value

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
@@ -381,10 +381,16 @@ public class OSQueryBackend extends QueryBackend {
         return null;
     }*/
 
+    /**
+     * Method used when structure of Sigma Rule does not have a field associated with the condition item and the value
+     * is a SigmaString type
+     * Ex:
+     *  condition: selection_1
+     *  selection1:
+     *      - keyword1
+     */
     @Override
     public Object convertConditionValStr(ConditionValueExpression condition, boolean applyDeMorgans) throws SigmaValueError {
-        String field = getFinalValueField();
-        ruleQueryFields.put(field, Map.of("type", "text", "analyzer", "rule_analyzer"));
         SigmaString value = (SigmaString) condition.getValue();
         boolean containsWildcard = value.containsWildcard();
         String exprWithDeMorgansApplied = this.notToken + " " + "%s";
@@ -397,6 +403,10 @@ public class OSQueryBackend extends QueryBackend {
         return conditionValStr;
     }
 
+    /**
+     * Method used when structure of Sigma Rule does not have a field associated with the condition item and the value
+     * is a SigmaNumber type
+     */
     @Override
     public Object convertConditionValNum(ConditionValueExpression condition, boolean applyDeMorgans) {
         String exprWithDeMorgansApplied = this.notToken + " " + "%s";
@@ -407,6 +417,10 @@ public class OSQueryBackend extends QueryBackend {
         return conditionValNum;
     }
 
+    /**
+     * Method used when structure of Sigma Rule does not have a field associated with the condition item and the value
+     * is a SigmaRegularExpression type
+     */
     @Override
     public Object convertConditionValRe(ConditionValueExpression condition, boolean applyDeMorgans) {
         String exprWithDeMorgansApplied = this.notToken + " " + "%s";
@@ -514,12 +528,6 @@ public class OSQueryBackend extends QueryBackend {
 
     private String getFinalField(String field) {
         return this.getMappedField(field);
-    }
-
-    private String getFinalValueField() {
-        String field = "_" + valExpCount;
-        valExpCount++;
-        return field;
     }
 
     public static class AggregationQueries implements Writeable, ToXContentObject {


### PR DESCRIPTION
### Description
When a sigma rule has a keywords structure (example below), we do not want to include a field value in the `ruleQueryFields` because there is no field associated with a keyword.

```
Ex:
  condition: selection_1
  selection1:
    - keyword1
```
PR also adds comments to clarify methods meaning.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
