### PR TITLE
add enabled for scan flag in source config.

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocUploadSource.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocUploadSource.java
@@ -89,15 +89,7 @@ public class IocUploadSource extends Source implements Writeable, ToXContent {
         return iocs;
     }
 
-    public void setIocs(List<STIX2IOCDto> iocs) {
-        this.iocs = iocs;
-    }
-
     public String getFileName() {
         return fileName;
-    }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/TIFSourceConfig.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/TIFSourceConfig.java
@@ -17,58 +17,30 @@ public interface TIFSourceConfig {
 
     public String getId();
 
-    public void setId(String id);
-
     Long getVersion();
-
-    void setVersion(Long version);
 
     String getName();
 
-    void setName(String feedName);
-
     String getFormat();
-
-    void setFormat(String format);
 
     SourceConfigType getType();
 
-    void setType(SourceConfigType type);
-
     User getCreatedByUser();
-
-    void setCreatedByUser(User createdByUser);
 
     Instant getCreatedAt();
 
-    void setCreatedAt(Instant createdAt);
-
     Instant getEnabledTime();
-
-    void setEnabledTime(Instant enabledTime);
 
     Instant getLastUpdateTime();
 
-    void setLastUpdateTime(Instant lastUpdateTime);
-
     Schedule getSchedule();
-
-    void setSchedule(Schedule schedule);
 
     TIFJobState getState();
 
-    void setState(TIFJobState previousState);
-
-    void enable();
-
-    void disable();
-
     IocStoreConfig getIocStoreConfig();
-
-    void setIocStoreConfig(IocStoreConfig iocStoreConfig);
 
     public List<String> getIocTypes();
 
-    public void setIocTypes(List<String> iocTypes);
+    public boolean isEnabledForScan();
 
 }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/TIFSourceConfigDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/TIFSourceConfigDto.java
@@ -16,51 +16,25 @@ public interface TIFSourceConfigDto {
 
     public String getId();
 
-    public void setId(String id);
-
     Long getVersion();
-
-    void setVersion(Long version);
 
     String getName();
 
-    void setName(String feedName);
-
     String getFormat();
-
-    void setFormat(String format);
 
     SourceConfigType getType();
 
-    void setType(SourceConfigType type);
-
     User getCreatedByUser();
-
-    void setCreatedByUser(User createdByUser);
 
     Instant getCreatedAt();
 
-    void setCreatedAt(Instant createdAt);
-
     Instant getEnabledTime();
-
-    void setEnabledTime(Instant enabledTime);
 
     Instant getLastUpdateTime();
 
-    void setLastUpdateTime(Instant lastUpdateTime);
-
     Schedule getSchedule();
 
-    void setSchedule(Schedule schedule);
-
     TIFJobState getState();
-
-    void setState(TIFJobState previousState);
-
-    void enable();
-
-    void disable();
 
     public List<String> getIocTypes();
 

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
@@ -161,7 +161,8 @@ public class SATIFSourceConfigService {
                 saTifSourceConfig.getLastRefreshedUser(),
                 saTifSourceConfig.isEnabled(),
                 saTifSourceConfig.getIocStoreConfig(),
-                saTifSourceConfig.getIocTypes()
+                saTifSourceConfig.getIocTypes(),
+                saTifSourceConfig.isEnabledForScan()
         );
     }
 

--- a/src/main/resources/mappings/threat_intel_job_mapping.json
+++ b/src/main/resources/mappings/threat_intel_job_mapping.json
@@ -128,6 +128,9 @@
         "refresh_type": {
           "type": "keyword"
         },
+        "enabled_for_scan": {
+          "type": "boolean"
+        },
         "last_refreshed_time": {
           "type": "date",
           "format": "strict_date_time||epoch_millis"

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -248,7 +248,7 @@ public class TestHelpers {
     }
 
     public static CorrelationRule randomCorrelationRuleWithTrigger(String name) {
-        name = name.isEmpty()? "><script>prompt(document.domain)</script>": name;
+        name = name.isEmpty() ? "><script>prompt(document.domain)</script>" : name;
         List<Action> actions = new ArrayList<Action>();
         CorrelationRuleTrigger trigger = new CorrelationRuleTrigger("trigger-123", "Trigger 1", "high", actions);
         return new CorrelationRule(CorrelationRule.NO_ID, CorrelationRule.NO_VERSION, name,
@@ -2825,7 +2825,8 @@ public class TestHelpers {
                 lastRefreshedTime,
                 lastRefreshedUser,
                 isEnabled,
-                iocTypes
+                iocTypes,
+                true
         );
     }
 
@@ -2916,7 +2917,8 @@ public class TestHelpers {
                 lastRefreshedUser,
                 isEnabled,
                 iocStoreConfig,
-                iocTypes
+                iocTypes,
+                true
         );
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/action/GetTIFSourceConfigResponseTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/GetTIFSourceConfigResponseTests.java
@@ -53,7 +53,8 @@ public class GetTIFSourceConfigResponseTests extends OpenSearchTestCase {
                 Instant.now(),
                 null,
                 false,
-                iocTypes
+                iocTypes,
+                true
         );
 
         SAGetTIFSourceConfigResponse response = new SAGetTIFSourceConfigResponse(saTifSourceConfigDto.getId(), saTifSourceConfigDto.getVersion(), RestStatus.OK, saTifSourceConfigDto);

--- a/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigResponseTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigResponseTests.java
@@ -49,7 +49,8 @@ public class IndexTIFSourceConfigResponseTests extends OpenSearchTestCase {
                 Instant.now(),
                 null,
                 false,
-                iocTypes
+                iocTypes,
+                true
         );
 
         SAIndexTIFSourceConfigResponse response = new SAIndexTIFSourceConfigResponse(saTifSourceConfigDto.getId(), saTifSourceConfigDto.getVersion(), RestStatus.OK, saTifSourceConfigDto);

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
@@ -135,7 +135,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                 Instant.now(),
                 null,
                 true,
-                iocTypes
+                iocTypes, true
         );
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
         Assert.assertEquals(201, response.getStatusLine().getStatusCode());
@@ -229,7 +229,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                 Instant.now(),
                 null,
                 true,
-                iocTypes
+                iocTypes, true
         );
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -295,7 +295,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                 Instant.now(),
                 null,
                 true,
-                iocTypes
+                iocTypes, true
         );
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -364,7 +364,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                 Instant.now(),
                 null,
                 true,
-                iocTypes
+                iocTypes, true
         );
 
         // Confirm test feed was created successfully

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
@@ -77,7 +77,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes
+                iocTypes, true
         );
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
@@ -97,7 +97,8 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 false,
                 new DefaultIocStoreConfig(Map.of("ipv4_addr", List.of(iocIndexName))),
-                List.of("ipv4_addr")
+                List.of("ipv4_addr"),
+                true
         );
         String indexName = SecurityAnalyticsPlugin.JOB_INDEX_NAME;
         Response response = indexDoc(indexName, configId, config.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).toString());


### PR DESCRIPTION
### Description
Adds a field `enabled_for_scan` in source config model.
1. This flag is used by threat intel monitor - if true, monitor will use indicators from source config to scan for malicious iocs in user data, if false it will be ignores.
2. This flag is also used to determine whether to refresh a feed or not when job is run. Refresh api however will ignore flag value
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
