### PR TITLE
ListIOCs API support lists of feedIds, and types.

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -215,7 +215,7 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
     public static final String THREAT_INTEL_BASE_URI = PLUGINS_BASE_URI + "/threat_intel";
     public static final String THREAT_INTEL_SOURCE_URI = PLUGINS_BASE_URI + "/threat_intel/source";
     public static final String THREAT_INTEL_MONITOR_URI = PLUGINS_BASE_URI + "/threat_intel/monitor";
-    public static final String LIST_IOCS_URI = PLUGINS_BASE_URI + "/iocs/list";
+    public static final String IOCS_URI = PLUGINS_BASE_URI + "/iocs";
 
     public static final String CUSTOM_LOG_TYPE_URI = PLUGINS_BASE_URI + "/logtype";
     public static final String JOB_INDEX_NAME = ".opensearch-sap--job";

--- a/src/main/java/org/opensearch/securityanalytics/action/ListIOCsActionRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/ListIOCsActionRequest.java
@@ -43,7 +43,9 @@ public class ListIOCsActionRequest extends ActionRequest {
         this.sortOrder = SortOrder.valueOf(sortOrder.toLowerCase(Locale.ROOT));
         this.sortString = sortString;
         this.search = search;
-        this.types = types.stream().map(t -> t.toLowerCase(Locale.ROOT)).collect(Collectors.toList());
+        this.types = types == null
+                ? null
+                : types.stream().map(t -> t.toLowerCase(Locale.ROOT)).collect(Collectors.toList());
         this.feedIds = feedIds;
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/action/ListIOCsActionResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/ListIOCsActionResponse.java
@@ -10,6 +10,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.securityanalytics.model.DetailedSTIX2IOCDto;
 import org.opensearch.securityanalytics.model.STIX2IOCDto;
 
 import java.io.IOException;
@@ -23,16 +24,16 @@ public class ListIOCsActionResponse extends ActionResponse implements ToXContent
     public static ListIOCsActionResponse EMPTY_RESPONSE = new ListIOCsActionResponse(0, Collections.emptyList());
 
     private long totalHits;
-    private List<STIX2IOCDto> hits;
+    private List<DetailedSTIX2IOCDto> hits;
 
-    public ListIOCsActionResponse(long totalHits, List<STIX2IOCDto> hits) {
+    public ListIOCsActionResponse(long totalHits, List<DetailedSTIX2IOCDto> hits) {
         super();
         this.totalHits = totalHits;
         this.hits = hits;
     }
 
     public ListIOCsActionResponse(StreamInput sin) throws IOException {
-        this(sin.readInt(), sin.readList(STIX2IOCDto::new));
+        this(sin.readInt(), sin.readList(DetailedSTIX2IOCDto::new));
     }
 
     @Override

--- a/src/main/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDto.java
@@ -10,6 +10,8 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.xcontent.XContentParserUtils;
 
 import java.io.IOException;
 
@@ -17,7 +19,7 @@ import java.io.IOException;
  * A data transfer object for <STIX2IOC> containing additional details.
  */
 public class DetailedSTIX2IOCDto implements Writeable, ToXContentObject {
-    public static String NUM_FINDINGS_FIELD = "num_findings";
+    public static final String NUM_FINDINGS_FIELD = "num_findings";
     STIX2IOCDto ioc;
     private long numFindings = 0L;
 
@@ -39,6 +41,27 @@ public class DetailedSTIX2IOCDto implements Writeable, ToXContentObject {
         out.writeLong(numFindings);
     }
 
+    public static DetailedSTIX2IOCDto parse(XContentParser xcp, String id, Long version) throws IOException {
+        STIX2IOCDto ioc = STIX2IOCDto.parse(xcp, id, version);
+        long numFindings = 0;
+
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
+        while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = xcp.currentName();
+            xcp.nextToken();
+
+            switch (fieldName) {
+                case NUM_FINDINGS_FIELD:
+                    numFindings = xcp.longValue();
+                    break;
+                default:
+                    xcp.skipChildren();
+            }
+        }
+
+        return new DetailedSTIX2IOCDto(ioc, numFindings);
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return builder.startObject()
@@ -56,6 +79,14 @@ public class DetailedSTIX2IOCDto implements Writeable, ToXContentObject {
                 .field(STIX2IOC.VERSION_FIELD, ioc.getVersion())
                 .field(NUM_FINDINGS_FIELD, numFindings)
                 .endObject();
+    }
+
+    public STIX2IOCDto getIoc() {
+        return ioc;
+    }
+
+    public void setIoc(STIX2IOCDto ioc) {
+        this.ioc = ioc;
     }
 
     public long getNumFindings() {

--- a/src/main/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDto.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.securityanalytics.model;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * A data transfer object for <STIX2IOC> containing additional details.
+ */
+public class DetailedSTIX2IOCDto extends STIX2IOCDto implements Writeable, ToXContentObject {
+    public static String NUM_FINDINGS_FIELD = "num_findings";
+    private long numFindings = 0L;
+
+    public DetailedSTIX2IOCDto(
+            STIX2IOCDto ioc,
+            Long numFindings
+    ) {
+        super(
+                ioc.getId(),
+                ioc.getName(),
+                ioc.getType(),
+                ioc.getValue(),
+                ioc.getSeverity(),
+                ioc.getCreated(),
+                ioc.getModified(),
+                ioc.getDescription(),
+                ioc.getLabels(),
+                ioc.getFeedId(),
+                ioc.getSpecVersion(),
+                ioc.getVersion()
+        );
+        this.numFindings = numFindings;
+    }
+
+    public DetailedSTIX2IOCDto(StreamInput sin) throws IOException {
+        this(STIX2IOCDto.readFrom(sin), sin.readLong());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeLong(numFindings);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject()
+                .field(STIX2IOC.ID_FIELD, super.getId())
+                .field(STIX2IOC.NAME_FIELD, super.getName())
+                .field(STIX2IOC.TYPE_FIELD, super.getType())
+                .field(STIX2IOC.VALUE_FIELD, super.getValue())
+                .field(STIX2IOC.SEVERITY_FIELD, super.getSeverity())
+                .timeField(STIX2IOC.CREATED_FIELD, super.getCreated())
+                .timeField(STIX2IOC.MODIFIED_FIELD, super.getModified())
+                .field(STIX2IOC.DESCRIPTION_FIELD, super.getDescription())
+                .field(STIX2IOC.LABELS_FIELD, super.getLabels())
+                .field(STIX2IOC.FEED_ID_FIELD, super.getFeedId())
+                .field(STIX2IOC.SPEC_VERSION_FIELD, super.getSpecVersion())
+                .field(STIX2IOC.VERSION_FIELD, super.getVersion())
+                .field(NUM_FINDINGS_FIELD, numFindings)
+                .endObject();
+    }
+
+    public long getNumFindings() {
+        return numFindings;
+    }
+
+    public void setNumFindings(Long numFindings) {
+        this.numFindings = numFindings;
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDto.java
@@ -16,28 +16,16 @@ import java.io.IOException;
 /**
  * A data transfer object for <STIX2IOC> containing additional details.
  */
-public class DetailedSTIX2IOCDto extends STIX2IOCDto implements Writeable, ToXContentObject {
+public class DetailedSTIX2IOCDto implements Writeable, ToXContentObject {
     public static String NUM_FINDINGS_FIELD = "num_findings";
+    STIX2IOCDto ioc;
     private long numFindings = 0L;
 
     public DetailedSTIX2IOCDto(
             STIX2IOCDto ioc,
-            Long numFindings
+            long numFindings
     ) {
-        super(
-                ioc.getId(),
-                ioc.getName(),
-                ioc.getType(),
-                ioc.getValue(),
-                ioc.getSeverity(),
-                ioc.getCreated(),
-                ioc.getModified(),
-                ioc.getDescription(),
-                ioc.getLabels(),
-                ioc.getFeedId(),
-                ioc.getSpecVersion(),
-                ioc.getVersion()
-        );
+        this.ioc = ioc;
         this.numFindings = numFindings;
     }
 
@@ -47,25 +35,25 @@ public class DetailedSTIX2IOCDto extends STIX2IOCDto implements Writeable, ToXCo
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+        ioc.writeTo(out);
         out.writeLong(numFindings);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return builder.startObject()
-                .field(STIX2IOC.ID_FIELD, super.getId())
-                .field(STIX2IOC.NAME_FIELD, super.getName())
-                .field(STIX2IOC.TYPE_FIELD, super.getType())
-                .field(STIX2IOC.VALUE_FIELD, super.getValue())
-                .field(STIX2IOC.SEVERITY_FIELD, super.getSeverity())
-                .timeField(STIX2IOC.CREATED_FIELD, super.getCreated())
-                .timeField(STIX2IOC.MODIFIED_FIELD, super.getModified())
-                .field(STIX2IOC.DESCRIPTION_FIELD, super.getDescription())
-                .field(STIX2IOC.LABELS_FIELD, super.getLabels())
-                .field(STIX2IOC.FEED_ID_FIELD, super.getFeedId())
-                .field(STIX2IOC.SPEC_VERSION_FIELD, super.getSpecVersion())
-                .field(STIX2IOC.VERSION_FIELD, super.getVersion())
+                .field(STIX2IOC.ID_FIELD, ioc.getId())
+                .field(STIX2IOC.NAME_FIELD, ioc.getName())
+                .field(STIX2IOC.TYPE_FIELD, ioc.getType())
+                .field(STIX2IOC.VALUE_FIELD, ioc.getValue())
+                .field(STIX2IOC.SEVERITY_FIELD, ioc.getSeverity())
+                .timeField(STIX2IOC.CREATED_FIELD, ioc.getCreated())
+                .timeField(STIX2IOC.MODIFIED_FIELD, ioc.getModified())
+                .field(STIX2IOC.DESCRIPTION_FIELD, ioc.getDescription())
+                .field(STIX2IOC.LABELS_FIELD, ioc.getLabels())
+                .field(STIX2IOC.FEED_ID_FIELD, ioc.getFeedId())
+                .field(STIX2IOC.SPEC_VERSION_FIELD, ioc.getSpecVersion())
+                .field(STIX2IOC.VERSION_FIELD, ioc.getVersion())
                 .field(NUM_FINDINGS_FIELD, numFindings)
                 .endObject();
     }

--- a/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
@@ -29,6 +29,8 @@ import java.util.Locale;
 public class STIX2IOCDto implements Writeable, ToXContentObject {
     private static final Logger logger = LogManager.getLogger(STIX2IOCDto.class);
 
+    public static String NUM_IOC_MATCHES_FIELD = "num_ioc_matches";
+
     private String id;
     private String name;
     private IOCType type;
@@ -41,6 +43,7 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
     private String feedId;
     private String specVersion;
     private long version;
+    private Long numIocMatches;
 
     // No arguments constructor needed for parsing from S3
     public STIX2IOCDto() {}
@@ -116,7 +119,7 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.startObject()
+        builder.startObject()
                 .field(STIX2IOC.ID_FIELD, id)
                 .field(STIX2IOC.NAME_FIELD, name)
                 .field(STIX2IOC.TYPE_FIELD, type)
@@ -128,8 +131,9 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                 .field(STIX2IOC.LABELS_FIELD, labels)
                 .field(STIX2IOC.FEED_ID_FIELD, feedId)
                 .field(STIX2IOC.SPEC_VERSION_FIELD, specVersion)
-                .field(STIX2IOC.VERSION_FIELD, version)
-                .endObject();
+                .field(STIX2IOC.VERSION_FIELD, version);
+        if (numIocMatches != null) builder.field(NUM_IOC_MATCHES_FIELD, numIocMatches);
+        return builder.endObject();
     }
 
     public static STIX2IOCDto parse(XContentParser xcp, String id, Long version) throws IOException {
@@ -323,5 +327,13 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
 
     public void setVersion(Long version) {
         this.version = version;
+    }
+
+    public long getNumIocMatches() {
+        return numIocMatches;
+    }
+
+    public void setNumIocMatches(Long numIocMatches) {
+        this.numIocMatches = numIocMatches;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.securityanalytics.model;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -27,10 +25,6 @@ import java.util.Locale;
  * A data transfer object for the [STIX2IOC] data model.
  */
 public class STIX2IOCDto implements Writeable, ToXContentObject {
-    private static final Logger logger = LogManager.getLogger(STIX2IOCDto.class);
-
-    public static String NUM_FINDINGS_FIELD = "num_findings";
-
     private String id;
     private String name;
     private IOCType type;
@@ -43,7 +37,6 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
     private String feedId;
     private String specVersion;
     private long version;
-    private Long numFindings;
 
     // No arguments constructor needed for parsing from S3
     public STIX2IOCDto() {}
@@ -119,7 +112,7 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject()
+        return builder.startObject()
                 .field(STIX2IOC.ID_FIELD, id)
                 .field(STIX2IOC.NAME_FIELD, name)
                 .field(STIX2IOC.TYPE_FIELD, type)
@@ -131,9 +124,8 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                 .field(STIX2IOC.LABELS_FIELD, labels)
                 .field(STIX2IOC.FEED_ID_FIELD, feedId)
                 .field(STIX2IOC.SPEC_VERSION_FIELD, specVersion)
-                .field(STIX2IOC.VERSION_FIELD, version);
-        if (numFindings != null) builder.field(NUM_FINDINGS_FIELD, numFindings);
-        return builder.endObject();
+                .field(STIX2IOC.VERSION_FIELD, version)
+                .endObject();
     }
 
     public static STIX2IOCDto parse(XContentParser xcp, String id, Long version) throws IOException {
@@ -327,13 +319,5 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
 
     public void setVersion(Long version) {
         this.version = version;
-    }
-
-    public long getNumFindings() {
-        return numFindings;
-    }
-
-    public void setNumFindings(Long numFindings) {
-        this.numFindings = numFindings;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
@@ -29,7 +29,7 @@ import java.util.Locale;
 public class STIX2IOCDto implements Writeable, ToXContentObject {
     private static final Logger logger = LogManager.getLogger(STIX2IOCDto.class);
 
-    public static String NUM_IOC_MATCHES_FIELD = "num_ioc_matches";
+    public static String NUM_FINDINGS_FIELD = "num_findings";
 
     private String id;
     private String name;
@@ -43,7 +43,7 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
     private String feedId;
     private String specVersion;
     private long version;
-    private Long numIocMatches;
+    private Long numFindings;
 
     // No arguments constructor needed for parsing from S3
     public STIX2IOCDto() {}
@@ -132,7 +132,7 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                 .field(STIX2IOC.FEED_ID_FIELD, feedId)
                 .field(STIX2IOC.SPEC_VERSION_FIELD, specVersion)
                 .field(STIX2IOC.VERSION_FIELD, version);
-        if (numIocMatches != null) builder.field(NUM_IOC_MATCHES_FIELD, numIocMatches);
+        if (numFindings != null) builder.field(NUM_FINDINGS_FIELD, numFindings);
         return builder.endObject();
     }
 
@@ -329,11 +329,11 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
         this.version = version;
     }
 
-    public long getNumIocMatches() {
-        return numIocMatches;
+    public long getNumFindings() {
+        return numFindings;
     }
 
-    public void setNumIocMatches(Long numIocMatches) {
-        this.numIocMatches = numIocMatches;
+    public void setNumFindings(Long numFindings) {
+        this.numFindings = numFindings;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestListIOCsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestListIOCsAction.java
@@ -29,19 +29,21 @@ import java.util.Locale;
 public class RestListIOCsAction extends BaseRestHandler {
     private static final Logger log = LogManager.getLogger(RestListIOCsAction.class);
 
+    public static String URI = SecurityAnalyticsPlugin.IOCS_URI + "/list";
+
     public String getName() {
         return "list_iocs_action";
     }
 
     public List<Route> routes() {
         return List.of(
-                new Route(RestRequest.Method.GET, SecurityAnalyticsPlugin.LIST_IOCS_URI)
+                new Route(RestRequest.Method.GET, URI)
         );
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        log.debug(String.format(Locale.ROOT, "%s %s", request.method(), SecurityAnalyticsPlugin.LIST_IOCS_URI));
+        log.debug(String.format(Locale.ROOT, "%s %s", request.method(), URI));
 
         int startIndex = request.paramAsInt(ListIOCsActionRequest.START_INDEX_FIELD, 0);
         int size = request.paramAsInt(ListIOCsActionRequest.SIZE_FIELD, 10);

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestListIOCsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestListIOCsAction.java
@@ -8,6 +8,7 @@ package org.opensearch.securityanalytics.resthandler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.rest.BaseRestHandler;
@@ -50,10 +51,10 @@ public class RestListIOCsAction extends BaseRestHandler {
         String sortOrder = request.param(ListIOCsActionRequest.SORT_ORDER_FIELD, ListIOCsActionRequest.SortOrder.asc.toString());
         String sortString = request.param(ListIOCsActionRequest.SORT_STRING_FIELD, STIX2.NAME_FIELD);
         String search = request.param(ListIOCsActionRequest.SEARCH_FIELD, "");
-        String type = request.param(ListIOCsActionRequest.TYPE_FIELD, ListIOCsActionRequest.ALL_TYPES_FILTER);
-        String feedId = request.param(STIX2IOC.FEED_ID_FIELD, "");
+        List<String> types = List.of(Strings.commaDelimitedListToStringArray(request.param(ListIOCsActionRequest.TYPE_FIELD, ListIOCsActionRequest.ALL_TYPES_FILTER)));
+        List<String> feedIds = List.of(Strings.commaDelimitedListToStringArray(request.param(STIX2IOC.FEED_ID_FIELD, "")));
 
-        ListIOCsActionRequest listRequest = new ListIOCsActionRequest(startIndex, size, sortOrder, sortString, search, type, feedId);
+        ListIOCsActionRequest listRequest = new ListIOCsActionRequest(startIndex, size, sortOrder, sortString, search, types, feedIds);
 
         return channel -> client.execute(ListIOCsAction.INSTANCE, listRequest, new RestResponseListener<>(channel) {
             @Override

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportListIOCsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportListIOCsAction.java
@@ -35,6 +35,7 @@ import org.opensearch.search.sort.SortOrder;
 import org.opensearch.securityanalytics.action.ListIOCsAction;
 import org.opensearch.securityanalytics.action.ListIOCsActionRequest;
 import org.opensearch.securityanalytics.action.ListIOCsActionResponse;
+import org.opensearch.securityanalytics.model.DetailedSTIX2IOCDto;
 import org.opensearch.securityanalytics.model.STIX2IOC;
 import org.opensearch.securityanalytics.model.STIX2IOCDto;
 import org.opensearch.securityanalytics.services.STIX2IOCFeedStore;
@@ -159,9 +160,9 @@ public class TransportListIOCsAction extends HandledTransportAction<ListIOCsActi
                                     STIX2IOCDto ioc = STIX2IOCDto.parse(xcp, hit.getId(), hit.getVersion());
 
                                     // TODO integrate with findings API that returns IOCMatches
-                                    ioc.setNumFindings(0L);
+                                    long numFindings = 0L;
 
-                                    iocs.add(ioc);
+                                    iocs.add(new DetailedSTIX2IOCDto(ioc, numFindings));
                                 } catch (Exception e) {
                                     log.error(
                                             () -> new ParameterizedMessage("Failed to parse IOC doc from hit {}", hit.getId()), e

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportListIOCsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportListIOCsAction.java
@@ -45,7 +45,6 @@ import org.opensearch.transport.TransportService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -174,6 +173,7 @@ public class TransportListIOCsAction extends HandledTransportAction<ListIOCsActi
                         // If no IOC system indexes are found, return empty list response
                         listener.onResponse(ListIOCsActionResponse.EMPTY_RESPONSE);
                     } else {
+                        log.error("Failed to list IOCs.", e);
                         listener.onFailure(SecurityAnalyticsException.wrap(e));
                     }
                 }

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportListIOCsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportListIOCsAction.java
@@ -147,7 +147,7 @@ public class TransportListIOCsAction extends HandledTransportAction<ListIOCsActi
                     if (searchResponse.isTimedOut()) {
                         onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                     }
-                    List<STIX2IOCDto> iocs = new ArrayList<>();
+                    List<DetailedSTIX2IOCDto> iocs = new ArrayList<>();
                     Arrays.stream(searchResponse.getHits().getHits())
                             .forEach(hit -> {
                                 try {

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportListIOCsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportListIOCsAction.java
@@ -108,7 +108,7 @@ public class TransportListIOCsAction extends HandledTransportAction<ListIOCsActi
                                 .defaultOperator(Operator.OR)
 //                            .field(STIX2_IOC_NESTED_PATH + STIX2IOC.ID_FIELD) // Currently not a column in UX table
                                 .field(STIX2_IOC_NESTED_PATH + STIX2IOC.NAME_FIELD)
-                                .field(STIX2_IOC_NESTED_PATH + STIX2IOC.TYPE_FIELD)
+//                                .field(STIX2_IOC_NESTED_PATH + STIX2IOC.TYPE_FIELD)
                                 .field(STIX2_IOC_NESTED_PATH + STIX2IOC.VALUE_FIELD)
                                 .field(STIX2_IOC_NESTED_PATH + STIX2IOC.SEVERITY_FIELD)
                                 .field(STIX2_IOC_NESTED_PATH + STIX2IOC.CREATED_FIELD)

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportListIOCsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportListIOCsAction.java
@@ -96,7 +96,7 @@ public class TransportListIOCsAction extends HandledTransportAction<ListIOCsActi
             BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
 
             // If any of the 'type' options are 'ALL', do not apply 'type' filter
-            if (request.getTypes().stream().noneMatch(type -> ListIOCsActionRequest.ALL_TYPES_FILTER.equalsIgnoreCase(type))) {
+            if (request.getTypes() != null && request.getTypes().stream().noneMatch(type -> ListIOCsActionRequest.ALL_TYPES_FILTER.equalsIgnoreCase(type))) {
                 boolQueryBuilder.filter(QueryBuilders.termQuery(STIX2_IOC_NESTED_PATH + STIX2IOC.TYPE_FIELD, request.getTypes()));
             }
 
@@ -159,7 +159,7 @@ public class TransportListIOCsAction extends HandledTransportAction<ListIOCsActi
                                     STIX2IOCDto ioc = STIX2IOCDto.parse(xcp, hit.getId(), hit.getVersion());
 
                                     // TODO integrate with findings API that returns IOCMatches
-                                    ioc.setNumIocMatches(0L);
+                                    ioc.setNumFindings(0L);
 
                                     iocs.add(ioc);
                                 } catch (Exception e) {

--- a/src/test/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDtoTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDtoTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.securityanalytics.model;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+import static org.opensearch.securityanalytics.TestHelpers.parser;
+import static org.opensearch.securityanalytics.util.STIX2IOCGenerator.assertEqualIocDtos;
+import static org.opensearch.securityanalytics.util.STIX2IOCGenerator.randomIocDto;
+import static org.opensearch.securityanalytics.util.STIX2IOCGenerator.toJsonString;
+
+public class DetailedSTIX2IOCDtoTests extends OpenSearchTestCase {
+    public void testAsStream() throws IOException {
+        long numFindings = randomLongBetween(0, 100);
+        DetailedSTIX2IOCDto ioc = new DetailedSTIX2IOCDto(randomIocDto(), numFindings);
+        BytesStreamOutput out = new BytesStreamOutput();
+        ioc.writeTo(out);
+        StreamInput sin = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        DetailedSTIX2IOCDto newIoc = new DetailedSTIX2IOCDto(sin);
+        assertEqualIocDtos(ioc, newIoc);
+    }
+
+    public void testParseFunction() throws IOException {
+        long numFindings = randomLongBetween(0, 100);
+        DetailedSTIX2IOCDto ioc = new DetailedSTIX2IOCDto(randomIocDto(), numFindings);
+        String json = toJsonString(ioc);
+        DetailedSTIX2IOCDto newIoc = DetailedSTIX2IOCDto.parse(parser(json), ioc.getIoc().getId(), ioc.getIoc().getVersion());
+        assertEqualIocDtos(ioc, newIoc);
+    }
+}

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ListIOCsRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ListIOCsRestApiIT.java
@@ -22,6 +22,7 @@ import org.opensearch.securityanalytics.util.STIX2IOCGenerator;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -97,7 +98,7 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
         }
 
         // Ingest IOCs
-        List<STIX2IOC> iocs = IntStream.range(0, randomInt(5))
+        List<STIX2IOC> iocs = IntStream.range(0, 5)
                 .mapToObj(i -> STIX2IOCGenerator.randomIOC())
                 .collect(Collectors.toList());
         for (STIX2IOC ioc : iocs) {
@@ -110,8 +111,8 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
                 ListIOCsActionRequest.SortOrder.asc.toString(),
                 STIX2.NAME_FIELD,
                 "",
-                "ALL",
-                ""
+                Arrays.asList(ListIOCsActionRequest.ALL_TYPES_FILTER),
+                Arrays.asList("")
         );
 
         // Retrieve IOCs

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ListIOCsRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ListIOCsRestApiIT.java
@@ -146,6 +146,7 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
                     (String) hit.get(STIX2IOC.FEED_ID_FIELD),
                     (String) hit.get(STIX2IOC.SPEC_VERSION_FIELD),
                     Long.parseLong(String.valueOf(hit.get(STIX2IOC.VERSION_FIELD)))
+                    // TODO implement DetailedSTIX2IOCDto.NUM_FINDINGS_FIELD check when GetFindings API is added
             );
             STIX2IOCGenerator.assertEqualIOCs(iocs.get(i), newIoc);
         }

--- a/src/test/java/org/opensearch/securityanalytics/util/STIX2IOCGenerator.java
+++ b/src/test/java/org/opensearch/securityanalytics/util/STIX2IOCGenerator.java
@@ -14,6 +14,7 @@ import org.opensearch.securityanalytics.action.ListIOCsActionRequest;
 import org.opensearch.securityanalytics.commons.model.IOC;
 import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.commons.utils.testUtils.PojoGenerator;
+import org.opensearch.securityanalytics.model.DetailedSTIX2IOCDto;
 import org.opensearch.securityanalytics.model.STIX2IOC;
 import org.opensearch.securityanalytics.model.STIX2IOCDto;
 import org.opensearch.securityanalytics.resthandler.RestListIOCsAction;
@@ -219,6 +220,12 @@ public class STIX2IOCGenerator implements PojoGenerator {
         return BytesReference.bytes(builder).utf8ToString();
     }
 
+    public static String toJsonString(DetailedSTIX2IOCDto ioc) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder = ioc.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        return BytesReference.bytes(builder).utf8ToString();
+    }
+
     public static void assertIOCEqualsDTO(STIX2IOC ioc, STIX2IOCDto iocDto) {
         STIX2IOC newIoc = new STIX2IOC(iocDto);
         assertEqualIOCs(ioc, newIoc);
@@ -248,6 +255,11 @@ public class STIX2IOCGenerator implements PojoGenerator {
         assertEquals(ioc.getLabels(), newIoc.getLabels());
         assertEquals(ioc.getFeedId(), newIoc.getFeedId());
         assertEquals(ioc.getSpecVersion(), newIoc.getSpecVersion());
+    }
+
+    public static void assertEqualIocDtos(DetailedSTIX2IOCDto ioc, DetailedSTIX2IOCDto newIoc) {
+        assertEqualIocDtos(ioc.getIoc(), newIoc.getIoc());
+        assertEquals(ioc.getNumFindings(), newIoc.getNumFindings());
     }
 
     public static String getListIOCsURI(ListIOCsActionRequest request) {

--- a/src/test/java/org/opensearch/securityanalytics/util/STIX2IOCGenerator.java
+++ b/src/test/java/org/opensearch/securityanalytics/util/STIX2IOCGenerator.java
@@ -259,8 +259,8 @@ public class STIX2IOCGenerator implements PojoGenerator {
                 ListIOCsActionRequest.SORT_ORDER_FIELD, request.getSortOrder(),
                 ListIOCsActionRequest.SORT_STRING_FIELD, request.getSortString(),
                 ListIOCsActionRequest.SEARCH_FIELD, request.getSearch(),
-                ListIOCsActionRequest.TYPE_FIELD, request.getType(),
-                STIX2IOC.FEED_ID_FIELD, request.getFeedId()
+                ListIOCsActionRequest.TYPE_FIELD, String.join(",", request.getTypes()),
+                STIX2IOC.FEED_ID_FIELD, String.join(",", request.getFeedIds())
         );
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/util/STIX2IOCGenerator.java
+++ b/src/test/java/org/opensearch/securityanalytics/util/STIX2IOCGenerator.java
@@ -10,13 +10,13 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
 import org.opensearch.securityanalytics.action.ListIOCsActionRequest;
 import org.opensearch.securityanalytics.commons.model.IOC;
 import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.commons.utils.testUtils.PojoGenerator;
 import org.opensearch.securityanalytics.model.STIX2IOC;
 import org.opensearch.securityanalytics.model.STIX2IOCDto;
+import org.opensearch.securityanalytics.resthandler.RestListIOCsAction;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -253,7 +253,7 @@ public class STIX2IOCGenerator implements PojoGenerator {
     public static String getListIOCsURI(ListIOCsActionRequest request) {
         return String.format(
                 "%s?%s=%s&%s=%s&%s=%s&%s=%s&%s=%s&%s=%s&%s=%s",
-                SecurityAnalyticsPlugin.LIST_IOCS_URI,
+                RestListIOCsAction.URI,
                 ListIOCsActionRequest.START_INDEX_FIELD, request.getStartIndex(),
                 ListIOCsActionRequest.SIZE_FIELD, request.getSize(),
                 ListIOCsActionRequest.SORT_ORDER_FIELD, request.getSortOrder(),


### PR DESCRIPTION
### Description
Made feedId, and type params of ListIOCsActionRequest support lists of strings.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
