### PR TITLE
Added "feedName" to IOC model.

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/model/STIX2IOC.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/STIX2IOC.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.securityanalytics.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -31,15 +30,7 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
     public static final String NO_ID = "";
     public static final long NO_VERSION = 1L;
 
-    public static final String FEED_ID_FIELD = "feed_id";
-    public static final String FEED_NAME_FIELD = "feed_name";
     public static final String VERSION_FIELD = "version";
-
-    @JsonProperty(FEED_ID_FIELD)
-    private String feedId;
-
-    @JsonProperty(FEED_ID_FIELD)
-    private String feedName;
 
     private long version = NO_VERSION;
 
@@ -62,9 +53,7 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
             String feedName,
             Long version
     ) {
-        super(id, name, type, value, severity, created, modified, description, labels, specVersion);
-        this.feedId = feedId;
-        this.feedName = feedName;
+        super(id, name, type, value, severity, created, modified, description, labels, specVersion, feedId, feedName);
         this.version = version;
         validate();
     }
@@ -140,8 +129,8 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
         out.writeString(super.getDescription());
         out.writeStringCollection(super.getLabels());
         out.writeString(super.getSpecVersion());
-        out.writeString(feedId);
-        out.writeString(feedName);
+        out.writeString(super.getFeedId());
+        out.writeString(super.getFeedName());
         out.writeLong(version);
     }
 
@@ -158,8 +147,8 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
                 .field(DESCRIPTION_FIELD, super.getDescription())
                 .field(LABELS_FIELD, super.getLabels())
                 .field(SPEC_VERSION_FIELD, super.getSpecVersion())
-                .field(FEED_ID_FIELD, feedId)
-                .field(FEED_NAME_FIELD, feedName)
+                .field(FEED_ID_FIELD, super.getFeedId())
+                .field(FEED_NAME_FIELD, super.getFeedName())
                 .field(VERSION_FIELD, version)
                 .endObject();
     }
@@ -282,17 +271,9 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
             throw new IllegalArgumentException(String.format("[%s] is required.", VALUE_FIELD));
         }
 
-        if (feedId == null || feedId.isEmpty()) {
+        if (super.getFeedId() == null || super.getFeedId().isEmpty()) {
             throw new IllegalArgumentException(String.format("[%s] is required.", FEED_ID_FIELD));
         }
-    }
-
-    public String getFeedId() {
-        return feedId;
-    }
-
-    public String getFeedName() {
-        return feedName;
     }
 
     public Long getVersion() {

--- a/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
@@ -38,8 +38,9 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
     private Instant modified;
     private String description;
     private List<String> labels;
-    private String feedId;
     private String specVersion;
+    private String feedId;
+    private String feedName;
     private long version;
 
     // No arguments constructor needed for parsing from S3
@@ -55,8 +56,9 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
             Instant modified,
             String description,
             List<String> labels,
-            String feedId,
             String specVersion,
+            String feedId,
+            String feedName,
             long version
     ) {
         this.id = id;
@@ -68,8 +70,9 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
         this.modified = modified;
         this.description = description;
         this.labels = labels;
-        this.feedId = feedId;
         this.specVersion = specVersion;
+        this.feedId = feedId;
+        this.feedName = feedName;
         this.version = version;
     }
 
@@ -84,8 +87,9 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                 ioc.getModified(),
                 ioc.getDescription(),
                 ioc.getLabels(),
-                ioc.getFeedId(),
                 ioc.getSpecVersion(),
+                ioc.getFeedId(),
+                ioc.getFeedName(),
                 ioc.getVersion()
         );
     }
@@ -109,8 +113,9 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
         out.writeInstant(modified);
         out.writeString(description);
         out.writeStringCollection(labels);
-        out.writeString(feedId);
         out.writeString(specVersion);
+        out.writeString(feedId);
+        out.writeString(feedName);
         out.writeLong(version);
     }
 
@@ -126,8 +131,9 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                 .timeField(STIX2IOC.MODIFIED_FIELD, modified)
                 .field(STIX2IOC.DESCRIPTION_FIELD, description)
                 .field(STIX2IOC.LABELS_FIELD, labels)
-                .field(STIX2IOC.FEED_ID_FIELD, feedId)
                 .field(STIX2IOC.SPEC_VERSION_FIELD, specVersion)
+                .field(STIX2IOC.FEED_ID_FIELD, feedId)
+                .field(STIX2IOC.FEED_NAME_FIELD, feedName)
                 .field(STIX2IOC.VERSION_FIELD, version)
                 .endObject();
     }
@@ -149,8 +155,9 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
         Instant modified = null;
         String description = null;
         List<String> labels = new ArrayList<>();
-        String feedId = null;
         String specVersion = null;
+        String feedId = null;
+        String feedName = null;
 
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -202,11 +209,14 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                         }
                     }
                     break;
-                case STIX2.FEED_ID_FIELD:
-                    feedId = xcp.text();
-                    break;
                 case STIX2.SPEC_VERSION_FIELD:
                     specVersion = xcp.text();
+                    break;
+                case STIX2IOC.FEED_ID_FIELD:
+                    feedId = xcp.text();
+                    break;
+                case STIX2IOC.FEED_NAME_FIELD:
+                    feedName = xcp.text();
                     break;
                 default:
                     xcp.skipChildren();
@@ -223,8 +233,9 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                 modified,
                 description,
                 labels,
-                feedId,
                 specVersion,
+                feedId,
+                feedName,
                 version
         );
     }
@@ -301,6 +312,14 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
         this.labels = labels;
     }
 
