### PR TITLE
adds new tif source config type - url download

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -157,6 +157,7 @@ import org.opensearch.securityanalytics.threatIntel.resthandler.monitor.RestGetT
 import org.opensearch.securityanalytics.threatIntel.resthandler.monitor.RestIndexThreatIntelMonitorAction;
 import org.opensearch.securityanalytics.threatIntel.resthandler.monitor.RestSearchThreatIntelMonitorAction;
 import org.opensearch.securityanalytics.threatIntel.resthandler.monitor.RestUpdateThreatIntelAlertsStatusAction;
+import org.opensearch.securityanalytics.threatIntel.service.DefaultTifSourceConfigLoaderService;
 import org.opensearch.securityanalytics.threatIntel.service.DetectorThreatIntelService;
 import org.opensearch.securityanalytics.threatIntel.service.SATIFSourceConfigManagementService;
 import org.opensearch.securityanalytics.threatIntel.service.SATIFSourceConfigService;
@@ -326,12 +327,13 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
         IocFindingService iocFindingService = new IocFindingService(client, clusterService, xContentRegistry);
         ThreatIntelAlertService threatIntelAlertService = new ThreatIntelAlertService(client, clusterService, xContentRegistry);
         SaIoCScanService ioCScanService = new SaIoCScanService(client, xContentRegistry, iocFindingService, threatIntelAlertService, notificationService);
+        DefaultTifSourceConfigLoaderService defaultTifSourceConfigLoaderService = new DefaultTifSourceConfigLoaderService(builtInTIFMetadataLoader, client, saTifSourceConfigManagementService);
         return List.of(
                 detectorIndices, correlationIndices, correlationRuleIndices, ruleTopicIndices, customLogTypeIndices, ruleIndices, threatIntelAlertService,
                 mapperService, indexTemplateManager, builtinLogTypeLoader, builtInTIFMetadataLoader, threatIntelFeedDataService, detectorThreatIntelService,
                 correlationAlertService, notificationService,
                 tifJobUpdateService, tifJobParameterService, threatIntelLockService, saTifSourceConfigService, saTifSourceConfigManagementService, stix2IOCFetchService,
-                ioCScanService);
+                ioCScanService, defaultTifSourceConfigLoaderService);
     }
 
     @Override

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
@@ -270,7 +270,8 @@ public class STIX2IOCFetchService {
                 }
                 break;
             default:
-                // if the feed type doesn't match any of the supporting feed types, throw an exception
+                log.error("unsupported feed format for url download:" + source.getFeedFormat());
+                listener.onFailure(new UnsupportedOperationException("unsupported feed format for url download:" + source.getFeedFormat()));
         }
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
@@ -7,8 +7,11 @@ package org.opensearch.securityanalytics.services;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
@@ -29,6 +32,7 @@ import org.opensearch.securityanalytics.commons.connector.model.InputCodecSchema
 import org.opensearch.securityanalytics.commons.connector.model.S3ConnectorConfig;
 import org.opensearch.securityanalytics.commons.model.FeedConfiguration;
 import org.opensearch.securityanalytics.commons.model.IOCSchema;
+import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.commons.model.STIX2;
 import org.opensearch.securityanalytics.commons.model.UpdateType;
 import org.opensearch.securityanalytics.model.STIX2IOC;
@@ -36,7 +40,9 @@ import org.opensearch.securityanalytics.model.STIX2IOCDto;
 import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.securityanalytics.threatIntel.model.S3Source;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
+import org.opensearch.securityanalytics.threatIntel.model.UrlDownloadSource;
 import org.opensearch.securityanalytics.threatIntel.service.TIFJobParameterService;
+import org.opensearch.securityanalytics.threatIntel.util.ThreatIntelFeedParser;
 import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
