### PR TITLE
Logic to delete old iocs and add ioc index rollover

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -288,7 +288,7 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
         TIFLockService threatIntelLockService = new TIFLockService(clusterService, client);
         saTifSourceConfigService = new SATIFSourceConfigService(client, clusterService, threadPool, xContentRegistry, threatIntelLockService);
         STIX2IOCFetchService stix2IOCFetchService = new STIX2IOCFetchService(client, clusterService);
-        SATIFSourceConfigManagementService saTifSourceConfigManagementService = new SATIFSourceConfigManagementService(saTifSourceConfigService, threatIntelLockService, stix2IOCFetchService, xContentRegistry);
+        SATIFSourceConfigManagementService saTifSourceConfigManagementService = new SATIFSourceConfigManagementService(saTifSourceConfigService, threatIntelLockService, stix2IOCFetchService, xContentRegistry, indexNameExpressionResolver, clusterService);
         SecurityAnalyticsRunner.getJobRunnerInstance();
         TIFSourceConfigRunner.getJobRunnerInstance().initialize(clusterService, threatIntelLockService, threadPool, saTifSourceConfigManagementService, saTifSourceConfigService);
         TIFJobRunner.getJobRunnerInstance().initialize(clusterService, tifJobUpdateService, tifJobParameterService, threatIntelLockService, threadPool, detectorThreatIntelService);

--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -449,7 +449,9 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
                 SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE,
                 SecurityAnalyticsSettings.TIF_UPDATE_INTERVAL,
                 SecurityAnalyticsSettings.BATCH_SIZE,
-                SecurityAnalyticsSettings.THREAT_INTEL_TIMEOUT
+                SecurityAnalyticsSettings.THREAT_INTEL_TIMEOUT,
+                SecurityAnalyticsSettings.IOC_INDEX_RETENTION_PERIOD,
+                SecurityAnalyticsSettings.IOC_INDICES_PER_ALIAS
         );
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -288,7 +288,7 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
         TIFLockService threatIntelLockService = new TIFLockService(clusterService, client);
         saTifSourceConfigService = new SATIFSourceConfigService(client, clusterService, threadPool, xContentRegistry, threatIntelLockService);
         STIX2IOCFetchService stix2IOCFetchService = new STIX2IOCFetchService(client, clusterService);
-        SATIFSourceConfigManagementService saTifSourceConfigManagementService = new SATIFSourceConfigManagementService(saTifSourceConfigService, threatIntelLockService, stix2IOCFetchService, xContentRegistry, indexNameExpressionResolver, clusterService);
+        SATIFSourceConfigManagementService saTifSourceConfigManagementService = new SATIFSourceConfigManagementService(saTifSourceConfigService, threatIntelLockService, stix2IOCFetchService, xContentRegistry, clusterService);
         SecurityAnalyticsRunner.getJobRunnerInstance();
         TIFSourceConfigRunner.getJobRunnerInstance().initialize(clusterService, threatIntelLockService, threadPool, saTifSourceConfigManagementService, saTifSourceConfigService);
         TIFJobRunner.getJobRunnerInstance().initialize(clusterService, tifJobUpdateService, tifJobParameterService, threatIntelLockService, threadPool, detectorThreatIntelService);

--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -451,7 +451,7 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
                 SecurityAnalyticsSettings.BATCH_SIZE,
                 SecurityAnalyticsSettings.THREAT_INTEL_TIMEOUT,
                 SecurityAnalyticsSettings.IOC_INDEX_RETENTION_PERIOD,
-                SecurityAnalyticsSettings.IOC_INDICES_PER_ALIAS
+                SecurityAnalyticsSettings.IOC_MAX_INDICES_PER_ALIAS
         );
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
@@ -5,19 +5,23 @@
 
 package org.opensearch.securityanalytics.services;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
+import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.admin.indices.rollover.RolloverRequest;
+import org.opensearch.action.admin.indices.rollover.RolloverResponse;
 import org.opensearch.action.bulk.BulkRequest;
-import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.index.IndexRequest;
-import org.opensearch.action.support.GroupedActionListener;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.io.Streams;
@@ -32,6 +36,7 @@ import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.securityanalytics.threatIntel.common.StashedThreadContext;
 import org.opensearch.securityanalytics.threatIntel.model.DefaultIocStoreConfig;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
+import org.opensearch.securityanalytics.util.IndexUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -50,11 +55,8 @@ public class STIX2IOCFeedStore implements FeedStore {
     public static final String IOC_ALL_INDEX_PATTERN = IOC_INDEX_NAME_BASE + "-*";
     public static final String IOC_FEED_ID_PLACEHOLDER = "FEED_ID";
     public static final String IOC_INDEX_NAME_TEMPLATE = IOC_INDEX_NAME_BASE + "-" + IOC_FEED_ID_PLACEHOLDER;
-
-    // TODO hurneyt implement history indexes + rollover logic
-    public static final String IOC_HISTORY_WRITE_INDEX_ALIAS = IOC_INDEX_NAME_TEMPLATE + "-history-write";
-    public static final String IOC_HISTORY_INDEX_PATTERN = "<." + IOC_INDEX_NAME_BASE + "-history-{now/d{yyyy.MM.dd.hh.mm.ss|UTC}}-1>";
-
+    public static final String IOC_HISTORY_WRITE_INDEX_ALIAS = IOC_INDEX_NAME_TEMPLATE + "-write"; // this is the alias
+    public static final String IOC_HISTORY_INDEX_PATTERN = "<" + IOC_INDEX_NAME_TEMPLATE + "-" + Instant.now().toEpochMilli() +"-000001>"; // this is the pattern for new indices
     private final Logger log = LogManager.getLogger(STIX2IOCFeedStore.class);
     Instant startTime = Instant.now();
 
@@ -111,24 +113,85 @@ public class STIX2IOCFeedStore implements FeedStore {
         }
     }
 
