### PR TITLE
[BUG_FIX] fix check for agg rules in detector trigger condition to create chained findings monitor

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -901,7 +901,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                                 @Override
                                 public void onResponse(Collection<IndexMonitorRequest> indexMonitorRequests) {
                                     // if workflow usage enabled, add chained findings monitor request if there are bucket level requests and if the detector triggers have any group by rules configured to trigger
-                                    if (enabledWorkflowUsage && !monitorRequests.isEmpty() && !DetectorUtils.getAggRuleIdsConfiguredToTrigger(detector, queries).isEmpty()) {
+                                    if (enabledWorkflowUsage && !monitorRequests.isEmpty()) {
                                         monitorRequests.add(createDocLevelMonitorMatchAllRequest(detector, RefreshPolicy.IMMEDIATE, detector.getId() + "_chained_findings", Method.POST));
                                     }
                                     listener.onResponse(monitorRequests);

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -910,7 +910,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                                 @Override
                                 public void onResponse(Collection<IndexMonitorRequest> indexMonitorRequests) {
                                     // if workflow usage enabled, add chained findings monitor request if there are bucket level requests and if the detector triggers have any group by rules configured to trigger
-                                    if (enabledWorkflowUsage && !monitorRequests.isEmpty()) {
+                                    if (enabledWorkflowUsage && !monitorRequests.isEmpty() && queries.stream().anyMatch(it -> it.getRight().isAggregationRule())) {
                                         monitorRequests.add(createDocLevelMonitorMatchAllRequest(detector, RefreshPolicy.IMMEDIATE, detector.getId() + "_chained_findings", Method.POST, queries));
                                     }
                                     listener.onResponse(monitorRequests);

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -294,7 +294,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
                             // Indexing monitors in two steps in order to prevent all shards failed error from alerting
                             // https://github.com/opensearch-project/alerting/issues/646
-
+                            AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, monitorRequests.get(0), namedWriteableRegistry, addFirstMonitorStep);
                             addFirstMonitorStep.whenComplete(addedFirstMonitorResponse -> {
                                         log.debug("first monitor created id {} of type {}", addedFirstMonitorResponse.getId(), addedFirstMonitorResponse.getMonitor().getMonitorType());
                                         monitorResponses.add(addedFirstMonitorResponse);
@@ -325,7 +325,6 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                                         listener.onFailure(e1);
                                     }
                             );
-                            AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, monitorRequests.get(0), namedWriteableRegistry, addFirstMonitorStep);
                         }, listener::onFailure);
                     } else {
                         // Failure if detector doesn't have any monitor

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -294,7 +294,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
                             // Indexing monitors in two steps in order to prevent all shards failed error from alerting
                             // https://github.com/opensearch-project/alerting/issues/646
-                            AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, monitorRequests.get(0), namedWriteableRegistry, addFirstMonitorStep);
+
                             addFirstMonitorStep.whenComplete(addedFirstMonitorResponse -> {
                                         log.debug("first monitor created id {} of type {}", addedFirstMonitorResponse.getId(), addedFirstMonitorResponse.getMonitor().getMonitorType());
                                         monitorResponses.add(addedFirstMonitorResponse);
@@ -325,6 +325,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                                         listener.onFailure(e1);
                                     }
                             );
+                            AlertingPluginInterface.INSTANCE.indexMonitor((NodeClient) client, monitorRequests.get(0), namedWriteableRegistry, addFirstMonitorStep);
                         }, listener::onFailure);
                     } else {
                         // Failure if detector doesn't have any monitor

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorUtils.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorUtils.java
@@ -104,17 +104,12 @@ public class DetectorUtils {
         });
     }
 
