### PR TITLE
Add S3 connector for TIF stored in S3

### DIFF
--- a/tif/build.gradle
+++ b/tif/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id 'java'
+    id 'java-library'
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+}
+
+dependencies {
+    implementation 'software.amazon.awssdk:s3:2.25.42'
+    implementation 'software.amazon.awssdk:sts:2.25.42'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.17.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
+    implementation 'com.fasterxml.jackson.module:jackson-module-afterburner:2.17.0'
+    implementation 'com.google.guava:guava:33.1.0-jre'
+
+    testImplementation "org.mockito:mockito-inline:5.2.0"
+    testImplementation "org.mockito:mockito-core:5.11.0"
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.1'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/IOCConnector.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/IOCConnector.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector;
 
 import org.opensearch.securityanalytics.model.IOC;

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/IOCConnector.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/IOCConnector.java
@@ -1,0 +1,14 @@
+package org.opensearch.securityanalytics.connector;
+
+import org.opensearch.securityanalytics.model.IOC;
+
+import java.util.List;
+
+public interface IOCConnector {
+    /**
+     * Loads a list of IOCs from a storage system
+     *
+     * @return List<IOC> a list of the retrieved IOCs
+     */
+    List<IOC> loadIOCs();
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/S3Connector.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/S3Connector.java
@@ -1,0 +1,40 @@
+package org.opensearch.securityanalytics.connector;
+
+import org.opensearch.securityanalytics.connector.codec.InputCodec;
+import org.opensearch.securityanalytics.connector.factory.InputCodecFactory;
+import org.opensearch.securityanalytics.connector.factory.S3ClientFactory;
+import org.opensearch.securityanalytics.connector.model.S3ConnectorConfig;
+import org.opensearch.securityanalytics.model.IOC;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.util.List;
+
+public class S3Connector implements IOCConnector {
+    private final S3ConnectorConfig s3ConnectorConfig;
+    private final S3Client s3Client;
+    private final InputCodec inputCodec;
+
+    public S3Connector(final S3ConnectorConfig s3ConnectorConfig, final S3ClientFactory s3ClientFactory, final InputCodecFactory inputCodecFactory) {
+        this.s3ConnectorConfig = s3ConnectorConfig;
+        this.s3Client = s3ClientFactory.create(s3ConnectorConfig.getRoleArn(), s3ConnectorConfig.getRegion());
+        this.inputCodec = inputCodecFactory.create(s3ConnectorConfig.getInputCodecSchema(), s3ConnectorConfig.getIocSchema());
+    }
+
+    @Override
+    public List<IOC> loadIOCs() {
+        final GetObjectRequest getObjectRequest = getObjectRequest();
+        final ResponseInputStream<GetObjectResponse> response = s3Client.getObject(getObjectRequest);
+
+        return inputCodec.parse(response);
+    }
+
+    private GetObjectRequest getObjectRequest() {
+        return GetObjectRequest.builder()
+                .bucket(s3ConnectorConfig.getBucketName())
+                .key(s3ConnectorConfig.getObjectKey())
+                .build();
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/S3Connector.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/S3Connector.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector;
 
 import org.opensearch.securityanalytics.connector.codec.InputCodec;

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/codec/InputCodec.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/codec/InputCodec.java
@@ -1,0 +1,16 @@
+package org.opensearch.securityanalytics.connector.codec;
+
+import org.opensearch.securityanalytics.model.IOC;
+
+import java.io.InputStream;
+import java.util.List;
+
+public interface InputCodec {
+    /**
+     * Parses an {@link InputStream} into the provided type.
+     *
+     * @param inputStream The input stream for code to process
+     * @return List<IOC> A list of IOCs parsed from the input stream
+     */
+    List<IOC> parse(InputStream inputStream);
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/codec/InputCodec.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/codec/InputCodec.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.codec;
 
 import org.opensearch.securityanalytics.model.IOC;

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/codec/NewlineDelimitedJsonCodec.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/codec/NewlineDelimitedJsonCodec.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.codec;
 
 import com.fasterxml.jackson.databind.MappingIterator;

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/codec/NewlineDelimitedJsonCodec.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/codec/NewlineDelimitedJsonCodec.java
@@ -1,0 +1,36 @@
+package org.opensearch.securityanalytics.connector.codec;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import com.google.common.annotations.VisibleForTesting;
+import org.opensearch.securityanalytics.exceptions.ConnectorParsingException;
+import org.opensearch.securityanalytics.model.IOC;
+
+import java.io.InputStream;
+import java.util.List;
+
+public class NewlineDelimitedJsonCodec implements InputCodec {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
+    private final ObjectReader objectReader;
+
+    public NewlineDelimitedJsonCodec(final Class<? extends IOC> clazz) {
+        this.objectReader = OBJECT_MAPPER.readerFor(clazz);
+    }
+
+    @VisibleForTesting
+    NewlineDelimitedJsonCodec(final ObjectReader objectReader) {
+        this.objectReader = objectReader;
+    }
+
+    @Override
+    public List<IOC> parse(final InputStream inputStream) {
+        try {
+            final MappingIterator<IOC> mappingIterator = objectReader.readValues(inputStream);
+            return mappingIterator.readAll();
+        } catch (final Exception e) {
+            throw new ConnectorParsingException(e);
+        }
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/InputCodecFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/InputCodecFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.factory;
 
 import org.opensearch.securityanalytics.connector.codec.InputCodec;

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/InputCodecFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/InputCodecFactory.java
@@ -1,0 +1,13 @@
+package org.opensearch.securityanalytics.connector.factory;
+
+import org.opensearch.securityanalytics.connector.codec.InputCodec;
+import org.opensearch.securityanalytics.factory.BinaryParameterCachingFactory;
+import org.opensearch.securityanalytics.model.IOCSchema;
+import org.opensearch.securityanalytics.connector.model.InputCodecSchema;
+
+public class InputCodecFactory extends BinaryParameterCachingFactory<InputCodecSchema, IOCSchema, InputCodec> {
+    @Override
+    protected InputCodec doCreate(final InputCodecSchema inputCodecSchema, final IOCSchema iocSchema) {
+        return inputCodecSchema.getInputCodecConstructor().apply(iocSchema);
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/S3ClientFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/S3ClientFactory.java
@@ -1,0 +1,24 @@
+package org.opensearch.securityanalytics.connector.factory;
+
+import org.opensearch.securityanalytics.factory.BinaryParameterCachingFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class S3ClientFactory extends BinaryParameterCachingFactory<String, String, S3Client> {
+    private final StsAssumeRoleCredentialsProviderFactory stsAssumeRoleCredentialsProviderFactory;
+
+    public S3ClientFactory(final StsAssumeRoleCredentialsProviderFactory stsAssumeRoleCredentialsProviderFactory) {
+        super();
+        this.stsAssumeRoleCredentialsProviderFactory = stsAssumeRoleCredentialsProviderFactory;
+    }
+
+    @Override
+    protected S3Client doCreate(final String roleArn, final String region) {
+        final AwsCredentialsProvider credentialsProvider = stsAssumeRoleCredentialsProviderFactory.create(roleArn, region);
+        return S3Client.builder()
+                .credentialsProvider(credentialsProvider)
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/S3ClientFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/S3ClientFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.factory;
 
 import org.opensearch.securityanalytics.factory.BinaryParameterCachingFactory;

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/StsAssumeRoleCredentialsProviderFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/StsAssumeRoleCredentialsProviderFactory.java
@@ -1,0 +1,57 @@
+package org.opensearch.securityanalytics.connector.factory;
+
+import org.opensearch.securityanalytics.factory.BinaryParameterCachingFactory;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class StsAssumeRoleCredentialsProviderFactory extends BinaryParameterCachingFactory<String, String, AwsCredentialsProvider> {
+    private static final String AWS_IAM = "iam";
+    private static final String AWS_IAM_ROLE = "role";
+
+    private final StsClientFactory stsClientFactory;
+
+    public StsAssumeRoleCredentialsProviderFactory(final StsClientFactory stsClientFactory) {
+        super();
+        this.stsClientFactory = stsClientFactory;
+    }
+
+    @Override
+    protected AwsCredentialsProvider doCreate(final String stsRoleArn, final String region) {
+        validateStsRoleArn(stsRoleArn);
+
+        final AssumeRoleRequest.Builder assumeRoleRequestBuilder = AssumeRoleRequest.builder()
+                .roleSessionName("TIF-" + UUID.randomUUID())
+                .roleArn(stsRoleArn);
+        final StsClient stsClient = stsClientFactory.create(region);
+
+        return StsAssumeRoleCredentialsProvider.builder()
+                .stsClient(stsClient)
+                .refreshRequest(assumeRoleRequestBuilder.build())
+                .build();
+    }
+
+    private void validateStsRoleArn(final String stsRoleArn) {
+        final Arn arn = getArn(stsRoleArn);
+        if (!AWS_IAM.equals(arn.service())) {
+            throw new IllegalArgumentException("roleArn must be an IAM Role");
+        }
+        final Optional<String> resourceType = arn.resource().resourceType();
+        if (resourceType.isEmpty() || !resourceType.get().equals(AWS_IAM_ROLE)) {
+            throw new IllegalArgumentException("roleArn must be an IAM Role");
+        }
+    }
+
+    private Arn getArn(final String stsRoleArn) {
+        try {
+            return Arn.fromString(stsRoleArn);
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(String.format("Invalid ARN format for roleArn. Check the format of %s", stsRoleArn));
+        }
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/StsAssumeRoleCredentialsProviderFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/StsAssumeRoleCredentialsProviderFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.factory;
 
 import org.opensearch.securityanalytics.factory.BinaryParameterCachingFactory;

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/StsClientFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/StsClientFactory.java
@@ -1,0 +1,14 @@
+package org.opensearch.securityanalytics.connector.factory;
+
+import org.opensearch.securityanalytics.factory.UnaryParameterCachingFactory;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+
+public class StsClientFactory extends UnaryParameterCachingFactory<String, StsClient> {
+
+    protected StsClient doCreate(final String region) {
+        return StsClient.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/StsClientFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/StsClientFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.factory;
 
 import org.opensearch.securityanalytics.factory.UnaryParameterCachingFactory;

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/StsClientFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/factory/StsClientFactory.java
@@ -5,7 +5,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
 
 public class StsClientFactory extends UnaryParameterCachingFactory<String, StsClient> {
-
+    @Override
     protected StsClient doCreate(final String region) {
         return StsClient.builder()
                 .region(Region.of(region))

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/model/InputCodecSchema.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/model/InputCodecSchema.java
@@ -1,0 +1,21 @@
+package org.opensearch.securityanalytics.connector.model;
+
+import org.opensearch.securityanalytics.connector.codec.InputCodec;
+import org.opensearch.securityanalytics.connector.codec.NewlineDelimitedJsonCodec;
+import org.opensearch.securityanalytics.model.IOCSchema;
+
+import java.util.function.Function;
+
+public enum InputCodecSchema {
+    ND_JSON(iocSchema -> new NewlineDelimitedJsonCodec(iocSchema.getModelClass()));
+
+    private final Function<IOCSchema, InputCodec> inputCodecConstructor;
+
+    InputCodecSchema(final Function<IOCSchema, InputCodec> inputCodecConstructor) {
+        this.inputCodecConstructor = inputCodecConstructor;
+    }
+
+    public Function<IOCSchema, InputCodec> getInputCodecConstructor() {
+        return inputCodecConstructor;
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/model/InputCodecSchema.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/model/InputCodecSchema.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.model;
 
 import org.opensearch.securityanalytics.connector.codec.InputCodec;

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/model/S3ConnectorConfig.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/model/S3ConnectorConfig.java
@@ -1,0 +1,46 @@
+package org.opensearch.securityanalytics.connector.model;
+
+import org.opensearch.securityanalytics.model.IOCSchema;
+
+public class S3ConnectorConfig {
+    private final String bucketName;
+    private final String objectKey;
+    private final String region;
+    private final String roleArn;
+    private final IOCSchema iocSchema;
+    private final InputCodecSchema inputCodecSchema;
+
+    public S3ConnectorConfig(final String bucketName, final String objectKey, final String region,
+                             final String roleArn, final IOCSchema iocSchema, final InputCodecSchema inputCodecSchema) {
+        this.bucketName = bucketName;
+        this.objectKey = objectKey;
+        this.region = region;
+        this.roleArn = roleArn;
+        this.iocSchema = iocSchema;
+        this.inputCodecSchema = inputCodecSchema;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public String getObjectKey() {
+        return objectKey;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getRoleArn() {
+        return roleArn;
+    }
+
+    public IOCSchema getIocSchema() {
+        return iocSchema;
+    }
+
+    public InputCodecSchema getInputCodecSchema() {
+        return inputCodecSchema;
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/connector/model/S3ConnectorConfig.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/connector/model/S3ConnectorConfig.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.model;
 
 import org.opensearch.securityanalytics.model.IOCSchema;

--- a/tif/src/main/java/org/opensearch/securityanalytics/exceptions/ConnectorParsingException.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/exceptions/ConnectorParsingException.java
@@ -1,0 +1,7 @@
+package org.opensearch.securityanalytics.exceptions;
+
+public class ConnectorParsingException extends RuntimeException {
+    public ConnectorParsingException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/exceptions/ConnectorParsingException.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/exceptions/ConnectorParsingException.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.exceptions;
 
 public class ConnectorParsingException extends RuntimeException {

--- a/tif/src/main/java/org/opensearch/securityanalytics/factory/BinaryParameterCachingFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/factory/BinaryParameterCachingFactory.java
@@ -1,0 +1,22 @@
+package org.opensearch.securityanalytics.factory;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+
+public abstract class BinaryParameterCachingFactory<T, U, V> {
+    private final Table<T, U, V> cache;
+
+    public BinaryParameterCachingFactory() {
+        this.cache = HashBasedTable.create();
+    }
+
+    protected abstract V doCreate(T parameter1, U parameter2);
+
+    public V create(final T parameter1, final U parameter2) {
+        if (!cache.contains(parameter1, parameter2)) {
+            cache.put(parameter1, parameter2, doCreate(parameter1, parameter2));
+        }
+
+        return cache.get(parameter1, parameter2);
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/factory/BinaryParameterCachingFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/factory/BinaryParameterCachingFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.factory;
 
 import com.google.common.collect.HashBasedTable;

--- a/tif/src/main/java/org/opensearch/securityanalytics/factory/UnaryParameterCachingFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/factory/UnaryParameterCachingFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.factory;
 
 import com.google.common.cache.Cache;

--- a/tif/src/main/java/org/opensearch/securityanalytics/factory/UnaryParameterCachingFactory.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/factory/UnaryParameterCachingFactory.java
@@ -1,0 +1,22 @@
+package org.opensearch.securityanalytics.factory;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+public abstract class UnaryParameterCachingFactory<T, U> {
+    private final Cache<T, U> cache;
+
+    public UnaryParameterCachingFactory() {
+        this.cache = CacheBuilder.newBuilder().build();
+    }
+
+    protected abstract U doCreate(T parameter);
+
+    public U create(T parameter) {
+        if (cache.getIfPresent(parameter) == null) {
+            cache.put(parameter, doCreate(parameter));
+        }
+
+        return cache.getIfPresent(parameter);
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/model/IOC.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/model/IOC.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.model;
 
 import java.io.Serializable;

--- a/tif/src/main/java/org/opensearch/securityanalytics/model/IOC.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/model/IOC.java
@@ -1,0 +1,6 @@
+package org.opensearch.securityanalytics.model;
+
+import java.io.Serializable;
+
+public abstract class IOC implements Serializable {
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/model/IOCSchema.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/model/IOCSchema.java
@@ -1,0 +1,15 @@
+package org.opensearch.securityanalytics.model;
+
+public enum IOCSchema {
+    STIX2(STIX2.class);
+
+    private final Class<? extends IOC> modelClass;
+
+    IOCSchema(final Class<? extends IOC> modelClass) {
+        this.modelClass = modelClass;
+    }
+
+    public Class<? extends IOC> getModelClass() {
+        return modelClass;
+    }
+}

--- a/tif/src/main/java/org/opensearch/securityanalytics/model/IOCSchema.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/model/IOCSchema.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.model;
 
 public enum IOCSchema {

--- a/tif/src/main/java/org/opensearch/securityanalytics/model/STIX2.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/model/STIX2.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/tif/src/main/java/org/opensearch/securityanalytics/model/STIX2.java
+++ b/tif/src/main/java/org/opensearch/securityanalytics/model/STIX2.java
@@ -1,0 +1,36 @@
+package org.opensearch.securityanalytics.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class STIX2 extends IOC {
+    private String type;
+    @JsonProperty("spec_version")
+    private String specVersion;
+    private String id;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(final String type) {
+        this.type = type;
+    }
+
+    public String getSpecVersion() {
+        return specVersion;
+    }
+
+    public void setSpecVersion(final String specVersion) {
+        this.specVersion = specVersion;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(final String id) {
+        this.id = id;
+    }
+}

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/S3ConnectorTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/S3ConnectorTests.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector;
 
 import org.junit.jupiter.api.AfterEach;

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/S3ConnectorTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/S3ConnectorTests.java
@@ -1,0 +1,122 @@
+package org.opensearch.securityanalytics.connector;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.securityanalytics.connector.codec.InputCodec;
+import org.opensearch.securityanalytics.connector.factory.InputCodecFactory;
+import org.opensearch.securityanalytics.connector.factory.S3ClientFactory;
+import org.opensearch.securityanalytics.connector.model.S3ConnectorConfig;
+import org.opensearch.securityanalytics.model.IOC;
+import org.opensearch.securityanalytics.model.IOCSchema;
+import org.opensearch.securityanalytics.connector.model.InputCodecSchema;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class S3ConnectorTests {
+    private static final String BUCKET_NAME = UUID.randomUUID().toString();
+    private static final String OBJECT_KEY = UUID.randomUUID().toString();
+    private static final String REGION = UUID.randomUUID().toString();
+    private static final String ROLE_ARN = UUID.randomUUID().toString();
+    private static final IOCSchema IOC_SCHEMA = IOCSchema.STIX2;
+    private static final InputCodecSchema INPUT_CODEC_SCHEMA = InputCodecSchema.ND_JSON;
+    private static final S3ConnectorConfig S3_CONNECTOR_CONFIG = new S3ConnectorConfig(
+            BUCKET_NAME,
+            OBJECT_KEY,
+            REGION,
+            ROLE_ARN,
+            IOC_SCHEMA,
+            INPUT_CODEC_SCHEMA
+    );
+
+    @Mock
+    private S3ClientFactory s3ClientFactory;
+    @Mock
+    private S3Client s3Client;
+    @Mock
+    private InputCodecFactory inputCodecFactory;
+    @Mock
+    private InputCodec inputCodec;
+    @Mock
+    private ResponseInputStream<GetObjectResponse> responseInputStream;
+    @Mock
+    private IOC ioc;
+
+    private S3Connector s3Connector;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(s3ClientFactory.create(eq(ROLE_ARN), eq(REGION))).thenReturn(s3Client);
+        when(inputCodecFactory.create(eq(INPUT_CODEC_SCHEMA), eq(IOC_SCHEMA))).thenReturn(inputCodec);
+
+        this.s3Connector = new S3Connector(S3_CONNECTOR_CONFIG, s3ClientFactory, inputCodecFactory);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        verify(s3ClientFactory).create(eq(ROLE_ARN), eq(REGION));
+        verify(inputCodecFactory).create(eq(INPUT_CODEC_SCHEMA), eq(IOC_SCHEMA));
+
+        verifyNoMoreInteractions(s3ClientFactory, inputCodecFactory, s3Client, inputCodec, responseInputStream);
+    }
+
+    @Test
+    public void testLoadIOCs() {
+        when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(responseInputStream);
+        when(inputCodec.parse(eq(responseInputStream))).thenReturn(List.of(ioc));
+
+        assertEquals(List.of(ioc), s3Connector.loadIOCs());
+
+        final ArgumentCaptor<GetObjectRequest> argumentCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
+        verify(s3Client).getObject(argumentCaptor.capture());
+        verify(inputCodec).parse(eq(responseInputStream));
+
+        assertEquals(OBJECT_KEY, argumentCaptor.getValue().key());
+        assertEquals(BUCKET_NAME, argumentCaptor.getValue().bucket());
+    }
+
+    @Test
+    public void testLoadIOCs_ExceptionGettingObject() {
+        when(s3Client.getObject(any(GetObjectRequest.class))).thenThrow(new RuntimeException());
+
+        assertThrows(RuntimeException.class, () -> s3Connector.loadIOCs());
+
+        final ArgumentCaptor<GetObjectRequest> argumentCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
+        verify(s3Client).getObject(argumentCaptor.capture());
+
+        assertEquals(OBJECT_KEY, argumentCaptor.getValue().key());
+        assertEquals(BUCKET_NAME, argumentCaptor.getValue().bucket());
+    }
+
+    @Test
+    public void testLoadIOCs_ExceptionParsingObject() {
+        when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(responseInputStream);
+        when(inputCodec.parse(eq(responseInputStream))).thenThrow(new RuntimeException());
+
+        assertThrows(RuntimeException.class, () -> s3Connector.loadIOCs());
+
+        final ArgumentCaptor<GetObjectRequest> argumentCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
+        verify(s3Client).getObject(argumentCaptor.capture());
+        verify(inputCodec).parse(eq(responseInputStream));
+
+        assertEquals(OBJECT_KEY, argumentCaptor.getValue().key());
+        assertEquals(BUCKET_NAME, argumentCaptor.getValue().bucket());
+    }
+}

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/codec/NewlineDelimitedJsonCodecTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/codec/NewlineDelimitedJsonCodecTests.java
@@ -1,0 +1,77 @@
+package org.opensearch.securityanalytics.connector.codec;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.securityanalytics.exceptions.ConnectorParsingException;
+import org.opensearch.securityanalytics.model.IOC;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class NewlineDelimitedJsonCodecTests {
+    @Mock
+    private ObjectReader objectReader;
+    @Mock
+    private MappingIterator mappingIterator;
+    @Mock
+    private InputStream inputStream;
+    @Mock
+    private IOC ioc;
+
+    private NewlineDelimitedJsonCodec codec;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        this.codec = new NewlineDelimitedJsonCodec(objectReader);
+    }
+
+    @AfterEach
+    public void teardown() {
+        verifyNoMoreInteractions(objectReader, mappingIterator, inputStream, ioc);
+    }
+
+    @Test
+    public void testParse() throws IOException {
+        when(objectReader.readValues(eq(inputStream))).thenReturn(mappingIterator);
+        when(mappingIterator.readAll()).thenReturn(List.of(ioc));
+
+        assertEquals(List.of(ioc), codec.parse(inputStream));
+
+        verify(objectReader).readValues(eq(inputStream));
+        verify(mappingIterator).readAll();
+    }
+
+    @Test
+    public void testParse_ExceptionReadingValues() throws IOException {
+        when(objectReader.readValues(eq(inputStream))).thenThrow(new IOException());
+
+        assertThrows(ConnectorParsingException.class, () -> codec.parse(inputStream));
+
+        verify(objectReader).readValues(eq(inputStream));
+    }
+
+    @Test
+    public void testParse_ExceptionReadingIterator() throws IOException {
+        when(objectReader.readValues(eq(inputStream))).thenReturn(mappingIterator);
+        when(mappingIterator.readAll()).thenThrow(new IOException());
+
+        assertThrows(ConnectorParsingException.class, () -> codec.parse(inputStream));
+
+        verify(objectReader).readValues(eq(inputStream));
+        verify(mappingIterator).readAll();
+    }
+}

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/codec/NewlineDelimitedJsonCodecTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/codec/NewlineDelimitedJsonCodecTests.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.codec;
 
 import com.fasterxml.jackson.databind.MappingIterator;

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/InputCodecFactoryTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/InputCodecFactoryTests.java
@@ -1,0 +1,23 @@
+package org.opensearch.securityanalytics.connector.factory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.securityanalytics.connector.codec.NewlineDelimitedJsonCodecTests;
+import org.opensearch.securityanalytics.connector.model.InputCodecSchema;
+import org.opensearch.securityanalytics.model.IOCSchema;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class InputCodecFactoryTests {
+    private InputCodecFactory inputCodecFactory;
+
+    @BeforeEach
+    public void setup() {
+        inputCodecFactory = new InputCodecFactory();
+    }
+
+    @Test
+    public void testDoCreate_ND_JSON() {
+        assertInstanceOf(NewlineDelimitedJsonCodecTests.class, inputCodecFactory.doCreate(InputCodecSchema.ND_JSON, IOCSchema.STIX2));
+    }
+}

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/InputCodecFactoryTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/InputCodecFactoryTests.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.factory;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/S3ClientFactoryTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/S3ClientFactoryTests.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.factory;
 
 import org.junit.jupiter.api.AfterEach;

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/S3ClientFactoryTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/S3ClientFactoryTests.java
@@ -1,0 +1,59 @@
+package org.opensearch.securityanalytics.connector.factory;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class S3ClientFactoryTests {
+    private static final String REGION = UUID.randomUUID().toString();
+    private static final String ROLE_ARN = UUID.randomUUID().toString();
+
+    @Mock
+    private StsAssumeRoleCredentialsProviderFactory stsAssumeRoleCredentialsProviderFactory;
+    @Mock
+    private AwsCredentialsProvider awsCredentialsProvider;
+
+    private S3ClientFactory s3ClientFactory;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        s3ClientFactory = new S3ClientFactory(stsAssumeRoleCredentialsProviderFactory);
+    }
+
+    @AfterEach
+    public void teardown() {
+        verifyNoMoreInteractions(stsAssumeRoleCredentialsProviderFactory, awsCredentialsProvider);
+    }
+
+    @Test
+    public void testDoCreate() {
+        when(stsAssumeRoleCredentialsProviderFactory.create(eq(ROLE_ARN), eq(REGION))).thenReturn(awsCredentialsProvider);
+
+        assertInstanceOf(S3Client.class, s3ClientFactory.doCreate(ROLE_ARN, REGION));
+
+        verify(stsAssumeRoleCredentialsProviderFactory).create(eq(ROLE_ARN), eq(REGION));
+    }
+
+    @Test
+    public void testDoCreate_ExceptionGettingCredentialsProvider() {
+        when(stsAssumeRoleCredentialsProviderFactory.create(eq(ROLE_ARN), eq(REGION))).thenThrow(new RuntimeException());
+
+        assertThrows(RuntimeException.class, () -> s3ClientFactory.doCreate(ROLE_ARN, REGION));
+
+        verify(stsAssumeRoleCredentialsProviderFactory).create(eq(ROLE_ARN), eq(REGION));
+    }
+}

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/StsAssumeRoleCredentialsProviderFactoryTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/StsAssumeRoleCredentialsProviderFactoryTests.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.factory;
 
 import org.junit.jupiter.api.AfterEach;

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/StsAssumeRoleCredentialsProviderFactoryTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/StsAssumeRoleCredentialsProviderFactoryTests.java
@@ -1,0 +1,91 @@
+package org.opensearch.securityanalytics.connector.factory;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class StsAssumeRoleCredentialsProviderFactoryTests {
+    private static final String REGION = UUID.randomUUID().toString();
+    private static final String ROLE_ARN = "arn:aws:iam::123456789012:role/" + UUID.randomUUID();
+
+    @Mock
+    private StsClientFactory stsClientFactory;
+    @Mock
+    private StsClient stsClient;
+
+    private StsAssumeRoleCredentialsProviderFactory stsAssumeRoleCredentialsProviderFactory;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        this.stsAssumeRoleCredentialsProviderFactory = new StsAssumeRoleCredentialsProviderFactory(stsClientFactory);
+    }
+
+    @AfterEach
+    public void teardown() {
+        verifyNoMoreInteractions(stsClientFactory, stsClient);
+    }
+
+    @Test
+    public void testDoCreate() {
+        when(stsClientFactory.create(eq(REGION))).thenReturn(stsClient);
+
+        assertInstanceOf(StsAssumeRoleCredentialsProvider.class, stsAssumeRoleCredentialsProviderFactory.doCreate(ROLE_ARN, REGION));
+
+        verify(stsClientFactory).create(eq(REGION));
+    }
+
+    @Test
+    public void testDoCreate_ExceptionCreatingStsClient() {
+        when(stsClientFactory.create(eq(REGION))).thenThrow(new RuntimeException());
+
+        assertThrows(RuntimeException.class, () -> stsAssumeRoleCredentialsProviderFactory.doCreate(ROLE_ARN, REGION));
+
+        verify(stsClientFactory).create(eq(REGION));
+    }
+
+    @Test
+    public void testDoCreate_MalformedArn() {
+        final String roleArn = UUID.randomUUID().toString();
+        when(stsClientFactory.create(eq(REGION))).thenReturn(stsClient);
+
+        assertThrows(IllegalArgumentException.class, () -> stsAssumeRoleCredentialsProviderFactory.doCreate(roleArn, REGION));
+    }
+
+    @Test
+    public void testDoCreate_NotIamService() {
+        final String roleArn = "arn:aws:ecs::123456789012:role/" + UUID.randomUUID();
+        when(stsClientFactory.create(eq(REGION))).thenReturn(stsClient);
+
+        assertThrows(IllegalArgumentException.class, () -> stsAssumeRoleCredentialsProviderFactory.doCreate(roleArn, REGION));
+    }
+
+    @Test
+    public void testDoCreate_NotRoleResource() {
+        final String roleArn = "arn:aws:iam::123456789012:task/" + UUID.randomUUID();
+        when(stsClientFactory.create(eq(REGION))).thenReturn(stsClient);
+
+        assertThrows(IllegalArgumentException.class, () -> stsAssumeRoleCredentialsProviderFactory.doCreate(roleArn, REGION));
+    }
+
+    @Test
+    public void testDoCreate_EmptyResource() {
+        final String roleArn = "arn:aws:iam::123456789012:/" + UUID.randomUUID();
+        when(stsClientFactory.create(eq(REGION))).thenReturn(stsClient);
+
+        assertThrows(IllegalArgumentException.class, () -> stsAssumeRoleCredentialsProviderFactory.doCreate(roleArn, REGION));
+    }
+}

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/StsClientFactoryTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/StsClientFactoryTests.java
@@ -1,0 +1,23 @@
+package org.opensearch.securityanalytics.connector.factory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sts.StsClient;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class StsClientFactoryTests {
+    private StsClientFactory stsClientFactory;
+
+    @BeforeEach
+    public void setup() {
+        stsClientFactory = new StsClientFactory();
+    }
+
+    @Test
+    public void testDoCreate() {
+        assertInstanceOf(StsClient.class, stsClientFactory.doCreate(UUID.randomUUID().toString()));
+    }
+}

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/StsClientFactoryTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/factory/StsClientFactoryTests.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.factory;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/model/InputCodecSchemaTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/model/InputCodecSchemaTests.java
@@ -1,0 +1,14 @@
+package org.opensearch.securityanalytics.connector.model;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.securityanalytics.connector.codec.NewlineDelimitedJsonCodecTests;
+import org.opensearch.securityanalytics.model.IOCSchema;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class InputCodecSchemaTests {
+    @Test
+    public void testGetInputCodecConstructor_ND_JSON() {
+        assertInstanceOf(NewlineDelimitedJsonCodecTests.class, InputCodecSchema.ND_JSON.getInputCodecConstructor().apply(IOCSchema.STIX2));
+    }
+}

--- a/tif/src/test/java/org/opensearch/securityanalytics/connector/model/InputCodecSchemaTests.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/connector/model/InputCodecSchemaTests.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.connector.model;
 
 import org.junit.jupiter.api.Test;

--- a/tif/src/test/java/org/opensearch/securityanalytics/factory/BinaryParameterCachingFactoryTest.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/factory/BinaryParameterCachingFactoryTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.factory;
 
 import org.junit.jupiter.api.AfterEach;

--- a/tif/src/test/java/org/opensearch/securityanalytics/factory/BinaryParameterCachingFactoryTest.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/factory/BinaryParameterCachingFactoryTest.java
@@ -1,0 +1,111 @@
+package org.opensearch.securityanalytics.factory;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class BinaryParameterCachingFactoryTest {
+    private static final String PARAMETER1 = UUID.randomUUID().toString();
+    private static final String PARAMETER2 = UUID.randomUUID().toString();
+    private static final String VALUE1 = UUID.randomUUID().toString();
+    private static final String PARAMETER3 = UUID.randomUUID().toString();
+    private static final String PARAMETER4 = UUID.randomUUID().toString();
+    private static final String VALUE2 = UUID.randomUUID().toString();
+
+    @Mock
+    private static Map<String, String> innerFactoryValues;
+    @Mock
+    private static Map<String, Map<String, String>> factoryValues;
+
+    private BinaryParameterCachingFactory<String, String, String> factory;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        factory = new TestBinaryParameterCachingFactory();
+
+        when(factoryValues.get(eq(PARAMETER1))).thenReturn(innerFactoryValues);
+        when(innerFactoryValues.get(eq(PARAMETER2))).thenReturn(VALUE1);
+        when(factoryValues.get(eq(PARAMETER3))).thenReturn(innerFactoryValues);
+        when(innerFactoryValues.get(eq(PARAMETER4))).thenReturn(VALUE2);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        verifyNoMoreInteractions(factoryValues, innerFactoryValues);
+    }
+
+    @Test
+    public void testCreate_callsDoCreateIfNoCache() {
+        assertEquals(VALUE1, factory.create(PARAMETER1, PARAMETER2));
+
+        verify(factoryValues).get(eq(PARAMETER1));
+        verify(innerFactoryValues).get(eq(PARAMETER2));
+    }
+
+    @Test
+    public void testCreate_fetchesCachedValueIfPresent() {
+        assertEquals(VALUE1, factory.create(PARAMETER1, PARAMETER2));
+        assertEquals(VALUE1, factory.create(PARAMETER1, PARAMETER2));
+
+        verify(factoryValues).get(eq(PARAMETER1));
+        verify(innerFactoryValues).get(eq(PARAMETER2));
+    }
+
+    @Test
+    public void testCreate_callsDoCreateForNewCacheEntry() {
+        assertEquals(VALUE1, factory.create(PARAMETER1, PARAMETER2));
+        assertEquals(VALUE2, factory.create(PARAMETER3, PARAMETER4));
+
+        verify(factoryValues).get(eq(PARAMETER1));
+        verify(innerFactoryValues).get(eq(PARAMETER2));
+        verify(factoryValues).get(eq(PARAMETER3));
+        verify(innerFactoryValues).get(eq(PARAMETER4));
+    }
+
+    @Test
+    public void testCreate_ContinuouslyReturnsCachedValue() {
+        final int calls = new Random().nextInt(100);
+
+        for (int i = 0; i < calls; i++) {
+            assertEquals(VALUE1, factory.create(PARAMETER1, PARAMETER2));
+            assertEquals(VALUE2, factory.create(PARAMETER3, PARAMETER4));
+        }
+
+        verify(factoryValues).get(eq(PARAMETER1));
+        verify(innerFactoryValues).get(eq(PARAMETER2));
+        verify(factoryValues).get(eq(PARAMETER3));
+        verify(innerFactoryValues).get(eq(PARAMETER4));
+    }
+
+    @Test
+    public void testCreate_NullValue() {
+        final String randomValue = UUID.randomUUID().toString();
+        when(factoryValues.get(eq(randomValue))).thenReturn(innerFactoryValues);
+
+        assertThrows(NullPointerException.class, () -> factory.create(randomValue, randomValue));
+
+        verify(factoryValues).get(eq(randomValue));
+        verify(innerFactoryValues).get(eq(randomValue));
+    }
+
+    private static class TestBinaryParameterCachingFactory extends BinaryParameterCachingFactory<String, String, String> {
+        @Override
+        protected String doCreate(final String param1, final String param2) {
+            return factoryValues.get(param1).get(param2);
+        }
+    }
+}

--- a/tif/src/test/java/org/opensearch/securityanalytics/factory/UnaryParameterCachingFactoryTest.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/factory/UnaryParameterCachingFactoryTest.java
@@ -1,0 +1,97 @@
+package org.opensearch.securityanalytics.factory;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class UnaryParameterCachingFactoryTest {
+    private static final String PARAMETER1 = UUID.randomUUID().toString();
+    private static final String VALUE1 = UUID.randomUUID().toString();
+    private static final String PARAMETER2 = UUID.randomUUID().toString();
+    private static final String VALUE2 = UUID.randomUUID().toString();
+
+    @Mock
+    private static Map<String, String> factoryValues;
+
+    private UnaryParameterCachingFactory<String, String> factory;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        factory = new TestUnaryParameterCachingFactory();
+
+        when(factoryValues.get(eq(PARAMETER1))).thenReturn(VALUE1);
+        when(factoryValues.get(eq(PARAMETER2))).thenReturn(VALUE2);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        verifyNoMoreInteractions(factoryValues);
+    }
+
+    @Test
+    public void testCreate_callsDoCreateIfNoCache() {
+        assertEquals(VALUE1, factory.create(PARAMETER1));
+
+        verify(factoryValues).get(eq(PARAMETER1));
+    }
+
+    @Test
+    public void testCreate_fetchesCachedValueIfPresent() {
+        assertEquals(VALUE1, factory.create(PARAMETER1));
+        assertEquals(VALUE1, factory.create(PARAMETER1));
+
+        verify(factoryValues).get(eq(PARAMETER1));
+    }
+
+    @Test
+    public void testCreate_callsDoCreateForNewCacheEntry() {
+        assertEquals(VALUE1, factory.create(PARAMETER1));
+        assertEquals(VALUE2, factory.create(PARAMETER2));
+
+        verify(factoryValues).get(eq(PARAMETER1));
+        verify(factoryValues).get(eq(PARAMETER2));
+    }
+
+    @Test
+    public void testCreate_ContinuouslyReturnsCachedValue() {
+        final int calls = new Random().nextInt(100);
+
+        for (int i = 0; i < calls; i++) {
+            assertEquals(VALUE1, factory.create(PARAMETER1));
+            assertEquals(VALUE2, factory.create(PARAMETER2));
+        }
+
+        verify(factoryValues).get(eq(PARAMETER1));
+        verify(factoryValues).get(eq(PARAMETER2));
+    }
+
+    @Test
+    public void testCreate_NullValue() {
+        final String randomValue = UUID.randomUUID().toString();
+        assertThrows(NullPointerException.class, () -> factory.create(randomValue));
+
+        verify(factoryValues).get(eq(randomValue));
+    }
+
+    private static class TestUnaryParameterCachingFactory extends UnaryParameterCachingFactory<String, String> {
+        @Override
+        protected String doCreate(final String param) {
+            return factoryValues.get(param);
+        }
+    }
+}

--- a/tif/src/test/java/org/opensearch/securityanalytics/factory/UnaryParameterCachingFactoryTest.java
+++ b/tif/src/test/java/org/opensearch/securityanalytics/factory/UnaryParameterCachingFactoryTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.securityanalytics.factory;
 
 import org.junit.jupiter.api.AfterEach;
@@ -11,7 +15,6 @@ import java.util.Random;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
### Description
Adds the S3 connector that is used to download TIF IOC data from a file in S3.

* Adds interface for the codec of the file in S3
* Adds implementation for ND JSON data
* Adds interface for the IOCConnector
* Adds implementation for the S3Connector to read IOC data from a file in S3
* Adds base classes to handle caching for factories
* Adds factories to create clients and codecs
* Adds models to support S3Connector
* Unit tests
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [N/A] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
