### PR TITLE
Add null check while adding fetched iocs into per-indicator-type map

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/IoCScanService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/IoCScanService.java
@@ -133,23 +133,25 @@ public abstract class IoCScanService<Data extends Object> implements IoCScanServ
                 ) {
                     // if concrete index resolves to multiple monitor input indices, it's undesirable. We just pick any one of the monitor input indices to get fields for each ioc.
                     String index = context.getConcreteIndexToMonitorInputIndicesMap().get(concreteIndex).get(0);
-                    List<String> fields = iocTypeToIndexFieldMapping.getIndexToFieldsMap().get(index);
-                    for (String field : fields) {
-                        List<String> vals = getValuesAsStringList(datum, field);
-                        String id = getId(datum);
-                        String docId = id + ":" + index;
-                        Set<String> iocs = docIdToIocsMap.getOrDefault(docId, new HashSet<>());
-                        iocs.addAll(vals);
-                        docIdToIocsMap.put(docId, iocs);
-                        for (String ioc : vals) {
-                            Set<String> docIds = iocValueToDocIdMap.getOrDefault(ioc, new HashSet<>());
-                            docIds.add(docId);
-                            iocValueToDocIdMap.put(ioc, docIds);
-                        }
-                        if (false == vals.isEmpty()) {
-                            iocs = iocsPerIocTypeMap.getOrDefault(iocType, new HashSet<>());
+                    List<String> fieldsConfiguredInMonitorForCurrentIndex = iocTypeToIndexFieldMapping.getIndexToFieldsMap().get(index);
+                    if(fieldsConfiguredInMonitorForCurrentIndex != null && false == fieldsConfiguredInMonitorForCurrentIndex.isEmpty()) {
+                        for (String field : fieldsConfiguredInMonitorForCurrentIndex) {
+                            List<String> vals = getValuesAsStringList(datum, field);
+                            String id = getId(datum);
+                            String docId = id + ":" + index;
+                            Set<String> iocs = docIdToIocsMap.getOrDefault(docId, new HashSet<>());
                             iocs.addAll(vals);
-                            iocsPerIocTypeMap.put(iocType, iocs);
+                            docIdToIocsMap.put(docId, iocs);
+                            for (String ioc : vals) {
+                                Set<String> docIds = iocValueToDocIdMap.getOrDefault(ioc, new HashSet<>());
+                                docIds.add(docId);
+                                iocValueToDocIdMap.put(ioc, docIds);
+                            }
+                            if (false == vals.isEmpty()) {
+                                iocs = iocsPerIocTypeMap.getOrDefault(iocType, new HashSet<>());
+                                iocs.addAll(vals);
+                                iocsPerIocTypeMap.put(iocType, iocs);
+                            }
                         }
                     }
                 }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/IoCScanService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/IoCScanService.java
@@ -128,9 +128,7 @@ public abstract class IoCScanService<Data extends Object> implements IoCScanServ
             for (PerIocTypeScanInput iocTypeToIndexFieldMapping : context.getThreatIntelInput().getPerIocTypeScanInputList()) {
                 String iocType = iocTypeToIndexFieldMapping.getIocType().toLowerCase();
                 String concreteIndex = getIndexName(datum);
-                if (context.getConcreteIndexToMonitorInputIndicesMap().containsKey(concreteIndex)
-                        && false == context.getConcreteIndexToMonitorInputIndicesMap().get(concreteIndex).isEmpty()
-                ) {
+                if (context.getConcreteIndexToMonitorInputIndicesMap().containsKey(concreteIndex)) {
                     // if concrete index resolves to multiple monitor input indices, it's undesirable. We just pick any one of the monitor input indices to get fields for each ioc.
                     String index = context.getConcreteIndexToMonitorInputIndicesMap().get(concreteIndex).get(0);
                     List<String> fieldsConfiguredInMonitorForCurrentIndex = iocTypeToIndexFieldMapping.getIndexToFieldsMap().get(index);

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
@@ -48,7 +48,6 @@ import static org.opensearch.securityanalytics.TestHelpers.randomDetectorType;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithTriggers;
 import static org.opensearch.securityanalytics.TestHelpers.randomIndex;
 import static org.opensearch.securityanalytics.TestHelpers.windowsIndexMapping;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.ALERT_HISTORY_MAX_DOCS;
 import static org.opensearch.securityanalytics.threatIntel.resthandler.monitor.RestSearchThreatIntelMonitorAction.SEARCH_THREAT_INTEL_MONITOR_PATH;
 
 public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
@@ -65,6 +64,71 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                     "random",
                     new IOCType(IOCType.IPV4_TYPE),
                     iocVals.get(i1),
+                    "",
+                    Instant.now(),
+                    Instant.now(),
+                    "",
+                    emptyList(),
+                    "spec",
+                    "configId",
+                    "",
+                    1L
+            );
+
+            testIocDtos.add(stix2IOCDto);
+        }
+        return indexTifSourceConfig(testIocDtos);
+    }
+
+    public String indexSourceConfigsAndIocs(List<String> ipVals, List<String> hashVals, List<String> domainVals) throws IOException {
+        testIocDtos = new ArrayList<>();
+        for (int i1 = 0; i1 < ipVals.size(); i1++) {
+            // create IOCs
+            STIX2IOCDto stix2IOCDto = new STIX2IOCDto(
+                    "id" + randomAlphaOfLength(3),
+                    "random",
+                    new IOCType(IOCType.IPV4_TYPE),
+                    ipVals.get(i1),
+                    "",
+                    Instant.now(),
+                    Instant.now(),
+                    "",
+                    emptyList(),
+                    "spec",
+                    "configId",
+                    "",
+                    1L
+            );
+
+            testIocDtos.add(stix2IOCDto);
+        }
+        for (int i1 = 0; i1 < hashVals.size(); i1++) {
+            // create IOCs
+            STIX2IOCDto stix2IOCDto = new STIX2IOCDto(
+                    "id" + randomAlphaOfLength(3),
+                    "random",
+                    new IOCType(IOCType.HASHES_TYPE),
+                    hashVals.get(i1),
+                    "",
+                    Instant.now(),
+                    Instant.now(),
+                    "",
+                    emptyList(),
+                    "spec",
+                    "configId",
+                    "",
+                    1L
+            );
+
+            testIocDtos.add(stix2IOCDto);
+        }
+        for (int i1 = 0; i1 < domainVals.size(); i1++) {
+            // create IOCs
+            STIX2IOCDto stix2IOCDto = new STIX2IOCDto(
+                    "id" + randomAlphaOfLength(3),
+                    "random",
+                    new IOCType(IOCType.DOMAIN_NAME_TYPE),
+                    domainVals.get(i1),
                     "",
                     Instant.now(),
                     Instant.now(),
@@ -100,7 +164,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 null,
                 false,
-                List.of(IOCType.IPV4_TYPE),
+                List.of(IOCType.IPV4_TYPE, IOCType.HASHES_TYPE, IOCType.DOMAIN_NAME_TYPE),
                 true
         );
 
@@ -249,6 +313,96 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         totalHits = (HashMap<String, Object>) hits.get("total");
         totalHitsVal = (Integer) totalHits.get("value");
         assertEquals(totalHitsVal.intValue(), 0);
+    }
+
+
+
+    public void testCreateThreatIntelMonitor_configureMultipleIndicatorTypesInMonitor() throws IOException {
+        updateClusterSetting(SecurityAnalyticsSettings.IOC_SCAN_MAX_TERMS_COUNT.getKey(), "1");
+        Response iocFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.THREAT_INTEL_BASE_URI + "/findings/_search",
+                Map.of(), null);
+        Map<String, Object> responseAsMap = responseAsMap(iocFindingsResponse);
+        Assert.assertEquals(0, ((List<Map<String, Object>>) responseAsMap.get("ioc_findings")).size());
+        List<String> ipVals = List.of("ip1", "ip2");
+        List<String> hashVals = List.of("h1", "h2");
+        List<String> domainVals = List.of("d1", "d2");
+        String createdId = indexSourceConfigsAndIocs(ipVals, hashVals, domainVals);
+
+        String ipIndex = "ipAlias";
+        createTestAlias(ipIndex, 1, true);
+        String hashIndex = "hashAlias";
+        createTestAlias(hashIndex, 1, true);
+        String domainIndex = "domainAlias";
+        createTestAlias(domainIndex, 1, true);
+
+
+        /**create monitor */
+        ThreatIntelMonitorDto iocScanMonitor = randomIocScanMonitorDtoWithMultipleIndicatorTypesToScan(ipIndex, hashIndex, domainIndex);
+        Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_MONITOR_URI, Collections.emptyMap(), toHttpEntity(iocScanMonitor));
+        Assert.assertEquals(201, response.getStatusLine().getStatusCode());
+        Map<String, Object> responseBody = asMap(response);
+
+        try {
+            makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_MONITOR_URI, Collections.emptyMap(), toHttpEntity(iocScanMonitor));
+            fail();
+        } catch (Exception e) {
+            /** creating a second threat intel monitor should fail*/
+            assertTrue(e.getMessage().contains("already exists"));
+        }
+
+        final String monitorId = responseBody.get("id").toString();
+        Assert.assertNotEquals("response is missing Id", Monitor.NO_ID, monitorId);
+        Response executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+        Assert.assertEquals(200, executeResponse.getStatusLine().getStatusCode());
+
+        Response alertingMonitorResponse = getAlertingMonitor(client(), monitorId);
+        Assert.assertEquals(200, alertingMonitorResponse.getStatusLine().getStatusCode());
+        int i = 1;
+        for (String val : ipVals) {
+            String doc = String.format("{\"ip\":\"%s\", \"ip1\":\"%s\"}", val, val);
+            try {
+                indexDoc(ipIndex, "" + i++, doc);
+            } catch (IOException e) {
+                fail();
+            }
+        }
+        for (String val : hashVals) {
+            String doc = String.format("{\"hash\":\"%s\", \"ip1\":\"%s\"}", val, val);
+            try {
+                indexDoc(hashIndex, "" + i++, doc);
+            } catch (IOException e) {
+                fail();
+            }
+        }
+        for (String val : domainVals) {
+            String doc = String.format("{\"domain\":\"%s\", \"ip1\":\"%s\"}", val, val);
+            try {
+                indexDoc(domainIndex, "" + i++, doc);
+            } catch (IOException e) {
+                fail();
+            }
+        }
+
+        executeResponse = executeAlertingMonitor(monitorId, Collections.emptyMap());
+        Map<String, Object> executeResults = entityAsMap(executeResponse);
+
+        String matchAllRequest = getMatchAllRequest();
+        Response searchMonitorResponse = makeRequest(client(), "POST", SEARCH_THREAT_INTEL_MONITOR_PATH, Collections.emptyMap(), new StringEntity(matchAllRequest, ContentType.APPLICATION_JSON, false));
+        Assert.assertEquals(200, alertingMonitorResponse.getStatusLine().getStatusCode());
+        HashMap<String, Object> hits = (HashMap<String, Object>) asMap(searchMonitorResponse).get("hits");
+        HashMap<String, Object> totalHits = (HashMap<String, Object>) hits.get("total");
+        Integer totalHitsVal = (Integer) totalHits.get("value");
+        assertEquals(totalHitsVal.intValue(), 1);
+        makeRequest(client(), "POST", SEARCH_THREAT_INTEL_MONITOR_PATH, Collections.emptyMap(), new StringEntity(matchAllRequest, ContentType.APPLICATION_JSON, false));
+
+        iocFindingsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.THREAT_INTEL_BASE_URI + "/findings/_search",
+                Map.of(), null);
+        responseAsMap = responseAsMap(iocFindingsResponse);
+        Assert.assertEquals(6, ((List<Map<String, Object>>) responseAsMap.get("ioc_findings")).size());
+
+        //alerts
+        List<SearchHit> searchHits = executeSearch(ThreatIntelAlertService.THREAT_INTEL_ALERT_ALIAS_NAME, matchAllRequest);
+        Assert.assertEquals(6, searchHits.size());
     }
 
     public void testCreateThreatIntelMonitor() throws IOException {
@@ -566,6 +720,26 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                 Monitor.NO_ID,
                 randomAlphaOfLength(10),
                 List.of(new PerIocTypeScanInputDto(IOCType.IPV4_TYPE, Map.of(index, List.of("ip")))),
+                new IntervalSchedule(1, ChronoUnit.MINUTES, Instant.now()),
+                false,
+                null,
+                List.of(t1, t2, t3, t4));
+    }
+
+    public static ThreatIntelMonitorDto randomIocScanMonitorDtoWithMultipleIndicatorTypesToScan(String ipIndex, String hashIndex, String domainIndex) {
+        ThreatIntelTriggerDto t1 = new ThreatIntelTriggerDto(List.of(ipIndex, "randomIndex"), List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE), emptyList(), "match", null, "severity");
+        ThreatIntelTriggerDto t2 = new ThreatIntelTriggerDto(List.of("randomIndex"), List.of(IOCType.DOMAIN_NAME_TYPE), emptyList(), "nomatch", null, "severity");
+        ThreatIntelTriggerDto t3 = new ThreatIntelTriggerDto(emptyList(), List.of(IOCType.DOMAIN_NAME_TYPE), emptyList(), "domainmatchsonomatch", null, "severity");
+        ThreatIntelTriggerDto t4 = new ThreatIntelTriggerDto(List.of(ipIndex), emptyList(), emptyList(), "indexmatch", null, "severity");
+
+        return new ThreatIntelMonitorDto(
+                Monitor.NO_ID,
+                randomAlphaOfLength(10),
+                List.of(
+                        new PerIocTypeScanInputDto(IOCType.IPV4_TYPE, Map.of(ipIndex, List.of("ip"))),
+                        new PerIocTypeScanInputDto(IOCType.HASHES_TYPE, Map.of(hashIndex, List.of("hash"))),
+                        new PerIocTypeScanInputDto(IOCType.DOMAIN_NAME_TYPE, Map.of(domainIndex, List.of("domain")))
+                ),
                 new IntervalSchedule(1, ChronoUnit.MINUTES, Instant.now()),
                 false,
                 null,


### PR DESCRIPTION
### Description
**This change adds null check while adding fetched iocs into per-indicator-type map to fix below issue**
Currently we are seeing a NullPointerException when there are multiple types of indicators configured in threat intel monitor.
```
[2024-10-02T13:58:22,195][ERROR][o.o.s.t.i.s.IoCScanService] [integTest-0] Threat intel monitor HOYGT5IBl5xy9GfJFbXV: Unexpected failure in running scan for 2 docs
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "fields" is null
        at org.opensearch.securityanalytics.threatIntel.iocscan.service.IoCScanService.extractIocsPerType(IoCScanService.java:137) ~[opensearch-security-analytics-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
        at org.opensearch.securityanalytics.threatIntel.iocscan.service.IoCScanService.scanIoCs(IoCScanService.java:42) [opensearch-security-analytics-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
        at org.opensearch.securityanalytics.threatIntel.model.monitor.TransportThreatIntelMonitorFanOutAction.lambda$onGetIocTypeToIndices$7(TransportThreatIntelMonitorFanOutAction.java:200) [opensearch-security-analytics-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$1.onResponse(ActionListener.java:82) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.securityanalytics.threatIntel.model.monitor.TransportThreatIntelMonitorFanOutAction.lambda$fetchDataFromShards$9(TransportThreatIntelMonitorFanOutAction.java:238) [opensearch-security-analytics-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$1.onResponse(ActionListener.java:82) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.support.GroupedActionListener.onResponse(GroupedActionListener.java:81) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.securityanalytics.threatIntel.model.monitor.TransportThreatIntelMonitorFanOutAction.fetchLatestDocsFromShard(TransportThreatIntelMonitorFanOutAction.java:275) [opensearch-security-analytics-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
        at org.opensearch.securityanalytics.threatIntel.model.monitor.TransportThreatIntelMonitorFanOutAction.lambda$fetchLatestDocsFromShard$11(TransportThreatIntelMonitorFanOutAction.java:305) [opensearch-security-analytics-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$1.onResponse(ActionListener.java:82) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.securityanalytics.threatIntel.model.monitor.TransportThreatIntelMonitorFanOutAction.lambda$searchShard$15(TransportThreatIntelMonitorFanOutAction.java:371) [opensearch-security-analytics-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$1.onResponse(ActionListener.java:82) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:113) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:107) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$5.onResponse(ActionListener.java:268) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction.sendSearchResponse(AbstractSearchAsyncAction.java:710) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.search.ExpandSearchPhase.run(ExpandSearchPhase.java:132) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.search.SearchPhase.recordAndRun(SearchPhase.java:61) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction.executePhase(AbstractSearchAsyncAction.java:454) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction.executeNextPhase(AbstractSearchAsyncAction.java:430) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.search.FetchSearchPhase.moveToNextPhase(FetchSearchPhase.java:298) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.search.FetchSearchPhase.lambda$innerRun$1(FetchSearchPhase.java:138) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.search.FetchSearchPhase.innerRun(FetchSearchPhase.java:150) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.search.FetchSearchPhase$1.doRun(FetchSearchPhase.java:122) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.threadpool.TaskAwareRunnable.doRun(TaskAwareRunnable.java:78) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:59) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:913) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) [?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) [?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]

```


