### PR TITLE
Make threat intel source config release lock event driven

### DIFF
--- a/src/test/java/org/opensearch/securityanalytics/threatIntel/common/ThreatIntelLockServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/threatIntel/common/ThreatIntelLockServiceTests.java
@@ -12,6 +12,7 @@ import static org.opensearch.securityanalytics.threatIntel.common.TIFLockService
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.update.UpdateRequest;
@@ -59,7 +60,9 @@ public class ThreatIntelLockServiceTests extends ThreatIntelTestCase {
                 LOCK_DURATION_IN_SECONDS,
                 false
         );
-        noOpsLockService.releaseLock(lockModel);
+        noOpsLockService.releaseLockEventDriven(lockModel, ActionListener.wrap(
+                Assert::assertFalse, e -> fail()
+        ));
     }
 
     public void testRenewLock_whenCalled_thenNotBlocked() {


### PR DESCRIPTION
### Description
Refactors action listeners so that when releasing the lock for creating/updating/refreshing threat intel source config it's event driven.

### Related Issues
Resolves #1224 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
