### PR TITLE
Change search source config request

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/SASearchTIFSourceConfigsRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/SASearchTIFSourceConfigsRequest.java
@@ -7,9 +7,9 @@ package org.opensearch.securityanalytics.threatIntel.action;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
-import org.opensearch.action.search.SearchRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.search.builder.SearchSourceBuilder;
 
 import java.io.IOException;
 
@@ -19,20 +19,20 @@ import java.io.IOException;
 public class SASearchTIFSourceConfigsRequest extends ActionRequest {
 
     // TODO: add pagination parameters
-    private SearchRequest searchRequest;
+    private final SearchSourceBuilder searchSourceBuilder;
 
-    public SASearchTIFSourceConfigsRequest(SearchRequest searchRequest) {
+    public SASearchTIFSourceConfigsRequest(SearchSourceBuilder searchSourceBuilder) {
         super();
-        this.searchRequest = searchRequest;
+        this.searchSourceBuilder = searchSourceBuilder;
     }
 
     public SASearchTIFSourceConfigsRequest(StreamInput sin) throws IOException {
-        searchRequest = new SearchRequest(sin);
+        searchSourceBuilder = new SearchSourceBuilder(sin);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        searchRequest.writeTo(out);
+        searchSourceBuilder.writeTo(out);
     }
 
     @Override
@@ -40,8 +40,8 @@ public class SASearchTIFSourceConfigsRequest extends ActionRequest {
         return null;
     }
 
-    public SearchRequest getSearchRequest() {
-        return searchRequest;
+    public SearchSourceBuilder getSearchSourceBuilder() {
+        return searchSourceBuilder;
     }
 
 }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/RestSearchTIFSourceConfigsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/RestSearchTIFSourceConfigsAction.java
@@ -2,33 +2,20 @@ package org.opensearch.securityanalytics.threatIntel.resthandler;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.cluster.routing.Preference;
-import org.opensearch.common.xcontent.LoggingDeprecationHandler;
-import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.ToXContent;
-import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestResponse;
 import org.opensearch.rest.action.RestResponseListener;
-import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
-import org.opensearch.securityanalytics.action.CorrelatedFindingResponse;
 import org.opensearch.securityanalytics.threatIntel.action.SASearchTIFSourceConfigsAction;
 import org.opensearch.securityanalytics.threatIntel.action.SASearchTIFSourceConfigsRequest;
-import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
 
 import java.io.IOException;
 import java.util.List;
@@ -56,14 +43,11 @@ public class RestSearchTIFSourceConfigsAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         log.debug(String.format(Locale.getDefault(), "%s %s", request.method(), SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI + "/" + "_search"));
 
-        // TODO: Change request to take in a BoolQueryBuilder
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.parseXContent(request.contentOrSourceParamParser());
         searchSourceBuilder.fetchSource(FetchSourceContext.parseFromRestRequest(request));
-        searchSourceBuilder.seqNoAndPrimaryTerm(true);
-        searchSourceBuilder.version(true);
 
-        SASearchTIFSourceConfigsRequest req = new SASearchTIFSourceConfigsRequest(new SearchRequest().source(searchSourceBuilder));
+        SASearchTIFSourceConfigsRequest req = new SASearchTIFSourceConfigsRequest(searchSourceBuilder);
 
         return channel -> client.execute(
                 SASearchTIFSourceConfigsAction.INSTANCE,

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportSearchTIFSourceConfigsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportSearchTIFSourceConfigsAction.java
@@ -64,7 +64,7 @@ public class TransportSearchTIFSourceConfigsAction extends HandledTransportActio
 
         this.threadPool.getThreadContext().stashContext(); // TODO: sync up with @deysubho about thread context
 
-        saTifConfigService.searchTIFSourceConfigs(request.getSearchRequest(), ActionListener.wrap(
+        saTifConfigService.searchTIFSourceConfigs(request.getSearchSourceBuilder(), ActionListener.wrap(
                 r -> {
                     log.debug("Successfully listed all threat intel source configs");
                     actionListener.onResponse(r);


### PR DESCRIPTION
### Description
Changes the search source config request type to take in a searchSourceBuilder so that the search request can be built in the service layer
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
