### PR TITLE
set blank response when indexNotFound exception

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/correlation/alert/CorrelationAlertService.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/alert/CorrelationAlertService.java
@@ -26,6 +26,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermsQueryBuilder;
@@ -188,7 +189,11 @@ public class CorrelationAlertService {
                 },
                 e -> {
                     log.error("Search request to fetch correlation alerts failed", e);
-                    listener.onFailure(e);
+                    if (e instanceof IndexNotFoundException) {
+                        listener.onResponse(new GetCorrelationAlertsResponse(Collections.emptyList(), 0));
+                    } else {
+                        listener.onFailure(e);
+                    }
                 }
         ));
     }


### PR DESCRIPTION
### Description
* Send empty array during indexNotFound exception
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
