### PR TITLE
throw error when no iocs are stored due to incompatible ioc types from S3 downloaded iocs file

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -164,13 +164,12 @@ public class SATIFSourceConfigManagementService {
                                                     saTifSourceConfigService.deleteTIFSourceConfig(indexSaTifSourceConfigResponse, ActionListener.wrap(
                                                             deleteResponse -> {
                                                                 log.debug("Successfully deleted threat intel source config [{}]", indexSaTifSourceConfigResponse.getId());
-                                                                listener.onFailure(new OpenSearchException("Successfully deleted threat intel source config [{}]", indexSaTifSourceConfigResponse.getId()));
+                                                                listener.onFailure(e);
                                                             }, ex -> {
                                                                 log.error("Failed to delete threat intel source config [{}]", indexSaTifSourceConfigResponse.getId());
                                                                 listener.onFailure(ex);
                                                             }
                                                     ));
-                                                    listener.onFailure(e);
                                                 })
                                 );
                             }, e -> {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportGetIocFindingsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportGetIocFindingsAction.java
@@ -110,7 +110,9 @@ public class TransportGetIocFindingsAction extends HandledTransportAction<GetIoc
         List<String> findingIds = request.getFindingIds();
 
         if (findingIds != null && !findingIds.isEmpty()) {
-            queryBuilder.filter(QueryBuilders.termsQuery("id", findingIds));
+            BoolQueryBuilder findingIdsFilter = QueryBuilders.boolQuery();
+            findingIds.forEach(it -> findingIdsFilter.should(QueryBuilders.matchQuery("_id", it)));
+            queryBuilder.filter(findingIdsFilter);
         }
 
         List<String> iocIds = request.getIocIds();


### PR DESCRIPTION
### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