+    public String getSpecVersion() {
+        return specVersion;
+    }
+
+    public void setSpecVersion(String specVersion) {
+        this.specVersion = specVersion;
+    }
+
     public String getFeedId() {
         return feedId;
     }
@@ -309,12 +328,12 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
         this.feedId = feedId;
     }
 
-    public String getSpecVersion() {
-        return specVersion;
+    public String getFeedName() {
+        return feedName;
     }
 
-    public void setSpecVersion(String specVersion) {
-        this.specVersion = specVersion;
+    public void setFeedName(String feedName) {
+        this.feedName = feedName;
     }
 
     public long getVersion() {

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCConsumer.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCConsumer.java
@@ -34,7 +34,12 @@ public class STIX2IOCConsumer implements Consumer<STIX2> {
 
     @Override
     public void accept(final STIX2 ioc) {
-        STIX2IOC stix2IOC = new STIX2IOC(ioc);
+        STIX2IOC stix2IOC = new STIX2IOC(
+                ioc,
+                feedStore.getSaTifSourceConfig().getId(),
+                feedStore.getSaTifSourceConfig().getName()
+        );
+
         if (queue.offer(stix2IOC)) {
             return;
         }

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
@@ -211,4 +211,8 @@ public class STIX2IOCFeedStore implements FeedStore {
             throw new IllegalStateException("Failed to load stix2_ioc_mapping.json file [" + iocMappingFile + "]", e);
         }
     }
+
+    public SATIFSourceConfig getSaTifSourceConfig() {
+        return saTifSourceConfig;
+    }
 }

--- a/src/test/java/org/opensearch/securityanalytics/util/STIX2IOCGenerator.java
+++ b/src/test/java/org/opensearch/securityanalytics/util/STIX2IOCGenerator.java
@@ -86,6 +86,7 @@ public class STIX2IOCGenerator implements PojoGenerator {
                 null,
                 null,
                 null,
+                null,
                 null
         );
     }
@@ -116,8 +117,9 @@ public class STIX2IOCGenerator implements PojoGenerator {
             Instant modified,
             String description,
             List<String> labels,
-            String feedId,
             String specVersion,
+            String feedId,
+            String feedName,
             Long version
     ) {
         if (name == null) {
@@ -131,9 +133,6 @@ public class STIX2IOCGenerator implements PojoGenerator {
         }
         if (severity == null) {
             severity = randomLowerCaseString();
-        }
-        if (specVersion == null) {
-            specVersion = randomLowerCaseString();
         }
         if (created == null) {
             created = Instant.now();
@@ -149,10 +148,15 @@ public class STIX2IOCGenerator implements PojoGenerator {
                     .mapToObj(i -> randomLowerCaseString())
                     .collect(Collectors.toList());
         }
+        if (specVersion == null) {
+            specVersion = randomLowerCaseString();
+        }
         if (feedId == null) {
             feedId = randomLowerCaseString();
         }
-
+        if (feedName == null) {
+            feedName = randomLowerCaseString();
+        }
         if (version == null) {
             version = randomLong();
         }
@@ -167,8 +171,9 @@ public class STIX2IOCGenerator implements PojoGenerator {
                 modified,
                 description,
                 labels,
-                feedId,
                 specVersion,
+                feedId,
+                feedName,
                 version
         );
     }
@@ -183,12 +188,13 @@ public class STIX2IOCGenerator implements PojoGenerator {
             IOCType type,
             String value,
             String severity,
-            String specVersion,
             Instant created,
             Instant modified,
             String description,
             List<String> labels,
+            String specVersion,
             String feedId,
+            String feedName,
             Long version
     ) {
         return new STIX2IOCDto(randomIOC(
@@ -201,8 +207,9 @@ public class STIX2IOCGenerator implements PojoGenerator {
                 modified,
                 description,
                 labels,
-                feedId,
                 specVersion,
+                feedId,
+                feedName,
                 version
         ));
     }
@@ -233,8 +240,9 @@ public class STIX2IOCGenerator implements PojoGenerator {
         assertEquals(ioc.getModified(), newIoc.getModified());
         assertEquals(ioc.getDescription(), newIoc.getDescription());
         assertEquals(ioc.getLabels(), newIoc.getLabels());
-        assertEquals(ioc.getFeedId(), newIoc.getFeedId());
         assertEquals(ioc.getSpecVersion(), newIoc.getSpecVersion());
+        assertEquals(ioc.getFeedId(), newIoc.getFeedId());
+        assertEquals(ioc.getFeedName(), newIoc.getFeedName());
     }
 
     public static void assertEqualIocDtos(STIX2IOCDto ioc, STIX2IOCDto newIoc) {
@@ -246,8 +254,9 @@ public class STIX2IOCGenerator implements PojoGenerator {
         assertEquals(ioc.getModified(), newIoc.getModified());
         assertEquals(ioc.getDescription(), newIoc.getDescription());
         assertEquals(ioc.getLabels(), newIoc.getLabels());
-        assertEquals(ioc.getFeedId(), newIoc.getFeedId());
         assertEquals(ioc.getSpecVersion(), newIoc.getSpecVersion());
+        assertEquals(ioc.getFeedId(), newIoc.getFeedId());
+        assertEquals(ioc.getFeedName(), newIoc.getFeedName());
     }
 
     public static String getListIOCsURI(ListIOCsActionRequest request) {


### PR DESCRIPTION
### Description
1. Moved "feed" variables from generic STIX2 model in SA-commons to STIX2IOC model as those variables are specific to security analytics functionality. 
2. Added feedName variables to STIX2IOC.

This PR is dependent on PR https://github.com/opensearch-project/security-analytics-commons/pull/10
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
