### PR TITLE
update build.gradle to use alerting-spi snapshot version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ buildscript {
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
         }
+
+        alerting_spi_build = opensearch_build
+        alerting_spi_build += "-SNAPSHOT"
         if (isSnapshot) {
             opensearch_build += "-SNAPSHOT"
 
@@ -168,7 +171,7 @@ dependencies {
     compileOnly "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
-    compileOnly "org.opensearch.alerting:alerting-spi:${opensearch_build}"
+    compileOnly "org.opensearch.alerting:alerting-spi:${alerting_spi_build}"
     implementation "org.apache.commons:commons-csv:1.10.0"
     compileOnly "com.google.guava:guava:32.1.3-jre"
 


### PR DESCRIPTION
### Description
update build.gradle to use alerting-spi snapshot version
 
### Issues Resolved
#1193 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
