### PR TITLE
Ignore feature tests that cannot execute in gjthub CI.

### DIFF
--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
@@ -11,6 +11,7 @@ package org.opensearch.securityanalytics.resthandler;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.opensearch.client.Response;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
@@ -100,6 +101,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
         s3Client.close();
     }
 
+    @Ignore
     public void testCreateSATIFSourceConfigAndVerifyJobRan() throws IOException, InterruptedException {
         // Generate test IOCs, and upload them to S3 to create the bucket object. Feed creation fails if the bucket object doesn't exist.
         int numOfIOCs = 1;
@@ -193,6 +195,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
         return false;
     }
 
+    @Ignore
     public void testGetSATIFSourceConfigById() throws IOException {
         // Generate test IOCs, and upload them to S3 to create the bucket object. Feed creation fails if the bucket object doesn't exist.
         int numOfIOCs = 1;
@@ -258,6 +261,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertTrue("Created ioc types and returned ioc types do not match", iocTypes.containsAll(returnedIocTypes) && returnedIocTypes.containsAll(iocTypes));
     }
 
+    @Ignore
     public void testDeleteSATIFSourceConfig() throws IOException {
         // Generate test IOCs, and upload them to S3 to create the bucket object. Feed creation fails if the bucket object doesn't exist.
         int numOfIOCs = 1;
@@ -326,6 +330,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertEquals(0, hits.size());
     }
 
+    @Ignore
     public void testRetrieveIOCsSuccessfully() throws IOException, InterruptedException {
         // Generate test IOCs, and upload them to S3
         int numOfIOCs = 5;

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/TestS3ConnectionRestIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/TestS3ConnectionRestIT.java
@@ -7,6 +7,7 @@ package org.opensearch.securityanalytics.resthandler;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.opensearch.client.Response;
 import org.opensearch.core.rest.RestStatus;
@@ -90,6 +91,7 @@ public class TestS3ConnectionRestIT extends SecurityAnalyticsRestTestCase {
         s3Client.close();
     }
 
+    @Ignore
     public void testConnection_succeeds() throws IOException {
         // Create the test request
         request = new TestS3ConnectionRequest(bucketName, objectKey, region, roleArn);
@@ -107,6 +109,7 @@ public class TestS3ConnectionRestIT extends SecurityAnalyticsRestTestCase {
         assertTrue(error.isEmpty());
     }
 
+    @Ignore
     public void testConnection_wrongBucket() throws IOException {
         // Create the test request
         request = new TestS3ConnectionRequest("fakebucket",  objectKey, region, roleArn);
@@ -124,6 +127,7 @@ public class TestS3ConnectionRestIT extends SecurityAnalyticsRestTestCase {
         assertEquals("Resource not found.", error);
     }
 
+    @Ignore
     public void testConnection_wrongKey() throws IOException {
         // Create the test request
         request = new TestS3ConnectionRequest(bucketName, "fakekey", region, roleArn);
@@ -141,6 +145,7 @@ public class TestS3ConnectionRestIT extends SecurityAnalyticsRestTestCase {
         assertEquals("The specified key does not exist.", error);
     }
 
+    @Ignore
     public void testConnection_wrongRegion() throws IOException {
         // Create the test request
         String wrongRegion = (Objects.equals(region, "us-west-2")) ? "us-east-1" : "us-west-2";
@@ -159,6 +164,7 @@ public class TestS3ConnectionRestIT extends SecurityAnalyticsRestTestCase {
         assertEquals("Resource not found.", error);
     }
 
+    @Ignore
     public void testConnection_invalidRegion() throws IOException {
         // Create the test request
         request = new TestS3ConnectionRequest(bucketName, objectKey, "fa-ke-1", roleArn);
@@ -176,6 +182,7 @@ public class TestS3ConnectionRestIT extends SecurityAnalyticsRestTestCase {
         assertEquals("Resource not found.", error);
     }
 
+    @Ignore
     public void testConnection_wrongRoleArn() throws IOException {
         // Create the test request
         request = new TestS3ConnectionRequest(bucketName, objectKey, region, "arn:aws:iam::123456789012:role/iam-fake-role");
@@ -193,6 +200,7 @@ public class TestS3ConnectionRestIT extends SecurityAnalyticsRestTestCase {
         assertTrue(error.contains("is not authorized to perform: sts:AssumeRole on resource"));
     }
 
+    @Ignore
     public void testConnection_invalidRoleArn() throws IOException {
         // Create the test request
         request = new TestS3ConnectionRequest(bucketName, objectKey, region, "arn:aws:iam::12345:role/iam-invalid-role");


### PR DESCRIPTION
### Description
As mentioned in https://github.com/opensearch-project/security-analytics/pull/1098#issuecomment-2200635491, the `TestS3ConnectionRestIT`, and `SATIFSourceConfigRestApiIT` tests cannot currently be executed via github CI as they require additional input params. 

Will discuss onboarding to github secrets with the build team to securely provide those params, and will raise a separate PR to remove the `@Ignore` annotations.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
