### PR TITLE
Fix the job scheduler parser, action listeners, and multi-node test

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -146,6 +146,7 @@ import org.opensearch.securityanalytics.threatIntel.jobscheduler.TIFJobRunner;
 import org.opensearch.securityanalytics.threatIntel.jobscheduler.TIFSourceConfigRunner;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
 import org.opensearch.securityanalytics.threatIntel.model.monitor.TransportThreatIntelMonitorFanOutAction;
+import org.opensearch.securityanalytics.threatIntel.model.TIFJobParameter;
 import org.opensearch.securityanalytics.threatIntel.resthandler.RestDeleteTIFSourceConfigAction;
 import org.opensearch.securityanalytics.threatIntel.resthandler.RestGetIocFindingsAction;
 import org.opensearch.securityanalytics.threatIntel.resthandler.RestGetTIFSourceConfigAction;
@@ -409,18 +410,20 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
 
     @Override
     public ScheduledJobParser getJobParser() {
-        // TODO: @jowg fix the job parser to parse previous tif job
         return (xcp, id, jobDocVersion) -> {
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp);
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
                 String fieldName = xcp.currentName();
-                xcp.nextToken();
-                switch (fieldName) {
-                    case SOURCE_CONFIG_FIELD:
-                        return SATIFSourceConfig.parse(xcp, id, jobDocVersion.getVersion());
-                    default:
-                        log.error("Job parser failed for [{}] in security analytics job registration", fieldName);
-                        xcp.skipChildren();
+                if (xcp.nextToken() == XContentParser.Token.START_OBJECT) {
+                    switch (fieldName) {
+                        case SOURCE_CONFIG_FIELD:
+                            return SATIFSourceConfig.parse(xcp, id, null);
+                        default:
+                            log.error("Job parser failed for [{}] in security analytics job registration", fieldName);
+                            xcp.skipChildren();
+                    }
+                } else {
+                    return TIFJobParameter.parseFromParser(xcp, id, jobDocVersion.getVersion());
                 }
             }
             return null;

--- a/src/main/java/org/opensearch/securityanalytics/jobscheduler/SecurityAnalyticsRunner.java
+++ b/src/main/java/org/opensearch/securityanalytics/jobscheduler/SecurityAnalyticsRunner.java
@@ -5,7 +5,9 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 import org.opensearch.jobscheduler.spi.ScheduledJobRunner;
+import org.opensearch.securityanalytics.threatIntel.jobscheduler.TIFJobRunner;
 import org.opensearch.securityanalytics.threatIntel.jobscheduler.TIFSourceConfigRunner;
+import org.opensearch.securityanalytics.threatIntel.model.TIFJobParameter;
 import org.opensearch.securityanalytics.threatIntel.sacommons.TIFSourceConfig;
 
 public class SecurityAnalyticsRunner implements ScheduledJobRunner {
@@ -30,6 +32,8 @@ public class SecurityAnalyticsRunner implements ScheduledJobRunner {
     public void runJob(ScheduledJobParameter job, JobExecutionContext context) {
         if (job instanceof TIFSourceConfig) {
             TIFSourceConfigRunner.getJobRunnerInstance().runJob(job, context);
+        } else if (job instanceof TIFJobParameter) {
+            TIFJobRunner.getJobRunnerInstance().runJob(job, context);
         } else {
             String errorMessage = "Invalid job type, found " + job.getClass().getSimpleName() + "with id: " + context.getJobId();
             log.error(errorMessage);

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/BaseEntityCrudService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/BaseEntityCrudService.java
@@ -25,6 +25,7 @@ import org.opensearch.rest.action.admin.indices.AliasesNotFoundException;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.securityanalytics.model.threatintel.BaseEntity;
 import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
+import org.opensearch.transport.RemoteTransportException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -226,7 +227,7 @@ public abstract class BaseEntityCrudService<Entity extends BaseEntity> {
                         log.debug("{} index created", getEntityName());
                         listener.onResponse(null);
                     }, e -> {
-                        if (e instanceof ResourceAlreadyExistsException) {
+                        if (e instanceof ResourceAlreadyExistsException || (e instanceof RemoteTransportException && e.getCause() instanceof ResourceAlreadyExistsException)) {
                             log.debug("index {} already exist", getEntityIndexMapping());
                             listener.onResponse(null);
                             return;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -397,7 +397,6 @@ public class SATIFSourceConfigManagementService {
                                 listener.onFailure(ex);
                             }
                     ));
-                    listener.onFailure(e);
                 })
         );
     }
@@ -498,7 +497,6 @@ public class SATIFSourceConfigManagementService {
                                 listener.onFailure(e);
                             }
                     ));
-                    listener.onFailure(downloadAndSaveIocsError);
                 }));
     }
 


### PR DESCRIPTION
### Description
Fixes the the job scheduler parser to be compatible with detector configured with threat intel, clean up the action listeners, and fixes multi-node test
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