@@ -49,9 +55,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static org.opensearch.securityanalytics.threatIntel.service.ThreatIntelFeedDataService.isValidIp;
 
 /**
  * IOC Service implements operations that interact with retrieving IOCs from data sources,
@@ -84,14 +96,14 @@ public class STIX2IOCFetchService {
 
     /**
      * Method takes in and calls method to rollover and bulk index a list of STIX2IOCs
+     *
      * @param saTifSourceConfig
      * @param stix2IOCList
      * @param listener
      */
     public void onlyIndexIocs(SATIFSourceConfig saTifSourceConfig,
                               List<STIX2IOC> stix2IOCList,
-                              ActionListener<STIX2IOCFetchResponse> listener)
-    {
+                              ActionListener<STIX2IOCFetchResponse> listener) {
         STIX2IOCFeedStore feedStore = new STIX2IOCFeedStore(client, clusterService, saTifSourceConfig, listener);
         try {
             feedStore.indexIocs(stix2IOCList);
@@ -100,6 +112,7 @@ public class STIX2IOCFetchService {
             listener.onFailure(e);
         }
     }
+
     public void downloadAndIndexIOCs(SATIFSourceConfig saTifSourceConfig, ActionListener<STIX2IOCFetchResponse> listener) {
         S3ConnectorConfig s3ConnectorConfig = constructS3ConnectorConfig(saTifSourceConfig);
         Connector<STIX2> s3Connector = constructS3Connector(s3ConnectorConfig);
@@ -144,7 +157,7 @@ public class STIX2IOCFetchService {
         } catch (StsException stsException) {
             log.warn("S3Client connection test failed with StsException: ", stsException);
             listener.onResponse(new TestS3ConnectionResponse(RestStatus.fromCode(stsException.statusCode()), stsException.awsErrorDetails().errorMessage()));
-        } catch (SdkException sdkException ) {
+        } catch (SdkException sdkException) {
             // SdkException is a RunTimeException that doesn't have a status code.
             // Logging the full exception, and providing generic response as output.
             log.warn("S3Client connection test failed with SdkException: ", sdkException);
@@ -225,6 +238,76 @@ public class STIX2IOCFetchService {
             log.debug(String.format("Resource file [%s] doesn't exist.", ENDPOINT_CONFIG_PATH));
         }
         return "";
+    }
+
+    public void downloadFromUrlAndIndexIOCs(SATIFSourceConfig saTifSourceConfig, ActionListener<STIX2IOCFetchResponse> listener) {
+        UrlDownloadSource source = (UrlDownloadSource) saTifSourceConfig.getSource();
+        switch (source.getFeedFormat()) { // todo add check to stop user from creating url type config from rest api. only internal allowed
+            case "csv":
+                try (CSVParser reader = ThreatIntelFeedParser.getThreatIntelFeedReaderCSV(source.getUrl())) {
+                    CSVParser noHeaderReader = ThreatIntelFeedParser.getThreatIntelFeedReaderCSV(source.getUrl());
+                    boolean notFound = true;
+
+                    while (notFound) {
+                        CSVRecord hasHeaderRecord = reader.iterator().next();
+
+                        //if we want to skip this line and keep iterating
+                        if ((hasHeaderRecord.values().length == 1 && "".equals(hasHeaderRecord.values()[0])) || hasHeaderRecord.get(0).charAt(0) == '#' || hasHeaderRecord.get(0).charAt(0) == ' ') {
+                            noHeaderReader.iterator().next();
+                        } else { // we found the first line that contains information
+                            notFound = false;
+                        }
+                    }
+                    if (source.hasCsvHeader()) {
+                        parseAndSaveThreatIntelFeedDataCSV(reader.iterator(), saTifSourceConfig, listener);
+                    } else {
+                        parseAndSaveThreatIntelFeedDataCSV(noHeaderReader.iterator(), saTifSourceConfig, listener);
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to download the IoCs in CSV format for source " + saTifSourceConfig.getId());
+                    listener.onFailure(e);
+                    return;
+                }
+                break;
+            default:
+                // if the feed type doesn't match any of the supporting feed types, throw an exception
+        }
+    }
+
+    private void parseAndSaveThreatIntelFeedDataCSV(Iterator<CSVRecord> iterator, SATIFSourceConfig saTifSourceConfig, ActionListener<STIX2IOCFetchResponse> listener) throws IOException {
+        List<BulkRequest> bulkRequestList = new ArrayList<>();
+
+        UrlDownloadSource source = (UrlDownloadSource) saTifSourceConfig.getSource();
+        List<STIX2IOC> iocs = new ArrayList<>();
+        while (iterator.hasNext()) {
+            CSVRecord record = iterator.next();
+            String iocType = saTifSourceConfig.getIocTypes().stream().findFirst().orElse(null);
+            Integer colNum = source.getCsvIocValueColumnNo();
+            String iocValue = record.values()[colNum].split(" ")[0];
+            if (iocType.equalsIgnoreCase(IOCType.ipv6_addr.toString()) && !isValidIp(iocValue)) {
+                log.info("Invalid IP address, skipping this ioc record: {}", iocValue);
+                continue;
+            }
+            Instant now = Instant.now();
+            STIX2IOC stix2IOC = new STIX2IOC(
+                    UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString(),
+                    iocType == null ? IOCType.ipv4_addr : IOCType.valueOf(iocType),
+                    iocValue,
+                    "high",
+                    now,
+                    now,
+                    "",
+                    Collections.emptyList(),
+                    "",
+                    saTifSourceConfig.getId(),
+                    saTifSourceConfig.getName(),
+                    STIX2IOC.NO_VERSION
+            );
+            iocs.add(stix2IOC);
+        }
+        STIX2IOCFeedStore feedStore = new STIX2IOCFeedStore(client, clusterService, saTifSourceConfig, listener);
+        feedStore.indexIocs(iocs);
     }
 
     public static class STIX2IOCFetchResponse extends ActionResponse implements ToXContentObject {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
@@ -9,6 +9,7 @@ import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.threatIntel.model.IocUploadSource;
 import org.opensearch.securityanalytics.threatIntel.model.S3Source;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
+import org.opensearch.securityanalytics.threatIntel.model.UrlDownloadSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,6 +54,14 @@ public class SourceConfigDtoValidator {
                 }
                 if (sourceConfigDto.getSource() != null && sourceConfigDto.getSource() instanceof S3Source == false) {
                     errorMsgs.add("Source must be S3_CUSTOM type");
+                }
+                break;
+            case URL_DOWNLOAD:
+                if (sourceConfigDto.getSchedule() == null) {
+                    errorMsgs.add("Must pass in schedule for URL_DONWLOAD source type");
+                }
+                if (sourceConfigDto.getSource() != null && sourceConfigDto.getSource() instanceof UrlDownloadSource == false) {
+                    errorMsgs.add("Source must be URL_DONWLOAD source type");
                 }
                 break;
         }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
@@ -58,10 +58,10 @@ public class SourceConfigDtoValidator {
                 break;
             case URL_DOWNLOAD:
                 if (sourceConfigDto.getSchedule() == null) {
-                    errorMsgs.add("Must pass in schedule for URL_DONWLOAD source type");
+                    errorMsgs.add("Must pass in schedule for URL_DOWNLOAD source type");
                 }
                 if (sourceConfigDto.getSource() != null && sourceConfigDto.getSource() instanceof UrlDownloadSource == false) {
-                    errorMsgs.add("Source must be URL_DONWLOAD source type");
+                    errorMsgs.add("Source must be URL_DOWNLOAD source type");
                 }
                 break;
         }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigType.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigType.java
@@ -7,11 +7,11 @@ package org.opensearch.securityanalytics.threatIntel.common;
 
 /**
  * Types of feeds threat intel can support
- * Feed types include: S3_CUSTOM
  */
 public enum SourceConfigType {
     S3_CUSTOM,
-    IOC_UPLOAD
+    IOC_UPLOAD,
+    URL_DOWNLOAD
 
 //    LICENSED,
 //

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocUploadSource.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocUploadSource.java
@@ -96,8 +96,4 @@ public class IocUploadSource extends Source implements Writeable, ToXContent {
     public String getFileName() {
         return fileName;
     }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
 }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/Source.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/Source.java
@@ -20,6 +20,7 @@ public abstract class Source {
     abstract String name();
     public static final String S3_FIELD = "s3";
     public static final String IOC_UPLOAD_FIELD = "ioc_upload";
+    public static final String URL_DOWNLOAD_FIELD = "url_download";
 
     static Source readFrom(StreamInput sin) throws IOException {
         Type type = sin.readEnum(Type.class);
@@ -28,6 +29,8 @@ public abstract class Source {
                 return new S3Source(sin);
             case IOC_UPLOAD:
                 return new IocUploadSource(sin);
+            case URL_DOWNLOAD:
+                return new UrlDownloadSource(sin);
             default:
                 throw new IllegalStateException("Unexpected input ["+ type + "] when reading ioc store config");
         }
@@ -57,7 +60,9 @@ public abstract class Source {
     enum Type {
         S3(),
 
-        IOC_UPLOAD();
+        IOC_UPLOAD(),
+
+        URL_DOWNLOAD();
 
         @Override
         public String toString() {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/Source.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/Source.java
@@ -50,6 +50,9 @@ public abstract class Source {
                 case IOC_UPLOAD_FIELD:
                     source = IocUploadSource.parse(xcp);
                     break;
+                case URL_DOWNLOAD_FIELD:
+                    source = UrlDownloadSource.parse(xcp);
+                    break;
             }
         }
         return source;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/UrlDownloadSource.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/UrlDownloadSource.java
@@ -1,6 +1,7 @@
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -14,16 +15,39 @@ import java.net.URL;
  */
 public class UrlDownloadSource extends Source implements Writeable, ToXContent {
     public static final String URL_FIELD = "url";
+    public static final String FEED_FORMAT_FIELD = "feed_format";
+    public static final String HAS_CSV_HEADER_FIELD = "has_csv_header_field";
+    public static final String CSV_IOC_VALUE_COLUMN_NUM_FIELD = "csv_ioc_value_colum_num";
     public static final String SOURCE_NAME = "URL_DOWNLOAD";
 
     private final URL url;
+    private final String feedFormat;
+    private final Boolean hasCsvHeader;
+    private final Integer csvIocValueColumnNo;
 
-    public UrlDownloadSource(URL url) {
+    public UrlDownloadSource(URL url, String feedFormat, Boolean hasCsvHeader, Integer csvIocValueColumnNo) {
         this.url = url;
+        this.feedFormat = feedFormat;
+        this.hasCsvHeader = hasCsvHeader;
+        this.csvIocValueColumnNo = csvIocValueColumnNo;
+
     }
 
     public UrlDownloadSource(StreamInput sin) throws IOException {
-        this(new URL(sin.readString()));
+        this(
+                new URL(sin.readString()),
+                sin.readString(),
+                sin.readOptionalBoolean(),
+                sin.readOptionalInt()
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(url.toString());
+        out.writeString(feedFormat);
+        out.writeOptionalBoolean(hasCsvHeader);
+        out.writeOptionalInt(csvIocValueColumnNo);
     }
 
     @Override
@@ -37,6 +61,9 @@ public class UrlDownloadSource extends Source implements Writeable, ToXContent {
 
     public static UrlDownloadSource parse(XContentParser xcp) throws IOException {
         URL url = null;
+        String feedFormat = null;
+        Boolean hasCsvHeader = false;
+        Integer csvIocValueColumnNo = null;
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
             String fieldName = xcp.currentName();
             xcp.nextToken();
@@ -45,19 +72,46 @@ public class UrlDownloadSource extends Source implements Writeable, ToXContent {
                     String urlString = xcp.text();
                     url = new URL(urlString);
                     break;
+                case FEED_FORMAT_FIELD:
+                    feedFormat = xcp.text();
+                    break;
+                case HAS_CSV_HEADER_FIELD:
+                    hasCsvHeader = xcp.booleanValue();
+                    break;
+                case CSV_IOC_VALUE_COLUMN_NUM_FIELD:
+                    if (xcp.currentToken() == null)
+                        xcp.skipChildren();
+                    else
+                        csvIocValueColumnNo = xcp.intValue();
+                    break;
                 default:
                     xcp.skipChildren();
             }
         }
-        return new UrlDownloadSource(url);
+        return new UrlDownloadSource(url, feedFormat, hasCsvHeader, csvIocValueColumnNo);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return builder.startObject()
                 .startObject(URL_DOWNLOAD_FIELD)
-                .field(URL_FIELD, url)
+                .field(URL_FIELD, url.toString())
+                .field(FEED_FORMAT_FIELD, feedFormat)
+                .field(HAS_CSV_HEADER_FIELD, hasCsvHeader)
+                .field(CSV_IOC_VALUE_COLUMN_NUM_FIELD, csvIocValueColumnNo)
                 .endObject()
                 .endObject();
+    }
+
+    public String getFeedFormat() {
+        return feedFormat;
+    }
+
+    public boolean hasCsvHeader() {
+        return hasCsvHeader;
+    }
+
+    public Integer getCsvIocValueColumnNo() {
+        return csvIocValueColumnNo;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/UrlDownloadSource.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/UrlDownloadSource.java
@@ -1,0 +1,63 @@
+package org.opensearch.securityanalytics.threatIntel.model;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * This is a Threat Intel Source config where the iocs are downloaded from the URL
+ */
+public class UrlDownloadSource extends Source implements Writeable, ToXContent {
+    public static final String URL_FIELD = "url";
+    public static final String SOURCE_NAME = "URL_DOWNLOAD";
+
+    private final URL url;
+
+    public UrlDownloadSource(URL url) {
+        this.url = url;
+    }
+
+    public UrlDownloadSource(StreamInput sin) throws IOException {
+        this(new URL(sin.readString()));
+    }
+
+    @Override
+    String name() {
+        return SOURCE_NAME;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    public static UrlDownloadSource parse(XContentParser xcp) throws IOException {
+        URL url = null;
+        while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = xcp.currentName();
+            xcp.nextToken();
+            switch (fieldName) {
+                case URL_FIELD:
+                    String urlString = xcp.text();
+                    url = new URL(urlString);
+                    break;
+                default:
+                    xcp.skipChildren();
+            }
+        }
+        return new UrlDownloadSource(url);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject()
+                .startObject(URL_DOWNLOAD_FIELD)
+                .field(URL_FIELD, url)
+                .endObject()
+                .endObject();
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/DefaultTifSourceConfigLoaderService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/DefaultTifSourceConfigLoaderService.java
@@ -46,7 +46,7 @@ public class DefaultTifSourceConfigLoaderService {
     }
 
     /**
-     * check if the default
+     * check if the default tif source configs are loaded. if not, try create them from the feedMetadata.json file.
      */
     public void createDefaultTifConfigsIfNotExists(ActionListener<Void> listener) {
         List<TIFMetadata> tifMetadataList = tifMetadataLoader.getTifMetadataList();
@@ -135,7 +135,8 @@ public class DefaultTifSourceConfigLoaderService {
                                 null,
                                 null,
                                 true,
-                                List.of(iocType)
+                                List.of(iocType),
+                                true
                         ),
                         null,
                         RestRequest.Method.POST,

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/DefaultTifSourceConfigLoaderService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/DefaultTifSourceConfigLoaderService.java
@@ -1,0 +1,179 @@
+package org.opensearch.securityanalytics.threatIntel.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.GroupedActionListener;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.securityanalytics.commons.model.IOCType;
+import org.opensearch.securityanalytics.threatIntel.common.RefreshType;
+import org.opensearch.securityanalytics.threatIntel.common.SourceConfigType;
+import org.opensearch.securityanalytics.threatIntel.common.TIFJobState;
+import org.opensearch.securityanalytics.threatIntel.feedMetadata.BuiltInTIFMetadataLoader;
+import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
+import org.opensearch.securityanalytics.threatIntel.model.TIFMetadata;
+import org.opensearch.securityanalytics.threatIntel.model.UrlDownloadSource;
+
+import java.net.URL;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+//todo handle refresh, update tif config
+// todo block creation of url based config in transport layer
+public class DefaultTifSourceConfigLoaderService {
+    private static final Logger log = LogManager.getLogger(DefaultTifSourceConfigLoaderService.class);
+    private final BuiltInTIFMetadataLoader tifMetadataLoader;
+    private final Client client;
+    private final SATIFSourceConfigManagementService satifSourceConfigManagementService;
+
+    public DefaultTifSourceConfigLoaderService(BuiltInTIFMetadataLoader tifMetadataLoader, Client client, SATIFSourceConfigManagementService satifSourceConfigManagementService) {
+        this.tifMetadataLoader = tifMetadataLoader;
+        this.client = client;
+        this.satifSourceConfigManagementService = satifSourceConfigManagementService;
+    }
+
+    /**
+     * check if the default
+     */
+    public void createDefaultTifConfigsIfNotExists(ActionListener<Void> listener) {
+        List<TIFMetadata> tifMetadataList = tifMetadataLoader.getTifMetadataList();
+        if (tifMetadataList.isEmpty()) {
+            log.error("No built-in TIF Configs found");
+            listener.onResponse(null);
+            return;
+        }
+        BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+        for (TIFMetadata tifMetadata : tifMetadataList) {
+            boolQueryBuilder.should(new MatchQueryBuilder("_id", tifMetadata.getFeedId()));
+        }
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(boolQueryBuilder).size(9999);
+        satifSourceConfigManagementService.searchTIFSourceConfigs(searchSourceBuilder,
+                ActionListener.wrap(searchResponse -> {
+                    createTifConfigsThatDontExist(searchResponse, tifMetadataList, listener);
+                }, e -> {
+                    log.error("Failed to search tif config index for default tif configs", e);
+                    listener.onFailure(e);
+                }));
+    }
+
+    private void createTifConfigsThatDontExist(SearchResponse searchResponse, List<TIFMetadata> tifMetadataList, ActionListener<Void> listener) {
+        Map<String, TIFMetadata> feedsToCreate = tifMetadataList.stream()
+                .collect(Collectors.toMap(
+                        TIFMetadata::getFeedId,
+                        Function.identity()
+                ));
+        if (searchResponse.getHits() != null && searchResponse.getHits().getHits() != null) {
+            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                feedsToCreate.remove(hit.getId());
+            }
+        }
+        if (feedsToCreate.isEmpty()) {
+            listener.onResponse(null);
+            return;
+        }
+        GroupedActionListener<ResponseOrException<SATIFSourceConfigDto>> groupedActionListener = new GroupedActionListener<>(
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(Collection<ResponseOrException<SATIFSourceConfigDto>> responseOrExceptions) {
+                        if (responseOrExceptions.stream().allMatch(it -> it.getException() != null)) { // all configs returned error
+                            Exception e = responseOrExceptions.stream().findFirst().get().getException();
+                            log.error("Failed to create default tif configs", e);
+                            listener.onFailure(e);
+                            return;
+                        }
+                        listener.onResponse(null);
+                        return;
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        log.error("Unexpected failure while creating Default Threat intel source configs", e);
+                        listener.onFailure(e);
+                        return;
+                    }
+                }, feedsToCreate.size()
+        );
+        for (TIFMetadata tifMetadata : feedsToCreate.values()) {
+            if (tifMetadata == null) {
+                continue;
+            }
+            try {
+                Instant now = Instant.now();
+                String iocType = null;
+                if (tifMetadata.getIocType().equalsIgnoreCase("ip")) {
+                    iocType = IOCType.ipv4_addr.toString();
+                }
+                satifSourceConfigManagementService.createOrUpdateTifSourceConfig(
+                        new SATIFSourceConfigDto(
+                                tifMetadata.getFeedId(),
+                                SATIFSourceConfigDto.NO_VERSION,
+                                tifMetadata.getName(),
+                                "STIX2",
+                                SourceConfigType.URL_DOWNLOAD,
+                                tifMetadata.getDescription(),
+                                null,
+                                now,
+                                new UrlDownloadSource(new URL(tifMetadata.getUrl()), tifMetadata.getFeedType(), tifMetadata.hasHeader(), tifMetadata.getIocCol()),
+                                now,
+                                now,
+                                new IntervalSchedule(now, 1, ChronoUnit.DAYS),
+                                TIFJobState.CREATING,
+                                RefreshType.FULL,
+                                null,
+                                null,
+                                true,
+                                List.of(iocType)
+                        ),
+                        null,
+                        RestRequest.Method.POST,
+                        null,
+                        ActionListener.wrap(
+                                r -> {
+                                    groupedActionListener.onResponse(new ResponseOrException<>(r, null));
+                                },
+                                e -> {
+                                    log.error("failed to create default tif source config " + tifMetadata.getFeedId(), e);
+                                    groupedActionListener.onResponse(new ResponseOrException<>(null, e));
+                                })
+                );
+                continue;
+            } catch (Exception ex) {
+                log.error("Unexpected failure while creating Default Threat intel source configs " + tifMetadata.getFeedId(), ex);
+                groupedActionListener.onResponse(new ResponseOrException<>(null, ex));
+                continue;
+            }
+        }
+    }
+
+    private static class ResponseOrException<R> {
+        private final R response;
+        private final Exception exception;
+
+        private ResponseOrException(R response, Exception exception) {
+            this.response = response;
+            this.exception = exception;
+        }
+
+        public R getResponse() {
+            return response;
+        }
+
+        public Exception getException() {
+            return exception;
+        }
+    }
+}
+

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -51,6 +51,7 @@ import java.util.SortedMap;
 
 import java.util.stream.Collectors;
 
+import static org.opensearch.securityanalytics.services.STIX2IOCFeedStore.getIocIndexAlias;
 import static org.opensearch.securityanalytics.threatIntel.common.SourceConfigType.IOC_UPLOAD;
 
 /**
@@ -192,6 +193,9 @@ public class SATIFSourceConfigManagementService {
         switch (saTifSourceConfig.getType()) {
             case S3_CUSTOM:
                 stix2IOCFetchService.downloadAndIndexIOCs(saTifSourceConfig, actionListener);
+                break;
+            case URL_DOWNLOAD:
+                stix2IOCFetchService.downloadFromUrlAndIndexIOCs(saTifSourceConfig, actionListener);
                 break;
             case IOC_UPLOAD:
                 List<STIX2IOC> validStix2IocList = new ArrayList<>();

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -48,10 +48,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-
 import java.util.stream.Collectors;
 
-import static org.opensearch.securityanalytics.services.STIX2IOCFeedStore.getIocIndexAlias;
 import static org.opensearch.securityanalytics.threatIntel.common.SourceConfigType.IOC_UPLOAD;
 
 /**

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -51,6 +51,7 @@ import java.util.SortedMap;
 import java.util.stream.Collectors;
 
 import static org.opensearch.securityanalytics.threatIntel.common.SourceConfigType.IOC_UPLOAD;
+import static org.opensearch.securityanalytics.threatIntel.common.SourceConfigType.URL_DOWNLOAD;
 
 /**
  * Service class for threat intel feed source config object
@@ -511,6 +512,11 @@ public class SATIFSourceConfigManagementService {
     ) {
         saTifSourceConfigService.getTIFSourceConfig(saTifSourceConfigId, ActionListener.wrap(
                 saTifSourceConfig -> {
+                    if (URL_DOWNLOAD.equals(saTifSourceConfig.getType())) {
+                        log.error("Cannot delete tif source config {} as it's a built-in config and not user-defined.", saTifSourceConfigId);
+                        listener.onFailure(new IllegalArgumentException("Cannot delete built-in tif source config " + saTifSourceConfigId));
+                        return;
+                    }
                     // Check if all threat intel monitors are deleted
                     saTifSourceConfigService.checkAndEnsureThreatIntelMonitorsDeleted(ActionListener.wrap(
                             isDeleted -> {
@@ -770,15 +776,42 @@ public class SATIFSourceConfigManagementService {
     }
 
     private SATIFSourceConfig updateSaTifSourceConfig(SATIFSourceConfigDto saTifSourceConfigDto, SATIFSourceConfig saTifSourceConfig) {
+        // currently url download is only for default tif configs and supports only activate/deactivate. Ideally should be via an activate API
+        if (URL_DOWNLOAD.equals(saTifSourceConfig.getType())) {
+            return new SATIFSourceConfig(
+                    saTifSourceConfig.getId(),
+                    saTifSourceConfig.getVersion(),
+                    saTifSourceConfig.getName(),
+                    saTifSourceConfig.getFormat(),
+                    saTifSourceConfig.getType(),
+                    saTifSourceConfig.getDescription(),
+                    saTifSourceConfig.getCreatedByUser(),
+                    saTifSourceConfig.getCreatedAt(),
+                    saTifSourceConfig.getSource(),
+                    saTifSourceConfig.getEnabledTime(),
+                    saTifSourceConfig.getLastUpdateTime(),
+                    saTifSourceConfig.getSchedule(),
+                    saTifSourceConfig.getState(),
+                    saTifSourceConfig.getRefreshType(),
+                    saTifSourceConfig.getLastRefreshedTime(),
+                    saTifSourceConfig.getLastRefreshedUser(),
+                    saTifSourceConfig.isEnabled(),
+                    saTifSourceConfig.getIocStoreConfig(),
+                    saTifSourceConfig.getIocTypes(),
+                    saTifSourceConfigDto.isEnabledForScan()
+            );
+        }
+        if (false == saTifSourceConfig.getSource().getClass().equals(saTifSourceConfigDto.getSource().getClass())) {
+            throw new IllegalArgumentException("");
+        }
         // remove duplicates from iocTypes
         Set<String> iocTypes = new LinkedHashSet<>(saTifSourceConfigDto.getIocTypes());
-
         return new SATIFSourceConfig(
                 saTifSourceConfig.getId(),
                 saTifSourceConfig.getVersion(),
                 saTifSourceConfigDto.getName(),
                 saTifSourceConfigDto.getFormat(),
-                saTifSourceConfigDto.getType(),
+                saTifSourceConfig.getType(),
                 saTifSourceConfigDto.getDescription(),
                 saTifSourceConfig.getCreatedByUser(),
                 saTifSourceConfig.getCreatedAt(),

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/TIFJobUpdateService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/TIFJobUpdateService.java
@@ -187,7 +187,7 @@ public class TIFJobUpdateService {
                                         }
                                         break;
                                     default:
-                                        // if the feed type doesn't match any of the supporting feed types, throw an exception
+                                        onFailure(new UnsupportedOperationException("Not a supported feed format : " + tifMetadata.getFeedType()));
                                 }
                             }
                         } catch (IOException ex) {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/ThreatIntelFeedDataService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/ThreatIntelFeedDataService.java
@@ -229,6 +229,8 @@ public class ThreatIntelFeedDataService {
     }
 
     public static boolean isValidIp(String ip) {
+        if (StringUtils.isBlank(ip))
+            return false;
         String ipPattern = "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$";
         Pattern pattern = Pattern.compile(ipPattern);
         Matcher matcher = pattern.matcher(ip);

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportIndexTIFSourceConfigAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportIndexTIFSourceConfigAction.java
@@ -19,8 +19,10 @@ import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.securityanalytics.threatIntel.action.SAIndexTIFSourceConfigAction;
 import org.opensearch.securityanalytics.threatIntel.action.SAIndexTIFSourceConfigRequest;
 import org.opensearch.securityanalytics.threatIntel.action.SAIndexTIFSourceConfigResponse;
+import org.opensearch.securityanalytics.threatIntel.common.SourceConfigType;
 import org.opensearch.securityanalytics.threatIntel.common.TIFLockService;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
+import org.opensearch.securityanalytics.threatIntel.model.UrlDownloadSource;
 import org.opensearch.securityanalytics.threatIntel.service.SATIFSourceConfigManagementService;
 import org.opensearch.securityanalytics.transport.SecureTransportAction;
 import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
@@ -94,6 +96,9 @@ public class TransportIndexTIFSourceConfigAction extends HandledTransportAction<
                 }
                 try {
                     SATIFSourceConfigDto saTifSourceConfigDto = request.getTIFConfigDto();
+                    if (SourceConfigType.URL_DOWNLOAD.equals(saTifSourceConfigDto.getType()) || saTifSourceConfigDto.getSource() instanceof UrlDownloadSource) {
+                        listener.onFailure(new UnsupportedOperationException("Unsupported Threat intel Source Config Type passed - " + saTifSourceConfigDto.getType()));
+                    }
                     saTifSourceConfigManagementService.createOrUpdateTifSourceConfig(
                             saTifSourceConfigDto,
                             lock,

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportIndexTIFSourceConfigAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportIndexTIFSourceConfigAction.java
@@ -15,6 +15,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.securityanalytics.threatIntel.action.SAIndexTIFSourceConfigAction;
 import org.opensearch.securityanalytics.threatIntel.action.SAIndexTIFSourceConfigRequest;
@@ -96,8 +97,10 @@ public class TransportIndexTIFSourceConfigAction extends HandledTransportAction<
                 }
                 try {
                     SATIFSourceConfigDto saTifSourceConfigDto = request.getTIFConfigDto();
-                    if (SourceConfigType.URL_DOWNLOAD.equals(saTifSourceConfigDto.getType()) || saTifSourceConfigDto.getSource() instanceof UrlDownloadSource) {
+                    if (SourceConfigType.URL_DOWNLOAD.equals(saTifSourceConfigDto.getType()) || saTifSourceConfigDto.getSource() instanceof UrlDownloadSource
+                            && request.getMethod().equals(RestRequest.Method.POST)) {
                         listener.onFailure(new UnsupportedOperationException("Unsupported Threat intel Source Config Type passed - " + saTifSourceConfigDto.getType()));
+                        return;
                     }
                     saTifSourceConfigManagementService.createOrUpdateTifSourceConfig(
                             saTifSourceConfigDto,

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelFeedParser.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelFeedParser.java
@@ -42,8 +42,26 @@ public class ThreatIntelFeedParser {
                 connection.addRequestProperty(Constants.USER_AGENT_KEY, Constants.USER_AGENT_VALUE);
                 return new CSVParser(new BufferedReader(new InputStreamReader(connection.getInputStream())), CSVFormat.RFC4180);
             } catch (IOException e) {
-                log.error("Exception: failed to read threat intel feed data from {}",tifMetadata.getUrl(), e);
+                log.error("Exception: failed to read threat intel feed data from {}", tifMetadata.getUrl(), e);
                 throw new OpenSearchException("failed to read threat intel feed data from {}", tifMetadata.getUrl(), e);
+            }
+        });
+    }
+
+    /**
+     * Create CSVParser of a threat intel feed
+     */
+    @SuppressForbidden(reason = "Need to connect to http endpoint to read threat intel feed database file")
+    public static CSVParser getThreatIntelFeedReaderCSV(URL url) {
+        SpecialPermission.check();
+        return AccessController.doPrivileged((PrivilegedAction<CSVParser>) () -> {
+            try {
+                URLConnection connection = url.openConnection();
+                connection.addRequestProperty(Constants.USER_AGENT_KEY, Constants.USER_AGENT_VALUE);
+                return new CSVParser(new BufferedReader(new InputStreamReader(connection.getInputStream())), CSVFormat.RFC4180);
+            } catch (IOException e) {
+                log.error("Exception: failed to read threat intel feed data from {}", url, e);
+                throw new OpenSearchException("failed to read threat intel feed data from {}", url, e);
             }
         });
     }

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
@@ -113,10 +113,10 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
 
         // Evaluate response
         int totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
-        assertEquals(iocs.size(), totalHits);
+        assertTrue(iocs.size() < totalHits); //due to default feed leading to more iocs
 
         List<Map<String, Object>> iocHits = (List<Map<String, Object>>) respMap.get(ListIOCsActionResponse.HITS_FIELD);
-        assertEquals(iocs.size(), iocHits.size());
+        assertTrue(iocs.size() < iocHits.size());
 //         Retrieve all IOCs by feed Ids
         iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId + ",random"), null);
         Assert.assertEquals(200, iocResponse.getStatusLine().getStatusCode());
@@ -135,10 +135,10 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
 
         // Evaluate response
         totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
-        assertEquals(iocs.size(), totalHits);
+        assertTrue(iocs.size() < totalHits);
 
         iocHits = (List<Map<String, Object>>) respMap.get(ListIOCsActionResponse.HITS_FIELD);
-        assertEquals(iocs.size(), iocHits.size());
+        assertTrue(iocs.size() < iocHits.size());
     }
 
 }


### PR DESCRIPTION
### Description
adds new tif source config type - url download
Downloads Iocs from a url of a given format and makes it available for scans and viewing Iocs
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