-    public void indexIocs(List<STIX2IOC> iocs) throws IOException {
-        String feedIndexName = getFeedConfigIndexName(saTifSourceConfig.getId());
-
-        // init index and add name to ioc map store only if index does not already exist, otherwise ioc map store will contain duplicate index names
-        if (feedIndexExists(feedIndexName) == false) {
-            initFeedIndex(feedIndexName);
-            saTifSourceConfig.getIocTypes().forEach(type -> {
-                String lowerCaseType = type.toLowerCase(Locale.ROOT);
-                ((DefaultIocStoreConfig) saTifSourceConfig.getIocStoreConfig()).getIocMapStore().putIfAbsent(lowerCaseType, new ArrayList<>());
-                ((DefaultIocStoreConfig) saTifSourceConfig.getIocStoreConfig()).getIocMapStore().get(lowerCaseType).add(feedIndexName);
-            });
+    private void rolloverIndex(
+            String alias,
+            String pattern,
+            ActionListener<Void> listener
+    ) {
+        if (clusterService.state().metadata().hasAlias(alias) == false) {
+            return; // TODO: make sure that it has an alias first, initialize it basically
         }
+        // We have to pass null for newIndexName in order to get Elastic to increment the alias count.
+        RolloverRequest request = new RolloverRequest(alias, null);
+        request.getCreateIndexRequest().index(pattern)
+                .mapping(iocIndexMapping())
+                .settings(Settings.builder().put("index.hidden", true).build());
+        client.admin().indices().rolloverIndex(
+                request,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(RolloverResponse rolloverResponse) {
+                        if (!rolloverResponse.isRolledOver()) {
+                            log.info(alias + "not rolled over. Conditions were: " + rolloverResponse.getConditionStatus());
+                        } else {
+                            listener.onResponse(null);
+                        }
+                    }
 
+                    @Override
+                    public void onFailure(Exception e) {
+                        log.error("rollover failed for alias [" + alias + "].");
+                        listener.onFailure(e);
+                    }
+                }
+        );
+    }
+
+    public void indexIocs(List<STIX2IOC> iocs) throws IOException {
+        String iocAlias = getFeedConfigIndexName(saTifSourceConfig.getId());
+        String iocPattern = getFeedConfigRolloverName(saTifSourceConfig.getId());
+
+        // store the alias as the first item in the list, so the alias will always be #1
+        // add rollover mechanism... how to get the alias for this??
+        // init index and add name to ioc map store only if index does not already exist, otherwise ioc map store will contain duplicate index names
+        if (iocIndexExists(iocAlias) == false) {
+            initFeedIndex(iocAlias, iocPattern, ActionListener.wrap(
+                    r -> {
+                        // get the concrete index and add it here?
+                        saTifSourceConfig.getIocTypes().forEach(type -> {
+                            String writeIndex = IndexUtils.getWriteIndex(iocAlias, clusterService.state()); // need to figure this out\
+                            String lowerCaseType = type.toLowerCase(Locale.ROOT);
+                            ((DefaultIocStoreConfig) saTifSourceConfig.getIocStoreConfig()).getIocMapStore().putIfAbsent(lowerCaseType, new ArrayList<>());
+                            ((DefaultIocStoreConfig) saTifSourceConfig.getIocStoreConfig()).getIocMapStore().get(lowerCaseType).add(iocAlias);
+                            ((DefaultIocStoreConfig) saTifSourceConfig.getIocStoreConfig()).getIocMapStore().get(lowerCaseType).add(writeIndex);
+                        });
+                        bulkIndexIocs(iocs, iocAlias);
+                    }, e-> {
+                        log.error(e);
+                    }
+            ));
+        } else {
+            rolloverIndex(iocAlias, iocPattern, ActionListener.wrap(
+                    re -> {
+                        saTifSourceConfig.getIocTypes().forEach(type -> {
+                            String writeIndex = IndexUtils.getWriteIndex(iocAlias, clusterService.state());
+                            String lowerCaseType = type.toLowerCase(Locale.ROOT);
+                            ((DefaultIocStoreConfig) saTifSourceConfig.getIocStoreConfig()).getIocMapStore().get(lowerCaseType).add(writeIndex);
+                        });
+                        bulkIndexIocs(iocs, iocAlias);
+                    }, e -> {
+                        log.error(e);
+                    }
+            ));
+        }
+    }
+
+    private void bulkIndexIocs(List<STIX2IOC> iocs, String iocAlias) throws IOException {
         List<BulkRequest> bulkRequestList = new ArrayList<>();
         BulkRequest bulkRequest = new BulkRequest();
 
         for (STIX2IOC ioc : iocs) {
-            IndexRequest indexRequest = new IndexRequest(feedIndexName)
+            IndexRequest indexRequest = new IndexRequest(iocAlias)
                     .opType(DocWriteRequest.OpType.INDEX)
                     .source(ioc.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
             bulkRequest.add(indexRequest);
@@ -141,70 +204,87 @@ public class STIX2IOCFeedStore implements FeedStore {
         bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         bulkRequestList.add(bulkRequest);
 
-        GroupedActionListener<BulkResponse> bulkResponseListener = new GroupedActionListener<>(ActionListener.wrap(bulkResponses -> {
-            int idx = 0;
-            for (BulkResponse response : bulkResponses) {
-                BulkRequest request = bulkRequestList.get(idx);
-                if (response.hasFailures()) {
-                    throw new OpenSearchException(
-                            "Error occurred while ingesting IOCs to {} with an error {}",
-                            StringUtils.join(request.getIndices()),
-                            response.buildFailureMessage()
-                    );
-                }
-                idx++;
-            }
-
-            long duration = Duration.between(startTime, Instant.now()).toMillis();
-            STIX2IOCFetchService.STIX2IOCFetchResponse output = new STIX2IOCFetchService.STIX2IOCFetchResponse(iocs, duration);
-            baseListener.onResponse(output);
-        }, e -> {
-            log.error("Failed to index IOCs for config {}", saTifSourceConfig.getId(), e);
-            baseListener.onFailure(e);
-        }), bulkRequestList.size());
-
         for (BulkRequest req : bulkRequestList) {
             try {
-                StashedThreadContext.run(client, () -> client.bulk(req, bulkResponseListener));
+                StashedThreadContext.run(client, () -> client.bulk(req, ActionListener.wrap(
+                        response -> {
+                            log.info("bulk indexed");
+                        }, e-> {
+                            log.error("failed to bulk index");
+                        }
+                )));
             } catch (OpenSearchException e) {
                 log.error("Failed to save IOCs for config {}", saTifSourceConfig.getId(), e);
                 baseListener.onFailure(e);
             }
+            long duration = Duration.between(startTime, Instant.now()).toMillis();
+            STIX2IOCFetchService.STIX2IOCFetchResponse output = new STIX2IOCFetchService.STIX2IOCFetchResponse(iocs, duration);
+            baseListener.onResponse(output);
         }
     }
+
+    // sync up with @hurneyt about removing this
+//        GroupedActionListener<BulkResponse> bulkResponseListener = new GroupedActionListener<>(ActionListener.wrap(bulkResponses -> {
+//            int idx = 0;
+//            for (BulkResponse response : bulkResponses) {
+//                BulkRequest request = bulkRequestList.get(idx);
+//                if (response.hasFailures()) {
+//                    throw new OpenSearchException(
+//                            "Error occurred while ingesting IOCs to {} with an error {}",
+//                            StringUtils.join(request.getIndices()),
+//                            response.buildFailureMessage()
+//                    );
+//                }
+//                idx++;
+//            }
+//
+//            long duration = Duration.between(startTime, Instant.now()).toMillis();
+//            STIX2IOCFetchService.STIX2IOCFetchResponse output = new STIX2IOCFetchService.STIX2IOCFetchResponse(iocs, duration);
+//            baseListener.onResponse(output);
+//        }, e -> {
+//            log.error("Failed to index IOCs for config {}", saTifSourceConfig.getId(), e);
+//            baseListener.onFailure(e);
+//        }), bulkRequestList.size());
+
 
     /**
      * Checks whether the [IOC_INDEX_NAME_BASE]-related index exists.
      * @param index The index to evaluate.
      * @return TRUE if the index is an IOC-related system index, and exists; else returns FALSE.
      */
-    public boolean feedIndexExists(String index) {
+    public boolean feedIndexExists(String index) { // change this to check if the alias exists
         return index.startsWith(IOC_INDEX_NAME_BASE) && this.clusterService.state().routingTable().hasIndex(index);
     }
 
-    public static String getFeedConfigIndexName(String feedSourceConfigId) {
-        return IOC_INDEX_NAME_TEMPLATE.replace(IOC_FEED_ID_PLACEHOLDER, feedSourceConfigId.toLowerCase(Locale.ROOT));
+    public boolean iocIndexExists(String alias) {
+        ClusterState clusterState = clusterService.state();
+        return clusterState.metadata().hasAlias(alias);
     }
 
-    public void initFeedIndex(String feedIndexName) {
+    public static String getFeedConfigIndexName(String feedSourceConfigId) {
+        return IOC_HISTORY_WRITE_INDEX_ALIAS.replace(IOC_FEED_ID_PLACEHOLDER, feedSourceConfigId.toLowerCase(Locale.ROOT));
+    }
+
+    public static String getFeedConfigRolloverName(String feedSourceConfigId) {
+        return IOC_HISTORY_INDEX_PATTERN.replace(IOC_FEED_ID_PLACEHOLDER, feedSourceConfigId.toLowerCase(Locale.ROOT));
+    }
+
+
+    public void initFeedIndex(String feedAliasName, String feedIndexName, ActionListener<Void> listener) { // this is the first time the index is created
         var indexRequest = new CreateIndexRequest(feedIndexName)
                 .mapping(iocIndexMapping())
                 .settings(Settings.builder().put("index.hidden", true).build());
-
-        ActionListener<CreateIndexResponse> createListener = new ActionListener<>() {
-            @Override
-            public void onResponse(CreateIndexResponse createIndexResponse) {
-                log.info("Created system index {}", feedIndexName);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                log.error("Failed to create system index {}", feedIndexName);
-                baseListener.onFailure(e);
-            }
-        };
-
-        client.admin().indices().create(indexRequest, createListener);
+        indexRequest.alias(new Alias(feedAliasName)); // set the alias
+        client.admin().indices().create(indexRequest, ActionListener.wrap(
+                r -> {
+                    log.info("Created system index {}", feedIndexName);
+                    listener.onResponse(null);
+                },
+                e -> {
+                    log.error("Failed to create system index {}", feedIndexName);
+                    listener.onFailure(e);
+                }
+        ));
     }
 
     public String iocIndexMapping() {

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
@@ -53,7 +53,7 @@ public class STIX2IOCFeedStore implements FeedStore {
 
     // TODO hurneyt implement history indexes + rollover logic
     public static final String IOC_HISTORY_WRITE_INDEX_ALIAS = IOC_INDEX_NAME_TEMPLATE + "-history-write";
-    public static final String IOC_HISTORY_INDEX_PATTERN = "<." + IOC_INDEX_NAME_BASE + "-history-{now/d{yyyy.MM.dd.hh.mm.ss|UTC}}-1>";
+    public static final String IOC_HISTORY_INDEX_PATTERN = "<." + IOC_INDEX_NAME_TEMPLATE + "-history-{now/d{yyyy.MM.dd.hh.mm.ss|UTC}}-1>";
 
     private final Logger log = LogManager.getLogger(STIX2IOCFeedStore.class);
     Instant startTime = Instant.now();
@@ -112,7 +112,7 @@ public class STIX2IOCFeedStore implements FeedStore {
     }
 
     public void indexIocs(List<STIX2IOC> iocs) throws IOException {
-        String feedIndexName = getFeedConfigIndexName(saTifSourceConfig.getId());
+        String feedIndexName = getFeedConfigIndexName(saTifSourceConfig.getId()); //id + timestamp
 
         // init index and add name to ioc map store only if index does not already exist, otherwise ioc map store will contain duplicate index names
         if (feedIndexExists(feedIndexName) == false) {
@@ -183,7 +183,7 @@ public class STIX2IOCFeedStore implements FeedStore {
     }
 
     public static String getFeedConfigIndexName(String feedSourceConfigId) {
-        return IOC_INDEX_NAME_TEMPLATE.replace(IOC_FEED_ID_PLACEHOLDER, feedSourceConfigId.toLowerCase(Locale.ROOT));
+        return IOC_HISTORY_INDEX_PATTERN.replace(IOC_FEED_ID_PLACEHOLDER, feedSourceConfigId.toLowerCase(Locale.ROOT));
     }
 
     public void initFeedIndex(String feedIndexName) {
@@ -191,6 +191,7 @@ public class STIX2IOCFeedStore implements FeedStore {
                 .mapping(iocIndexMapping())
                 .settings(Settings.builder().put("index.hidden", true).build());
 
+        // TODO: change the alias to the newest created index
         ActionListener<CreateIndexResponse> createListener = new ActionListener<>() {
             @Override
             public void onResponse(CreateIndexResponse createIndexResponse) {

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -201,7 +201,7 @@ public class SecurityAnalyticsSettings {
 
     public static final Setting<Integer> IOC_INDICES_PER_ALIAS = Setting.intSetting(
             "plugins.security_analytics.ioc_indices_per_alias",
-            30,
+            1,
             0,
             Setting.Property.NodeScope, Setting.Property.Dynamic
     );

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -191,4 +191,18 @@ public class SecurityAnalyticsSettings {
         return List.of(BATCH_SIZE, THREAT_INTEL_TIMEOUT, TIF_UPDATE_INTERVAL);
     }
 
+    // Threat Intel IOC Settings
+    public static final Setting<TimeValue> IOC_INDEX_RETENTION_PERIOD = Setting.positiveTimeSetting(
+            "plugins.security_analytics.ioc_history_retention_period",
+            new TimeValue(30, TimeUnit.DAYS),
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+    );
+
+    public static final Setting<Integer> MAX_IOC_INDICES_PER_ALIAS = Setting.intSetting(
+            "plugins.security_analytics.ioc_history_max_indices_per_alias",
+            30,
+            0,
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+    );
+
 }

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -192,14 +192,15 @@ public class SecurityAnalyticsSettings {
     }
 
     // Threat Intel IOC Settings
-    public static final Setting<TimeValue> IOC_INDEX_RETENTION_PERIOD = Setting.positiveTimeSetting(
-            "plugins.security_analytics.ioc_history_retention_period",
+    public static final Setting<TimeValue> IOC_INDEX_RETENTION_PERIOD = Setting.timeSetting(
+            "plugins.security_analytics.ioc_index_retention_period",
             new TimeValue(30, TimeUnit.DAYS),
+            new TimeValue(1, TimeUnit.DAYS),
             Setting.Property.NodeScope, Setting.Property.Dynamic
     );
 
-    public static final Setting<Integer> MAX_IOC_INDICES_PER_ALIAS = Setting.intSetting(
-            "plugins.security_analytics.ioc_history_max_indices_per_alias",
+    public static final Setting<Integer> IOC_INDICES_PER_ALIAS = Setting.intSetting(
+            "plugins.security_analytics.ioc_indices_per_alias",
             30,
             0,
             Setting.Property.NodeScope, Setting.Property.Dynamic

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -201,7 +201,7 @@ public class SecurityAnalyticsSettings {
 
     public static final Setting<Integer> IOC_INDICES_PER_ALIAS = Setting.intSetting(
             "plugins.security_analytics.ioc_indices_per_alias",
-            1,
+            2,
             0,
             Setting.Property.NodeScope, Setting.Property.Dynamic
     );

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -201,8 +201,8 @@ public class SecurityAnalyticsSettings {
 
     public static final Setting<Integer> IOC_INDICES_PER_ALIAS = Setting.intSetting(
             "plugins.security_analytics.ioc_indices_per_alias",
-            2,
-            0,
+            30,
+            1,
             Setting.Property.NodeScope, Setting.Property.Dynamic
     );
 

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -193,14 +193,14 @@ public class SecurityAnalyticsSettings {
 
     // Threat Intel IOC Settings
     public static final Setting<TimeValue> IOC_INDEX_RETENTION_PERIOD = Setting.timeSetting(
-            "plugins.security_analytics.ioc_index_retention_period",
+            "plugins.security_analytics.ioc.index_retention_period",
             new TimeValue(30, TimeUnit.DAYS),
             new TimeValue(1, TimeUnit.DAYS),
             Setting.Property.NodeScope, Setting.Property.Dynamic
     );
 
-    public static final Setting<Integer> IOC_INDICES_PER_ALIAS = Setting.intSetting(
-            "plugins.security_analytics.ioc_indices_per_alias",
+    public static final Setting<Integer> IOC_MAX_INDICES_PER_ALIAS = Setting.intSetting(
+            "plugins.security_analytics.ioc.max_indices_per_alias",
             30,
             1,
             Setting.Property.NodeScope, Setting.Property.Dynamic

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -608,7 +608,7 @@ public class SATIFSourceConfigManagementService {
     }
 
     private Integer numOfIndicesToDelete(List<String> concreteIndices) {
-        Integer maxIndicesPerAlias = clusterService.getClusterSettings().get(SecurityAnalyticsSettings.MAX_IOC_INDICES_PER_ALIAS);
+        Integer maxIndicesPerAlias = clusterService.getClusterSettings().get(SecurityAnalyticsSettings.IOC_INDICES_PER_ALIAS);
         if (concreteIndices.size() > maxIndicesPerAlias ) {
             return concreteIndices.size() - maxIndicesPerAlias;
         }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -625,7 +625,9 @@ public class SATIFSourceConfigManagementService {
                     TIFJobState.DELETING,
                     ActionListener.wrap(
                             updateSaTifSourceConfigResponse -> {
-                                // TODO: Delete all IOCs associated with source config then delete source config, sync up with @hurneyt
+                                String type = updateSaTifSourceConfigResponse.getIocTypes().get(0);
+                                DefaultIocStoreConfig iocStoreConfig = (DefaultIocStoreConfig) updateSaTifSourceConfigResponse.getIocStoreConfig();
+                                saTifSourceConfigService.deleteAllOldIocHistoryIndices(iocStoreConfig.getIocMapStore().get(type));
                                 saTifSourceConfigService.deleteTIFSourceConfig(saTifSourceConfig, ActionListener.wrap(
                                         deleteResponse -> {
                                             log.debug("Successfully deleted threat intel source config [{}]", saTifSourceConfig.getId());

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -3,10 +3,18 @@ package org.opensearch.securityanalytics.threatIntel.service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchException;
+import org.opensearch.action.StepListener;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexAbstraction;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.routing.Preference;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -27,13 +35,21 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
 import org.opensearch.securityanalytics.services.STIX2IOCFetchService;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.securityanalytics.threatIntel.common.TIFJobState;
 import org.opensearch.securityanalytics.threatIntel.common.TIFLockService;
+import org.opensearch.securityanalytics.threatIntel.model.DefaultIocStoreConfig;
 import org.opensearch.securityanalytics.threatIntel.model.IocStoreConfig;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
+import org.opensearch.securityanalytics.util.IndexUtils;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+
 
 /**
  * Service class for threat intel feed source config object
@@ -44,6 +60,8 @@ public class SATIFSourceConfigManagementService {
     private final TIFLockService lockService; //TODO: change to js impl lock
     private final STIX2IOCFetchService stix2IOCFetchService;
     private final NamedXContentRegistry xContentRegistry;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final ClusterService clusterService;
 
     /**
      * Default constructor
@@ -57,13 +75,16 @@ public class SATIFSourceConfigManagementService {
             final SATIFSourceConfigService saTifSourceConfigService,
             final TIFLockService lockService,
             final STIX2IOCFetchService stix2IOCFetchService,
-            NamedXContentRegistry xContentRegistry
-
+            final NamedXContentRegistry xContentRegistry,
+            final IndexNameExpressionResolver indexNameExpressionResolver,
+            final ClusterService clusterService
     ) {
         this.saTifSourceConfigService = saTifSourceConfigService;
         this.lockService = lockService;
         this.stix2IOCFetchService = stix2IOCFetchService;
         this.xContentRegistry = xContentRegistry;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.clusterService = clusterService;
     }
 
     public void createOrUpdateTifSourceConfig(
@@ -394,6 +415,206 @@ public class SATIFSourceConfigManagementService {
                 }
         ));
     }
+
+    public IocStoreConfig deleteOldIocIndices (
+            final SATIFSourceConfig saTifSourceConfig,
+            ActionListener<Void> listener
+    ) {
+        Map<String, List<String>> iocToAliasMap = ((DefaultIocStoreConfig) saTifSourceConfig.getIocStoreConfig()).getIocMapStore();
+        List<String> iocTypes = saTifSourceConfig.getIocTypes();
+        String type = iocTypes.get(0); // just grabbing the first ioc type we see since all the indices are stored
+
+        List<String> iocIndicesDeleted = new ArrayList<>();
+        String alias = "dummyAlias"; // TODO: dummy alias for now, will replace after rollover is set
+        StepListener<List<String>> deleteIocIndicesByAgeListener = new StepListener<>();
+        checkAndDeleteOldIocIndicesByAge(iocToAliasMap.get(type), deleteIocIndicesByAgeListener, alias);
+        deleteIocIndicesByAgeListener.whenComplete(
+                iocIndicesDeletedByAge-> {
+                    // removing the indices deleted by age from the ioc map
+                    for (String indexName: iocIndicesDeletedByAge) {
+                        iocToAliasMap.get(type).remove(indexName);
+                    }
+
+                    // add the indices delete by age to indices deleted by type
+                    iocIndicesDeleted.addAll(iocIndicesDeletedByAge);
+
+                    // next delete the ioc indices by size
+                    checkAndDeleteOldIocIndicesBySize(iocToAliasMap.get(type), alias, ActionListener.wrap(
+                            iocIndicesDeletedBySize -> {
+                                for (String indexName: iocIndicesDeletedBySize) {
+                                    iocToAliasMap.get(type).remove(indexName);
+                                }
+                                iocIndicesDeleted.addAll(iocIndicesDeletedBySize);
+                                listener.onResponse(null);
+                            }, e -> {
+                                // add error log
+                                listener.onFailure(e);
+                            }
+                    ));
+                }, e -> {
+                    // add error log
+                    listener.onFailure(e);
+                });
+
+        // delete the iocs that were deleted from the store config for the other ioc types
+        saTifSourceConfig.getIocTypes().forEach(iocType -> {
+            if (iocType.equals(type) == false) {
+                for (String indexName: iocIndicesDeleted) {
+                    iocToAliasMap.get(iocType).remove(indexName);
+                }
+            }
+        });
+        return new DefaultIocStoreConfig(iocToAliasMap);
+    }
+
+    // Method checks if index is greater than retention period
+    private void checkAndDeleteOldIocIndicesByAge(
+            List<String> indices,
+            StepListener<List<String>> stepListener,
+            String alias
+    ) {
+        log.info("Delete old IOC indices by age");
+        saTifSourceConfigService.getClusterState( // get the cluster state to check the age of the indices
+                indices,
+                ActionListener.wrap(
+                        clusterStateResponse -> {
+                            List<String> indicesToDelete = new ArrayList<>();
+                            if (!clusterStateResponse.getState().metadata().getIndices().isEmpty()) {
+                                log.info("Checking if we should delete indices: [" + indicesToDelete + "]");
+                                indicesToDelete = getIocIndicesToDeleteByAge(clusterStateResponse, alias);
+                                saTifSourceConfigService.deleteAllOldIocHistoryIndices(indicesToDelete);
+                            } else {
+                                log.info("No old IOC indices to delete");
+                            }
+                            stepListener.onResponse(indicesToDelete);
+                        }, e -> {
+                            log.error("Failed to get the cluster metadata");
+                            stepListener.onFailure(e);
+                        }
+                )
+        );
+    }
+
+    // check if index is greater than retention period
+    private void checkAndDeleteOldIocIndicesBySize(
+            List<String> indices,
+            String alias,
+            ActionListener<List<String>> listener
+    ) {
+        log.info("Delete old IOC indices by size");
+        // get new cluster state after deleting indices past retention period
+        saTifSourceConfigService.getClusterState(
+                indices,
+                ActionListener.wrap(
+                        clusterStateResponse -> {
+                            List<String> indicesToDelete = new ArrayList<>();
+                            if (!clusterStateResponse.getState().metadata().getIndices().isEmpty()) {
+                                List<String> concreteIndices = getConcreteIndices(alias); // storing both alias and concrete index
+                                Integer numIndicesToDelete = numOfIndicesToDelete(concreteIndices);
+                                if (numIndicesToDelete > 0) {
+                                    indicesToDelete = getIocIndicesToDeleteBySize(clusterStateResponse, numIndicesToDelete, concreteIndices, alias);
+                                    log.info("Checking if we should delete indices: [" + indicesToDelete + "]");
+                                    if (indicesToDelete.size() != numIndicesToDelete) {
+                                        log.error("Number of indices to delete and retrieved index names not equivalent"); // TODO check this
+                                    }
+                                    saTifSourceConfigService.deleteAllOldIocHistoryIndices(indicesToDelete);
+                                    listener.onResponse(indicesToDelete);
+                                } else {
+                                    log.info("No old IOC indices to delete");
+                                    listener.onResponse(indicesToDelete);
+                                }
+                            } else {
+                                log.info("No old IOC indices to delete");
+                                listener.onResponse(indicesToDelete);
+                            }
+                        }, e -> {
+                            log.error("Failed to get the cluster metadata");
+                            listener.onFailure(e);
+                        }
+                )
+        );
+    }
+
+    public List<String> getIocIndicesToDeleteByAge(
+            ClusterStateResponse clusterStateResponse,
+            String alias
+    ) {
+        List<String> indicesToDelete = new ArrayList<>();
+        String writeIndex = IndexUtils.getWriteIndex(alias, clusterStateResponse.getState());
+        Long maxRetentionPeriod = clusterService.getClusterSettings().get(SecurityAnalyticsSettings.IOC_INDEX_RETENTION_PERIOD).millis();
+
+        // for every index metadata, check if the age is greater than the retention period
+        for (IndexMetadata indexMetadata : clusterStateResponse.getState().metadata().indices().values()) {
+            Long creationTime = indexMetadata.getCreationDate();
+            if ((Instant.now().toEpochMilli() - creationTime) > maxRetentionPeriod) {
+                // check that the index is not the current write index
+                String indexToDelete = indexMetadata.getIndex().getName();
+                if (indexToDelete.equals(writeIndex) == false) {
+                    indicesToDelete.add(indexToDelete);
+                }
+            }
+        }
+        return indicesToDelete;
+    }
+
+    public List<String> getIocIndicesToDeleteBySize(
+            ClusterStateResponse clusterStateResponse,
+            Integer numOfIndices,
+            List<String> concreteIndices,
+            String alias
+    ) {
+        List<String> indicesToDelete = new ArrayList<>();
+        String writeIndex = IndexUtils.getWriteIndex(alias, clusterStateResponse.getState());
+
+        for (int i = 0; i < numOfIndices; i++) {
+            String indexToDelete = getOldestIndexByCreationDate(concreteIndices, clusterStateResponse.getState(), indicesToDelete);
+            if (indexToDelete.equals(writeIndex) == false ) { // theoretically this should never be true (never be the write index)
+                indicesToDelete.add(indexToDelete);
+            }
+        }
+        return indicesToDelete;
+    }
+
+    private static String getOldestIndexByCreationDate(
+            List<String> concreteIndices,
+            ClusterState clusterState,
+            List<String> indicesToDelete
+    ) {
+        final SortedMap<String, IndexAbstraction> lookup = clusterState.getMetadata().getIndicesLookup();
+        long minCreationDate = Long.MAX_VALUE;
+        String oldestIndex = null;
+        for (String indexName : concreteIndices) {
+            IndexAbstraction index = lookup.get(indexName);
+            IndexMetadata indexMetadata = clusterState.getMetadata().index(indexName);
+            if(index != null && index.getType() == IndexAbstraction.Type.CONCRETE_INDEX) {
+                if (indexMetadata.getCreationDate() < minCreationDate && indicesToDelete.contains(indexName) == false) {
+                    minCreationDate = indexMetadata.getCreationDate();
+                    oldestIndex = indexName;
+                }
+            }
+        }
+        return oldestIndex;
+    }
+
+    private List<String> getConcreteIndices(String alias) {
+        ClusterState state = this.clusterService.state();
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(
+                state,
+                IndicesOptions.lenientExpand(),
+                false,
+                alias
+        );
+        return new ArrayList<>(List.of(concreteIndices));
+    }
+
+    private Integer numOfIndicesToDelete(List<String> concreteIndices) {
+        Integer maxIndicesPerAlias = clusterService.getClusterSettings().get(SecurityAnalyticsSettings.MAX_IOC_INDICES_PER_ALIAS);
+        if (concreteIndices.size() > maxIndicesPerAlias ) {
+            return concreteIndices.size() - maxIndicesPerAlias;
+        }
+        return 0;
+    }
+
 
     private void onDeleteThreatIntelMonitors(String saTifSourceConfigId, ActionListener<DeleteResponse> listener, SATIFSourceConfig saTifSourceConfig, Boolean isDeleted) {
         if (isDeleted == false) {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -621,7 +621,7 @@ public class SATIFSourceConfigManagementService {
      * @return
      */
     private Integer numOfIndicesToDelete(List<String> concreteIndices) {
-        Integer maxIndicesPerAlias = clusterService.getClusterSettings().get(SecurityAnalyticsSettings.IOC_INDICES_PER_ALIAS);
+        Integer maxIndicesPerAlias = clusterService.getClusterSettings().get(SecurityAnalyticsSettings.IOC_MAX_INDICES_PER_ALIAS);
         if (concreteIndices.size() > maxIndicesPerAlias ) {
             return concreteIndices.size() - maxIndicesPerAlias;
         }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
@@ -331,6 +331,7 @@ public class SATIFSourceConfigService {
     }
 
     public void deleteAllOldIocHistoryIndices(List<String> indicesToDelete) {
+//        indicesToDelete.remove(0); // don't include the alias, make this logic better
         if (indicesToDelete.size() > 0) {
             DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indicesToDelete.toArray(new String[0]));
             client.admin().indices().delete(

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
@@ -330,30 +330,29 @@ public class SATIFSourceConfigService {
         ));
     }
 
-    public void deleteAllOldIocHistoryIndices(List<String> indicesToDelete) {
-//        indicesToDelete.remove(0); // don't include the alias, make this logic better
-        if (indicesToDelete.size() > 0) {
+    public void deleteAllOldIocIndices(List<String> indicesToDelete) {
+        if (indicesToDelete.isEmpty() == false) {
             DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indicesToDelete.toArray(new String[0]));
             client.admin().indices().delete(
                     deleteIndexRequest,
                     ActionListener.wrap(
                             deleteIndicesResponse -> {
                                 if (!deleteIndicesResponse.isAcknowledged()) {
-                                    log.error("Could not delete one or more IOC history/IOC indices: [" + indicesToDelete + "]. Retrying one by one.");
-                                    deleteOldIocHistoryIndex(indicesToDelete);
+                                    log.error("Could not delete one or more IOC indices: [" + indicesToDelete + "]. Retrying one by one.");
+                                    deleteOldIocIndex(indicesToDelete);
                                 } else {
                                     log.info("Successfully deleted indices: [" + indicesToDelete + "]");
                                 }
                             }, e -> {
-                                log.error("Delete for IOC History Indices failed: [" + indicesToDelete + "]. Retrying one By one.");
-                                deleteOldIocHistoryIndex(indicesToDelete);
+                                log.error("Delete for IOC Indices failed: [" + indicesToDelete + "]. Retrying one By one.");
+                                deleteOldIocIndex(indicesToDelete);
                             }
                     )
             );
         }
     }
 
-    private void deleteOldIocHistoryIndex(List<String> indicesToDelete) {
+    private void deleteOldIocIndex(List<String> indicesToDelete) {
         for (String index : indicesToDelete) {
             final DeleteIndexRequest singleDeleteRequest = new DeleteIndexRequest(indicesToDelete.toArray(new String[0]));
             client.admin().indices().delete(
@@ -361,7 +360,7 @@ public class SATIFSourceConfigService {
                     ActionListener.wrap(
                             response -> {
                                 if (!response.isAcknowledged()) {
-                                    log.error("Could not delete one or more IOC history indices: " + index);
+                                    log.error("Could not delete one or more IOC indices: " + index);
                                 }
                             }, e -> {
                                 log.debug("Exception: [" + e.getMessage() + "] while deleting the index " + index);
@@ -371,12 +370,10 @@ public class SATIFSourceConfigService {
         }
     }
 
-    // TODO: cat indices?
     public void getClusterState(
             final ActionListener<ClusterStateResponse> actionListener,
             String... indices)
     {
-        log.info("info deleteOldIndices");
         ClusterStateRequest clusterStateRequest = new ClusterStateRequest()
                 .clear()
                 .indices(indices)

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
@@ -11,7 +11,10 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.StepListener;
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
@@ -19,6 +22,7 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.routing.Preference;
@@ -38,8 +42,6 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.jobscheduler.spi.LockModel;
-import org.opensearch.rest.BytesRestResponse;
-import org.opensearch.rest.RestResponse;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
@@ -49,7 +51,6 @@ import org.opensearch.securityanalytics.threatIntel.action.monitor.request.Searc
 import org.opensearch.securityanalytics.threatIntel.common.StashedThreadContext;
 import org.opensearch.securityanalytics.threatIntel.common.TIFLockService;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
-import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
 import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -58,10 +59,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
-import static org.opensearch.core.rest.RestStatus.OK;
 import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.INDEX_TIMEOUT;
 import static org.opensearch.securityanalytics.transport.TransportIndexDetectorAction.PLUGIN_OWNER_FIELD;
 
@@ -328,6 +329,74 @@ public class SATIFSourceConfigService {
                 }
         ));
     }
+
+    public void deleteAllOldIocHistoryIndices(List<String> indicesToDelete) {
+        if (indicesToDelete.size() > 0) {
+            DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indicesToDelete.toArray(new String[0]));
+            client.admin().indices().delete(
+                    deleteIndexRequest,
+                    ActionListener.wrap(
+                            deleteIndicesResponse -> {
+                                if (!deleteIndicesResponse.isAcknowledged()) {
+                                    log.error("Could not delete one or more IOC history/IOC indices: [" + indicesToDelete + "]. Retrying one by one.");
+                                    deleteOldIocHistoryIndex(indicesToDelete);
+                                } else {
+                                    log.info("Successfully deleted indices: [" + indicesToDelete + "]");
+                                }
+                            }, e -> {
+                                log.error("Delete for IOC History Indices failed: [" + indicesToDelete + "]. Retrying one By one.");
+                                deleteOldIocHistoryIndex(indicesToDelete);
+                            }
+                    )
+            );
+        }
+    }
+
+    private void deleteOldIocHistoryIndex(List<String> indicesToDelete) {
+        for (String index : indicesToDelete) {
+            final DeleteIndexRequest singleDeleteRequest = new DeleteIndexRequest(indicesToDelete.toArray(new String[0]));
+            client.admin().indices().delete(
+                    singleDeleteRequest,
+                    ActionListener.wrap(
+                            response -> {
+                                if (!response.isAcknowledged()) {
+                                    log.error("Could not delete one or more IOC history indices: " + index);
+                                }
+                            }, e -> {
+                                log.debug("Exception: [" + e.getMessage() + "] while deleting the index " + index);
+                            }
+                    )
+            );
+        }
+    }
+
+    // TODO: cat indices?
+    public void getClusterState(
+            List<String> indices,
+            final ActionListener<ClusterStateResponse> actionListener
+    ) {
+        log.info("info deleteOldIndices");
+        ClusterStateRequest clusterStateRequest = new ClusterStateRequest()
+                .clear()
+                .indices(String.valueOf(indices))
+                .metadata(true)
+                .local(true)
+                .indicesOptions(IndicesOptions.strictExpand());
+        client.admin().cluster().state(
+                clusterStateRequest,
+                ActionListener.wrap(
+                        clusterStateResponse -> {
+                            log.debug("Successfully retrieved cluster state");
+                            actionListener.onResponse(clusterStateResponse);
+                        }, e -> {
+                            log.error("Error fetching cluster state");
+                            actionListener.onFailure(e);
+                        }
+                )
+        );
+    }
+
+
 
     public void checkAndEnsureThreatIntelMonitorsDeleted(
             ActionListener<Boolean> listener

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
@@ -372,13 +372,13 @@ public class SATIFSourceConfigService {
 
     // TODO: cat indices?
     public void getClusterState(
-            List<String> indices,
-            final ActionListener<ClusterStateResponse> actionListener
-    ) {
+            final ActionListener<ClusterStateResponse> actionListener,
+            String... indices)
+    {
         log.info("info deleteOldIndices");
         ClusterStateRequest clusterStateRequest = new ClusterStateRequest()
                 .clear()
-                .indices(String.valueOf(indices))
+                .indices(indices)
                 .metadata(true)
                 .local(true)
                 .indicesOptions(IndicesOptions.strictExpand());

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ListIOCsRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ListIOCsRestApiIT.java
@@ -86,7 +86,7 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
     public void test_retrievesIOCs() throws IOException {
         // Create index with mappings
         testFeedSourceConfigId = TestHelpers.randomLowerCaseString();
-        indexName = STIX2IOCFeedStore.getFeedConfigIndexName(testFeedSourceConfigId);
+        indexName = STIX2IOCFeedStore.getIocIndexAlias(testFeedSourceConfigId);
 
         try {
             createIndex(indexName, Settings.EMPTY, indexMapping);

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
@@ -381,7 +381,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
         }, 240, TimeUnit.SECONDS);
 
         // Confirm IOCs were ingested to system index for the feed
-        String indexName = STIX2IOCFeedStore.getFeedConfigIndexName(createdId);
+        String indexName = STIX2IOCFeedStore.getIocIndexAlias(createdId);
         String request = "{\n" +
                 "   \"query\" : {\n" +
                 "     \"match_all\":{\n" +


### PR DESCRIPTION
### Description
Rollsover ioc indices based on age of index and number of indices associated with an alias. Deletes the old ioc indices
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
