### PR TITLE
Enum fix

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
@@ -532,7 +532,7 @@ public class SATIFSourceConfigService {
         String stateFieldName = getStateFieldName();
         BoolQueryBuilder stateQueryBuilder = QueryBuilders.boolQuery()
                 .should(QueryBuilders.matchQuery(stateFieldName, AVAILABLE.toString()));
-        stateQueryBuilder.should(QueryBuilders.matchQuery(stateFieldName, REFRESHING));
+        stateQueryBuilder.should(QueryBuilders.matchQuery(stateFieldName, REFRESHING.toString()));
         queryBuilder.must(stateQueryBuilder);
 
         searchRequest.source().query(queryBuilder);


### PR DESCRIPTION
Match query with REFRESHING sttate as value is currently using enum instead of string value of enum