### PR TITLE
Refactored calls to S3. Added support for consuming security analytics commons directly from project rootDir.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,15 @@ buildscript {
         }
         if (isSnapshot) {
             opensearch_build += "-SNAPSHOT"
-            sa_commons_version += "-SNAPSHOT"
+
+            // TODO consider enabling snapshot options once SA commons is published to maven central
+//            sa_commons_version += "-SNAPSHOT"
         }
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = '1.8.21'
+
+        sa_commons_file_name = "security-analytics-commons-${sa_commons_version}.jar"
+        sa_commons_file_path = "${project.rootDir}/${sa_commons_file_name}"
     }
 
     repositories {
@@ -165,8 +170,13 @@ dependencies {
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
     compileOnly "org.opensearch.alerting:alerting-spi:${opensearch_build}"
     implementation "org.apache.commons:commons-csv:1.10.0"
-    api "org.opensearch:security-analytics-commons:${sa_commons_version}@jar"
     compileOnly "com.google.guava:guava:32.1.3-jre"
+
+    // TODO uncomment once SA commons is published to maven central
+//    api "org.opensearch:security-analytics-commons:${sa_commons_version}@jar"
+
+    // TODO remove once SA commons is published to maven central
+    api files(sa_commons_file_path)
 
     // Needed for integ tests
     zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${opensearch_build}"
@@ -363,6 +373,12 @@ afterEvaluate {
 
         into '/usr/share/opensearch/plugins'
         from(zipTree(bundlePlugin.archivePath)) {
+            into opensearchplugin.name
+        }
+
+        // TODO remove once SA commons is published to maven central
+        from(project.rootDir) {
+            include sa_commons_file_name
             into opensearchplugin.name
         }
 

--- a/src/main/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDto.java
@@ -16,7 +16,7 @@ import org.opensearch.core.xcontent.XContentParserUtils;
 import java.io.IOException;
 
 /**
- * A data transfer object for <STIX2IOC> containing additional details.
+ * A data transfer object for STIX2IOC containing additional details.
  */
 public class DetailedSTIX2IOCDto implements Writeable, ToXContentObject {
     public static final String NUM_FINDINGS_FIELD = "num_findings";

--- a/src/main/java/org/opensearch/securityanalytics/model/STIX2IOC.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/STIX2IOC.java
@@ -116,6 +116,24 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
         );
     }
 
+    public STIX2IOC(STIX2IOCDto ioc, String feedId, String feedName) {
+        this(
+                ioc.getId(),
+                ioc.getName(),
+                ioc.getType(),
+                ioc.getValue(),
+                ioc.getSeverity(),
+                ioc.getCreated(),
+                ioc.getModified(),
+                ioc.getDescription(),
+                ioc.getLabels(),
+                ioc.getSpecVersion(),
+                feedId,
+                feedName,
+                NO_VERSION
+        );
+    }
+
     public static STIX2IOC readFrom(StreamInput sin) throws IOException {
         return new STIX2IOC(sin);
     }

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCConnectorFactory.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCConnectorFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.securityanalytics.services;
 
+import com.amazonaws.services.s3.AmazonS3;
 import org.opensearch.securityanalytics.commons.connector.Connector;
 import org.opensearch.securityanalytics.commons.connector.S3Connector;
 import org.opensearch.securityanalytics.commons.connector.codec.InputCodec;
@@ -17,6 +18,8 @@ import org.opensearch.securityanalytics.commons.model.FeedLocation;
 import org.opensearch.securityanalytics.commons.model.STIX2;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.util.List;
+
 public class STIX2IOCConnectorFactory extends UnaryParameterCachingFactory<FeedConfiguration, Connector<STIX2>> {
     private final InputCodecFactory inputCodecFactory;
     private final S3ClientFactory s3ClientFactory;
@@ -28,6 +31,7 @@ public class STIX2IOCConnectorFactory extends UnaryParameterCachingFactory<FeedC
 
     protected Connector<STIX2> doCreate(FeedConfiguration feedConfiguration) {
         final FeedLocation feedLocation = FeedLocation.fromFeedConfiguration(feedConfiguration);
+        // TODO hurneyt add debug log for which location gets used
         switch(feedLocation) {
             case S3: return createS3Connector(feedConfiguration);
             default: throw new IllegalArgumentException("Unsupported feedLocation: " + feedLocation);
@@ -37,6 +41,13 @@ public class STIX2IOCConnectorFactory extends UnaryParameterCachingFactory<FeedC
     private S3Connector<STIX2> createS3Connector(final FeedConfiguration feedConfiguration) {
         final S3ConnectorConfig s3ConnectorConfig = feedConfiguration.getS3ConnectorConfig();
         final S3Client s3Client = s3ClientFactory.create(s3ConnectorConfig.getRoleArn(), s3ConnectorConfig.getRegion());
+        final InputCodec inputCodec = inputCodecFactory.create(feedConfiguration.getIocSchema().getModelClass(), feedConfiguration.getInputCodecSchema());
+        return new S3Connector<>(s3ConnectorConfig, s3Client, inputCodec);
+    }
+
+    public S3Connector<STIX2> createAmazonS3Connector(final FeedConfiguration feedConfiguration, List<String> clusterTuple) {
+        final S3ConnectorConfig s3ConnectorConfig = feedConfiguration.getS3ConnectorConfig();
+        final AmazonS3 s3Client = s3ClientFactory.createAmazonS3(s3ConnectorConfig.getRoleArn(), s3ConnectorConfig.getRegion(), clusterTuple);
         final InputCodec inputCodec = inputCodecFactory.create(feedConfiguration.getIocSchema().getModelClass(), feedConfiguration.getInputCodecSchema());
         return new S3Connector<>(s3ConnectorConfig, s3Client, inputCodec);
     }

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCConsumer.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCConsumer.java
@@ -40,6 +40,12 @@ public class STIX2IOCConsumer implements Consumer<STIX2> {
                 feedStore.getSaTifSourceConfig().getName()
         );
 
+        // TODO hurneyt refactor once the enum values are updated
+        // If the IOC received is not a type listed for the config, do not add it to the queue
+        if (!feedStore.getSaTifSourceConfig().getIocTypes().contains(stix2IOC.getType().name())) {
+            return;
+        }
+
         if (queue.offer(stix2IOC)) {
             return;
         }

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.securityanalytics.services;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.Client;
@@ -13,8 +15,10 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.securityanalytics.action.TestS3ConnectionResponse;
 import org.opensearch.securityanalytics.commons.connector.Connector;
 import org.opensearch.securityanalytics.commons.connector.S3Connector;
 import org.opensearch.securityanalytics.commons.connector.factory.InputCodecFactory;
@@ -32,11 +36,22 @@ import org.opensearch.securityanalytics.model.STIX2IOCDto;
 import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.securityanalytics.threatIntel.model.S3Source;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
+import org.opensearch.securityanalytics.threatIntel.service.TIFJobParameterService;
+import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.sts.model.StsException;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * IOC Service implements operations that interact with retrieving IOCs from data sources,
@@ -44,6 +59,7 @@ import java.util.List;
  */
 public class STIX2IOCFetchService {
     private final Logger log = LogManager.getLogger(STIX2IOCFetchService.class);
+    private final String ENDPOINT_CONFIG_PATH = "/threatIntelFeed/internalAuthEndpoint.txt";
 
     private Client client;
     private ClusterService clusterService;
@@ -52,14 +68,16 @@ public class STIX2IOCFetchService {
 
     // TODO hurneyt this is using TIF batch size setting. Consider adding IOC-specific setting
     private Integer batchSize;
+    private String internalAuthEndpoint = "";
 
     public STIX2IOCFetchService(Client client, ClusterService clusterService) {
         this.client = client;
         this.clusterService = clusterService;
+        this.internalAuthEndpoint = getEndpoint();
 
         StsAssumeRoleCredentialsProviderFactory factory =
                 new StsAssumeRoleCredentialsProviderFactory(new StsClientFactory());
-        s3ClientFactory = new S3ClientFactory(factory);
+        s3ClientFactory = new S3ClientFactory(factory, internalAuthEndpoint);
         connectorFactory = new STIX2IOCConnectorFactory(new InputCodecFactory(), s3ClientFactory);
         batchSize = clusterService.getClusterSettings().get(SecurityAnalyticsSettings.BATCH_SIZE);
     }
@@ -104,14 +122,75 @@ public class STIX2IOCFetchService {
         }
     }
 
-    public HeadObjectResponse testS3Connection(S3ConnectorConfig s3ConnectorConfig) {
-        S3Connector<STIX2> connector = (S3Connector<STIX2>) constructS3Connector(s3ConnectorConfig);
-        return connector.testS3Connection(s3ConnectorConfig);
+    public void testS3Connection(S3ConnectorConfig s3ConnectorConfig, ActionListener<TestS3ConnectionResponse> listener) {
+        if (internalAuthEndpoint.isEmpty()) {
+            testS3ClientConnection(s3ConnectorConfig, listener);
+        } else {
+            testAmazonS3Connection(s3ConnectorConfig, listener);
+        }
+    }
+
+    private void testS3ClientConnection(S3ConnectorConfig s3ConnectorConfig, ActionListener<TestS3ConnectionResponse> listener) {
+        try {
+            S3Connector<STIX2> connector = (S3Connector<STIX2>) constructS3Connector(s3ConnectorConfig);
+            HeadObjectResponse response = connector.testS3Connection(s3ConnectorConfig);
+            listener.onResponse(new TestS3ConnectionResponse(RestStatus.fromCode(response.sdkHttpResponse().statusCode()), ""));
+        } catch (NoSuchKeyException noSuchKeyException) {
+            log.warn("S3Client connection test failed with NoSuchKeyException: ", noSuchKeyException);
+            listener.onResponse(new TestS3ConnectionResponse(RestStatus.fromCode(noSuchKeyException.statusCode()), noSuchKeyException.awsErrorDetails().errorMessage()));
+        } catch (S3Exception s3Exception) {
+            log.warn("S3Client connection test failed with S3Exception: ", s3Exception);
+            listener.onResponse(new TestS3ConnectionResponse(RestStatus.fromCode(s3Exception.statusCode()), "Resource not found."));
+        } catch (StsException stsException) {
+            log.warn("S3Client connection test failed with StsException: ", stsException);
+            listener.onResponse(new TestS3ConnectionResponse(RestStatus.fromCode(stsException.statusCode()), stsException.awsErrorDetails().errorMessage()));
+        } catch (SdkException sdkException ) {
+            // SdkException is a RunTimeException that doesn't have a status code.
+            // Logging the full exception, and providing generic response as output.
+            log.warn("S3Client connection test failed with SdkException: ", sdkException);
+            listener.onResponse(new TestS3ConnectionResponse(RestStatus.FORBIDDEN, "Resource not found."));
+        } catch (Exception e) {
+            log.warn("S3Client connection test failed with error: ", e);
+            listener.onFailure(SecurityAnalyticsException.wrap(e));
+        }
+
+    }
+
+    private void testAmazonS3Connection(S3ConnectorConfig s3ConnectorConfig, ActionListener<TestS3ConnectionResponse> listener) {
+        try {
+            S3Connector<STIX2> connector = (S3Connector<STIX2>) constructS3Connector(s3ConnectorConfig);
+            boolean response = connector.testAmazonS3Connection(s3ConnectorConfig);
+            listener.onResponse(new TestS3ConnectionResponse(response ? RestStatus.OK : RestStatus.FORBIDDEN, ""));
+        } catch (AmazonServiceException e) {
+            log.warn("AmazonS3 connection test failed with AmazonServiceException: ", e);
+            listener.onResponse(new TestS3ConnectionResponse(RestStatus.fromCode(e.getStatusCode()), e.getErrorMessage()));
+        } catch (SdkClientException e) {
+            // SdkException is a RunTimeException that doesn't have a status code.
+            // Logging the full exception, and providing generic response as output.
+            log.warn("AmazonS3 connection test failed with SdkClientException: ", e);
+            listener.onResponse(new TestS3ConnectionResponse(RestStatus.FORBIDDEN, "Resource not found."));
+        } catch (Exception e) {
+            log.warn("AmazonS3 connection test failed with error: ", e);
+            listener.onFailure(SecurityAnalyticsException.wrap(e));
+        }
     }
 
     private Connector<STIX2> constructS3Connector(S3ConnectorConfig s3ConnectorConfig) {
         FeedConfiguration feedConfiguration = new FeedConfiguration(IOCSchema.STIX2, InputCodecSchema.ND_JSON, s3ConnectorConfig);
+        if (internalAuthEndpoint.isEmpty()) {
+            return constructS3ClientConnector(feedConfiguration);
+        } else {
+            return constructAmazonS3Connector(feedConfiguration);
+        }
+    }
+
+    private Connector<STIX2> constructS3ClientConnector(FeedConfiguration feedConfiguration) {
         return connectorFactory.doCreate(feedConfiguration);
+    }
+
+    private Connector<STIX2> constructAmazonS3Connector(FeedConfiguration feedConfiguration) {
+        List<String> clusterTuple = List.of(clusterService.getClusterName().value().split(":"));
+        return connectorFactory.createAmazonS3Connector(feedConfiguration, clusterTuple);
     }
 
     private S3ConnectorConfig constructS3ConnectorConfig(SATIFSourceConfig saTifSourceConfig) {
@@ -133,6 +212,19 @@ public class STIX2IOCFetchService {
         if (s3ConnectorConfig.getRegion() == null || s3ConnectorConfig.getRegion().isEmpty()) {
             throw new IllegalArgumentException("Region is required.");
         }
+    }
+
+    private String getEndpoint() {
+        try {
+            try (InputStream is = TIFJobParameterService.class.getResourceAsStream(ENDPOINT_CONFIG_PATH)) {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+                    return reader.lines().map(String::trim).collect(Collectors.joining());
+                }
+            }
+        } catch (Exception e) {
+            log.debug(String.format("Resource file [%s] doesn't exist.", ENDPOINT_CONFIG_PATH));
+        }
+        return "";
     }
 
     public static class STIX2IOCFetchResponse extends ActionResponse implements ToXContentObject {
@@ -161,8 +253,6 @@ public class STIX2IOCFetchService {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             return builder.startObject()
-                    // TODO hurneyt include IOCs in response?
-//                    .field(IOCS_FIELD, this.iocs)
                     .field(TOTAL_FIELD, iocs.size())
                     .field(DURATION_FIELD, duration)
                     .endObject();

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -778,12 +778,7 @@ public class SATIFSourceConfigManagementService {
             return null;
         }
         return stix2IocDtoList.stream()
-                .map(dto -> {
-                    STIX2IOC stix2ioc = new STIX2IOC(dto);
-                    stix2ioc.setFeedName(name);
-                    stix2ioc.setFeedId(id);
-                    return stix2ioc;
-                })
+                .map(dto -> new STIX2IOC(dto, id, name))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
### Description
1. Implemented support for making calls to S3 using either S3Client, or AmazonS3. Dependency on S3Client will eventually be removed.
2. Added support for consuming security analytics commons directly from project rootDir.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
