### PR TITLE
update number of replicas of system indices to 1-20 and number of primary shards for system indices to 1

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/indexmanagment/DetectorIndexManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/indexmanagment/DetectorIndexManagementService.java
@@ -558,8 +558,17 @@ public class DetectorIndexManagementService extends AbstractLifecycleComponent i
         request.getCreateIndexRequest().index(pattern)
                 .mapping(map)
                 .settings(isCorrelation?
-                        Settings.builder().put("index.hidden", true).put("index.correlation", true).build():
-                        Settings.builder().put("index.hidden", true).build()
+                        Settings.builder()
+                                .put("index.hidden", true)
+                                .put("index.correlation", true)
+                                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                                .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                                .build():
+                        Settings.builder()
+                                .put("index.hidden", true)
+                                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                                .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                                .build()
                 );
         request.addMaxIndexDocsCondition(docsCondition);
         request.addMaxIndexAgeCondition(ageCondition);

--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -61,8 +61,9 @@ import org.opensearch.securityanalytics.model.LogType;
 import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
 
 import static org.opensearch.securityanalytics.model.FieldMappingDoc.LOG_TYPES;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.*;
-
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.DEFAULT_MAPPING_SCHEMA;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
 
 /**
  *

--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -60,9 +60,8 @@ import org.opensearch.securityanalytics.model.FieldMappingDoc;
 import org.opensearch.securityanalytics.model.LogType;
 import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
 
-import static org.opensearch.action.support.ActiveShardCount.ALL;
 import static org.opensearch.securityanalytics.model.FieldMappingDoc.LOG_TYPES;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.DEFAULT_MAPPING_SCHEMA;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.*;
 
 
 /**
@@ -456,7 +455,8 @@ public class LogTypeService {
             isConfigIndexInitialized = false;
             Settings indexSettings = Settings.builder()
                     .put("index.hidden", true)
-                    .put("index.auto_expand_replicas", "0-all")
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
                     .build();
 
             CreateIndexRequest createIndexRequest = new CreateIndexRequest();

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -10,10 +10,10 @@ import org.opensearch.common.unit.TimeValue;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.opensearch.index.IndexSettings.MAX_TERMS_COUNT_SETTING;
-
 public class SecurityAnalyticsSettings {
     public static final String CORRELATION_INDEX = "index.correlation";
+    public static final int minSystemIndexReplicas = 1;
+    public static final int maxSystemIndexReplicas = 20;
 
     public static Setting<TimeValue> INDEX_TIMEOUT = Setting.positiveTimeSetting("plugins.security_analytics.index_timeout",
             TimeValue.timeValueSeconds(60),

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/BaseEntityCrudService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/BaseEntityCrudService.java
@@ -14,6 +14,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -31,6 +32,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
 import static org.opensearch.securityanalytics.util.DetectorUtils.getEmptySearchResponse;
 
 /**
@@ -247,7 +250,9 @@ public abstract class BaseEntityCrudService<Entity extends BaseEntity> {
     public abstract String getEntityName();
 
     protected Settings.Builder getIndexSettings() {
-        return Settings.builder().put("index.hidden", true);
+        return Settings.builder().put("index.hidden", true)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas);
     }
 
     public abstract String getEntityAliasName();

--- a/src/main/java/org/opensearch/securityanalytics/util/CustomLogTypeIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/CustomLogTypeIndices.java
@@ -21,6 +21,8 @@ import org.opensearch.securityanalytics.logtype.LogTypeService;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Objects;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
 
 public class CustomLogTypeIndices {
 
@@ -42,9 +44,11 @@ public class CustomLogTypeIndices {
 
     public void initCustomLogTypeIndex(ActionListener<CreateIndexResponse> actionListener) throws IOException {
         if (!customLogTypeIndexExists()) {
+            // Security Analytics log types index is small. 1 primary shard is enough
             Settings indexSettings = Settings.builder()
                     .put("index.hidden", true)
-                    .put("index.auto_expand_replicas", "0-all")
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
                     .build();
             CreateIndexRequest indexRequest = new CreateIndexRequest(LogTypeService.LOG_TYPE_INDEX)
                     .mapping(customLogTypeMappings())

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorIndices.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Objects;
 
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
+
 public class DetectorIndices {
 
     private static final Logger log = LogManager.getLogger(DetectorIndices.class);
@@ -45,9 +48,14 @@ public class DetectorIndices {
 
     public void initDetectorIndex(ActionListener<CreateIndexResponse> actionListener) throws IOException {
         if (!detectorIndexExists()) {
+            Settings indexSettings = Settings.builder()
+                    .put("index.hidden", true)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                    .build();
             CreateIndexRequest indexRequest = new CreateIndexRequest(Detector.DETECTORS_INDEX)
                     .mapping(detectorMappings())
-                    .settings(Settings.builder().put("index.hidden", true).build());
+                    .settings(indexSettings);
             client.indices().create(indexRequest, actionListener);
         }
     }

--- a/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
@@ -58,6 +58,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.opensearch.securityanalytics.model.Detector.NO_VERSION;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
+import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
 
 public class RuleIndices {
 
@@ -86,6 +88,8 @@ public class RuleIndices {
         if (!ruleIndexExists(isPrepackaged)) {
             Settings indexSettings = Settings.builder()
                     .put("index.hidden", true)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
                     .build();
             CreateIndexRequest indexRequest = new CreateIndexRequest(getRuleIndex(isPrepackaged))
                     .mapping(ruleMappings())


### PR DESCRIPTION
### Description
update number of replicas of system indices to 0-20 and number of primary shards for system indices to 1

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