-    public static List<String> getBucketLevelMonitorIdsWhoseRulesAreConfiguredToTrigger(
-            Detector detector,
-            List<Pair<String, Rule>> rulesById,
+    public static List<String> getBucketLevelMonitorIds(
             List<IndexMonitorResponse> monitorResponses
     ) {
-        List<String> aggRuleIdsConfiguredToTrigger = getAggRuleIdsConfiguredToTrigger(detector, rulesById);
         return monitorResponses.stream().filter(
                 // In the case of bucket level monitors rule id is trigger id
                 it -> Monitor.MonitorType.BUCKET_LEVEL_MONITOR == it.getMonitor().getMonitorType()
-                        && !it.getMonitor().getTriggers().isEmpty()
-                        && aggRuleIdsConfiguredToTrigger.contains(it.getMonitor().getTriggers().get(0).getId())
                 ).map(IndexMonitorResponse::getId).collect(Collectors.toList());
     }
     public static List<String> getAggRuleIdsConfiguredToTrigger(Detector detector, List<Pair<String, Rule>> rulesById) {

--- a/src/main/java/org/opensearch/securityanalytics/util/WorkflowService.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/WorkflowService.java
@@ -21,7 +21,6 @@ import org.opensearch.commons.alerting.action.IndexWorkflowResponse;
 import org.opensearch.commons.alerting.model.ChainedMonitorFindings;
 import org.opensearch.commons.alerting.model.CompositeInput;
 import org.opensearch.commons.alerting.model.Delegate;
-import org.opensearch.commons.alerting.model.Monitor.MonitorType;
 import org.opensearch.commons.alerting.model.Sequence;
 import org.opensearch.commons.alerting.model.Workflow;
 import org.opensearch.commons.alerting.model.Workflow.WorkflowType;
@@ -34,12 +33,11 @@ import org.opensearch.securityanalytics.model.Rule;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static org.opensearch.securityanalytics.util.DetectorUtils.getBucketLevelMonitorIdsWhoseRulesAreConfiguredToTrigger;
+import static org.opensearch.securityanalytics.util.DetectorUtils.getBucketLevelMonitorIds;
 
 /**
  * Alerting common clas used for workflow manipulation
@@ -101,7 +99,7 @@ public class WorkflowService {
                 monitorResponses.addAll(updatedMonitorResponses);
             }
             cmfMonitorId = addedMonitorResponses.stream().filter(res -> (detector.getName() + "_chained_findings").equals(res.getMonitor().getName())).findFirst().get().getId();
-            chainedMonitorFindings = new ChainedMonitorFindings(null, getBucketLevelMonitorIdsWhoseRulesAreConfiguredToTrigger(detector, rulesById, monitorResponses));
+            chainedMonitorFindings = new ChainedMonitorFindings(null, getBucketLevelMonitorIds(monitorResponses));
         }
 
         IndexWorkflowRequest indexWorkflowRequest = createWorkflowRequest(monitorIds,

--- a/src/test/java/org/opensearch/securityanalytics/alerts/AlertsIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/alerts/AlertsIT.java
@@ -7,11 +7,14 @@ package org.opensearch.securityanalytics.alerts;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.hc.core5.http.HttpStatus;
@@ -23,6 +26,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
+import org.opensearch.commons.alerting.model.Monitor;
 import org.opensearch.commons.alerting.model.action.Action;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.search.SearchHit;
@@ -37,7 +41,9 @@ import org.opensearch.securityanalytics.model.DetectorTrigger;
 
 import static org.opensearch.securityanalytics.TestHelpers.netFlowMappings;
 import static org.opensearch.securityanalytics.TestHelpers.randomAction;
+import static org.opensearch.securityanalytics.TestHelpers.randomAggregationRule;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorType;
+import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputs;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputsAndThreatIntel;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputsAndTriggers;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithTriggers;
@@ -662,6 +668,150 @@ public class AlertsIT extends SecurityAnalyticsRestTestCase {
         assertTrue("Did not find 3 alert indices", alertIndices.size() >= 3);
 
         restoreAlertsFindingsIMSettings();
+    }
+    /**
+     * 1. Creates detector with aggregation and prepackaged rules
+     * (sum rule - should match docIds: 1, 2, 3; maxRule - 4, 5, 6, 7; minRule - 7)
+     * 2. Verifies monitor execution
+     * 3. Verifies alerts
+     *
+     * @throws IOException
+     */
+    public void testMultipleAggregationAndDocRules_alertSuccess() throws IOException {
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        // Execute CreateMappingsAction to add alias mapping for index
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        // both req params and req body are supported
+        createMappingRequest.setJsonEntity(
+                "{ \"index_name\":\"" + index + "\"," +
+                        "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                        "  \"partial\":true" +
+                        "}"
+        );
+
+        Response createMappingResponse = client().performRequest(createMappingRequest);
+
+        assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
+
+        String infoOpCode = "Info";
+
+        // 5 custom aggregation rules
+        String sumRuleId = createRule(randomAggregationRule("sum", " > 1", infoOpCode));
+//        String maxRuleId = createRule(randomAggregationRule("max", " > 3", infoOpCode));
+
+
+        List<DetectorRule> detectorRules = List.of(new DetectorRule(sumRuleId)
+//                ,new DetectorRule(maxRuleId)
+        );
+
+        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
+                Collections.emptyList());
+        Detector detector = randomDetectorWithInputsAndTriggers(List.of(input),
+                List.of(new DetectorTrigger("randomtrigegr", "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of(), List.of()))
+                );
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.DETECTOR_BASE_URI, Collections.emptyMap(), toHttpEntity(detector));
+
+
+        String request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match_all\":{\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+        SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
+
+        assertEquals(1, response.getHits().getTotalHits().value); // 5 for rules, 1 for match_all query in chained findings monitor
+
+        assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
+        Map<String, Object> responseBody = asMap(createResponse);
+        String detectorId = responseBody.get("_id").toString();
+        request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match\":{\n" +
+                "        \"_id\": \"" + detectorId + "\"\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+        List<SearchHit> hits = executeSearch(Detector.DETECTORS_INDEX, request);
+        SearchHit hit = hits.get(0);
+        Map<String, List> updatedDetectorMap = (HashMap<String, List>) (hit.getSourceAsMap().get("detector"));
+
+        List<String> monitorIds = ((List<String>) (updatedDetectorMap).get("monitor_id"));
+
+        indexDoc(index, "1", randomDoc(2, 4, infoOpCode));
+        indexDoc(index, "2", randomDoc(3, 4, infoOpCode));
+//        indexDoc(index, "3", randomDoc(1, 4, infoOpCode));
+//        indexDoc(index, "4", randomDoc(5, 3, infoOpCode));
+//        indexDoc(index, "5", randomDoc(2, 3, infoOpCode));
+//        indexDoc(index, "6", randomDoc(4, 3, infoOpCode));
+//        indexDoc(index, "7", randomDoc(6, 2, infoOpCode));
+//        indexDoc(index, "8", randomDoc(1, 1, infoOpCode));
+
+        Map<String, Integer> numberOfMonitorTypes = new HashMap<>();
+
+        for (String monitorId : monitorIds) {
+            Map<String, String> monitor = (Map<String, String>) (entityAsMap(client().performRequest(new Request("GET", "/_plugins/_alerting/monitors/" + monitorId)))).get("monitor");
+            numberOfMonitorTypes.merge(monitor.get("monitor_type"), 1, Integer::sum);
+            Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+
+            // Assert monitor executions
+            Map<String, Object> executeResults = entityAsMap(executeResponse);
+            if (Monitor.MonitorType.DOC_LEVEL_MONITOR.getValue().equals(monitor.get("monitor_type")) && false == monitor.get("name").equals(detector.getName() + "_chained_findings")) {
+                int noOfSigmaRuleMatches = ((List<Map<String, Object>>) ((Map<String, Object>) executeResults.get("input_results")).get("results")).get(0).size();
+                assertEquals(5, noOfSigmaRuleMatches);
+            }
+        }
+
+         assertEquals(1, numberOfMonitorTypes.get(Monitor.MonitorType.BUCKET_LEVEL_MONITOR.getValue()).intValue());
+         assertEquals(1, numberOfMonitorTypes.get(Monitor.MonitorType.DOC_LEVEL_MONITOR.getValue()).intValue());
+
+        Map<String, String> params = new HashMap<>();
+        params.put("detector_id", detectorId);
+        Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
+        Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
+
+        // Assert findings
+        assertNotNull(getFindingsBody);
+        // 8 findings from doc level rules, and 3 findings for aggregation (sum, max and min)assertEquals(1, getFindingsBody.get("total_findings"));
+        assertEquals(1, getFindingsBody.get("total_findings"));
+
+        String findingDetectorId = ((Map<String, Object>) ((List) getFindingsBody.get("findings")).get(0)).get("detectorId").toString();
+        assertEquals(detectorId, findingDetectorId);
+
+        String findingIndex = ((Map<String, Object>) ((List) getFindingsBody.get("findings")).get(0)).get("index").toString();
+        assertEquals(index, findingIndex);
+
+        List<String> docLevelFinding = new ArrayList<>();
+        List<Map<String, Object>> findings = (List) getFindingsBody.get("findings");
+
+
+        for (Map<String, Object> finding : findings) {
+            List<Map<String, Object>> queries = (List<Map<String, Object>>) finding.get("queries");
+            Set<String> findingRuleIds = queries.stream().map(it -> it.get("id").toString()).collect(Collectors.toSet());
+
+                // In the case of bucket level monitors, queries will always contain one value
+                String aggRuleId = findingRuleIds.iterator().next();
+                List<String> findingDocs = (List<String>) finding.get("related_doc_ids");
+
+                if (aggRuleId.equals(sumRuleId)) {
+                    assertTrue(List.of("1", "2", "3", "4", "5", "6", "7").containsAll(findingDocs));
+                }
+//                else if (aggRuleId.equals(maxRuleId)) {
+//                    assertTrue(List.of("4", "5", "6", "7").containsAll(findingDocs));
+//                }
+
+        }
+
+        assertTrue(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8").containsAll(docLevelFinding));
+
+        Map<String, String> params1 = new HashMap<>();
+        params1.put("detector_id", detectorId);
+        Response getAlertsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.ALERTS_BASE_URI, params1, null);
+        Map<String, Object> getAlertsBody = asMap(getAlertsResponse);
+        // TODO enable asserts here when able
+        Assert.assertEquals(3, getAlertsBody.get("total_alerts")); // 2 doc level alerts for each doc, 1 bucket level alert
     }
 
     public void testAlertHistoryRollover_maxAge_low_retention() throws IOException, InterruptedException {

--- a/src/test/java/org/opensearch/securityanalytics/alerts/AlertsIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/alerts/AlertsIT.java
@@ -680,9 +680,7 @@ public class AlertsIT extends SecurityAnalyticsRestTestCase {
     public void testMultipleAggregationAndDocRules_alertSuccess() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        // Execute CreateMappingsAction to add alias mapping for index
         Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
-        // both req params and req body are supported
         createMappingRequest.setJsonEntity(
                 "{ \"index_name\":\"" + index + "\"," +
                         "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
@@ -696,14 +694,10 @@ public class AlertsIT extends SecurityAnalyticsRestTestCase {
 
         String infoOpCode = "Info";
 
-        // 5 custom aggregation rules
         String sumRuleId = createRule(randomAggregationRule("sum", " > 1", infoOpCode));
-//        String maxRuleId = createRule(randomAggregationRule("max", " > 3", infoOpCode));
 
 
-        List<DetectorRule> detectorRules = List.of(new DetectorRule(sumRuleId)
-//                ,new DetectorRule(maxRuleId)
-        );
+        List<DetectorRule> detectorRules = List.of(new DetectorRule(sumRuleId));
 
         DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), detectorRules,
                 Collections.emptyList());
@@ -742,12 +736,6 @@ public class AlertsIT extends SecurityAnalyticsRestTestCase {
 
         indexDoc(index, "1", randomDoc(2, 4, infoOpCode));
         indexDoc(index, "2", randomDoc(3, 4, infoOpCode));
-//        indexDoc(index, "3", randomDoc(1, 4, infoOpCode));
-//        indexDoc(index, "4", randomDoc(5, 3, infoOpCode));
-//        indexDoc(index, "5", randomDoc(2, 3, infoOpCode));
-//        indexDoc(index, "6", randomDoc(4, 3, infoOpCode));
-//        indexDoc(index, "7", randomDoc(6, 2, infoOpCode));
-//        indexDoc(index, "8", randomDoc(1, 1, infoOpCode));
 
         Map<String, Integer> numberOfMonitorTypes = new HashMap<>();
 
@@ -772,9 +760,7 @@ public class AlertsIT extends SecurityAnalyticsRestTestCase {
         Response getFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.FINDINGS_BASE_URI + "/_search", params, null);
         Map<String, Object> getFindingsBody = entityAsMap(getFindingsResponse);
 
-        // Assert findings
         assertNotNull(getFindingsBody);
-        // 8 findings from doc level rules, and 3 findings for aggregation (sum, max and min)assertEquals(1, getFindingsBody.get("total_findings"));
         assertEquals(1, getFindingsBody.get("total_findings"));
 
         String findingDetectorId = ((Map<String, Object>) ((List) getFindingsBody.get("findings")).get(0)).get("detectorId").toString();
@@ -798,10 +784,6 @@ public class AlertsIT extends SecurityAnalyticsRestTestCase {
                 if (aggRuleId.equals(sumRuleId)) {
                     assertTrue(List.of("1", "2", "3", "4", "5", "6", "7").containsAll(findingDocs));
                 }
-//                else if (aggRuleId.equals(maxRuleId)) {
-//                    assertTrue(List.of("4", "5", "6", "7").containsAll(findingDocs));
-//                }
-
         }
 
         assertTrue(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8").containsAll(docLevelFinding));

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
@@ -890,7 +890,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                 "}";
         SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
 
-        assertEquals(6, response.getHits().getTotalHits().value);
+        assertEquals(7, response.getHits().getTotalHits().value); // 6 for rules, 1 for match_all query in chained findings monitor
 
         assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
         Map<String, Object> responseBody = asMap(createResponse);
@@ -910,8 +910,9 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(6, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
 
         List<String> monitorIds = ((List<String>) (updatedDetectorMap).get("monitor_id"));
-
-        assertEquals(6, monitorIds.size());
+        System.out.println("sashank");
+        monitorIds.forEach(it-> System.out.println(it + ", "));
+        assertEquals(7, monitorIds.size());
 
         indexDoc(index, "1", randomDoc(2, 4, infoOpCode));
         indexDoc(index, "2", randomDoc(3, 4, infoOpCode));
@@ -952,7 +953,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         }
 
         assertEquals(5, numberOfMonitorTypes.get(MonitorType.BUCKET_LEVEL_MONITOR.getValue()).intValue());
-        assertEquals(1, numberOfMonitorTypes.get(MonitorType.DOC_LEVEL_MONITOR.getValue()).intValue());
+        assertEquals(2, numberOfMonitorTypes.get(MonitorType.DOC_LEVEL_MONITOR.getValue()).intValue());
 
         Map<String, String> params = new HashMap<>();
         params.put("detector_id", detectorId);
@@ -1037,7 +1038,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                 "}";
         SearchResponse response = executeSearchAndGetResponse(DetectorMonitorConfig.getRuleIndex(randomDetectorType()), request, true);
 
-        assertEquals(1, response.getHits().getTotalHits().value);
+        assertEquals(2, response.getHits().getTotalHits().value);
 
         assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
         Map<String, Object> responseBody = asMap(createResponse);
@@ -1058,13 +1059,13 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(2, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
 
         List<String> monitorIds = ((List<String>) (detectorMap).get("monitor_id"));
-        assertEquals(2, monitorIds.size());
+        assertEquals(3, monitorIds.size());
 
         assertNotNull("Workflow not created", detectorMap.get("workflow_ids"));
         assertEquals("Number of workflows not correct", 1, ((List<String>) detectorMap.get("workflow_ids")).size());
 
         // Verify workflow
-        verifyWorkflow(detectorMap, monitorIds, 2);
+        verifyWorkflow(detectorMap, monitorIds, 3);
     }
 
     public void testCreateDetector_verifyWorkflowCreation_success_WithGroupByRulesInTrigger() throws IOException {

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorMonitorRestApiIT.java
@@ -910,8 +910,6 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         assertEquals(6, ((Map<String, Map<String, List>>) inputArr.get(0)).get("detector_input").get("custom_rules").size());
 
         List<String> monitorIds = ((List<String>) (updatedDetectorMap).get("monitor_id"));
-        System.out.println("sashank");
-        monitorIds.forEach(it-> System.out.println(it + ", "));
         assertEquals(7, monitorIds.size());
 
         indexDoc(index, "1", randomDoc(2, 4, infoOpCode));
@@ -1613,6 +1611,7 @@ public class DetectorMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         indexDoc(index, "7", randomDoc(6, 2, testOpCode));
         indexDoc(index, "8", randomDoc(1, 1, testOpCode));
         // Verify workflow
+
         verifyWorkflow(detectorMap, monitorIds, 7);
 
         String workflowId = ((List<String>) detectorMap.get("workflow_ids")).get(0);


### PR DESCRIPTION

### Description
remove check for agg rules in detector trigger condition to create chained findings monitor.
Currently, chained findings monitor is not created unless ids of aggregation Sigma rules are not mentioned in the detector trigger condition
Right behaviour is to create chained findings monitor irrespective of trigger condition.
Add agg rule tags to chained findings monitor
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
