### PR TITLE
Clean up empty IOC indices created by failed source configs

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
@@ -389,7 +389,7 @@ public class SATIFSourceConfigService {
 
         // check to make sure the job scheduler lock index exists
         if (clusterService.state().metadata().hasIndex(LOCK_INDEX_NAME) == false) {
-            actionListener.onFailure(SecurityAnalyticsException.wrap(new OpenSearchStatusException("Threat intel job scheduler lock index does not exist", RestStatus.BAD_REQUEST)));
+            actionListener.onResponse(null);
             return;
         }
 
@@ -404,7 +404,8 @@ public class SATIFSourceConfigService {
                         log.info("Deleted threat intel job scheduler lock [{}] successfully", id);
                         actionListener.onResponse(deleteResponse);
                     } else if (deleteResponse.status().equals(RestStatus.NOT_FOUND)) {
-                        actionListener.onFailure(SecurityAnalyticsException.wrap(new OpenSearchStatusException(String.format(Locale.getDefault(), "Threat intel job scheduler lock with id [{%s}] not found", id), RestStatus.NOT_FOUND)));
+                        log.info("Threat intel job scheduler lock with id [{}] not found", id);
+                        actionListener.onResponse(deleteResponse);
                     } else {
                         actionListener.onFailure(SecurityAnalyticsException.wrap(new OpenSearchStatusException(String.format(Locale.getDefault(), "Failed to delete threat intel job scheduler lock with id [{%s}]", id), deleteResponse.status())));
                     }

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.opensearch.jobscheduler.spi.utils.LockService.LOCK_INDEX_NAME;
 import static org.opensearch.securityanalytics.SecurityAnalyticsPlugin.JOB_INDEX_NAME;
 import static org.opensearch.securityanalytics.services.STIX2IOCFeedStore.IOC_ALL_INDEX_PATTERN;
 import static org.opensearch.securityanalytics.services.STIX2IOCFeedStore.getAllIocIndexPatternById;
@@ -717,6 +718,10 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
 
         // ensure all iocs are deleted
         hits = executeSearch(IOC_ALL_INDEX_PATTERN, request);
+        Assert.assertEquals(0, hits.size());
+
+        // ensure that lock is deleted
+        hits = executeSearch(LOCK_INDEX_NAME,request);
         Assert.assertEquals(0, hits.size());
     }
 


### PR DESCRIPTION
### Description
Deletes and cleans up any ioc indices that were created by failed source configs. Also manually deletes the job scheduler lock for source configs that have the job disabled. When a source config job is enabled and then the source config is deleted, the lock is automatically deleted. However, the lock is not cleaned up if the job is disabled. This PR adds a change to check whether or not the job is enabled, if not then it will manually delete the associated lock when source config is deleted.

### Related Issues
Resolves https://github.com/opensearch-project/security-analytics/issues/1255
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
