### PR TITLE
Fix S3 validation errors not caught by action listener

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
@@ -141,7 +141,14 @@ public class STIX2IOCFetchService {
     }
 
     public void downloadAndIndexIOCs(SATIFSourceConfig saTifSourceConfig, ActionListener<STIX2IOCFetchResponse> listener) {
-        S3ConnectorConfig s3ConnectorConfig = constructS3ConnectorConfig(saTifSourceConfig);
+        S3ConnectorConfig s3ConnectorConfig;
+        try {
+            s3ConnectorConfig = constructS3ConnectorConfig(saTifSourceConfig);
+        } catch (SecurityAnalyticsException e) {
+            listener.onFailure(e);
+            return;
+        }
+
         Connector<STIX2> s3Connector = constructS3Connector(s3ConnectorConfig);
         STIX2IOCFeedStore feedStore = new STIX2IOCFeedStore(client, clusterService, saTifSourceConfig, listener);
         STIX2IOCConsumer consumer = new STIX2IOCConsumer(batchSize, feedStore, UpdateType.REPLACE);


### PR DESCRIPTION
### Description
When constructing and validating the S3 connector config, the errors thrown during validation are not caught by the action listener so subsequent actions to delete the created source config are not happening. This PR adds a try catch to catch these errors and fails the action listener.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
