### PR TITLE
set the refresh policy to IMMEDIATE when updating correlation alerts

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/correlation/alert/CorrelationAlertService.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/alert/CorrelationAlertService.java
@@ -13,6 +13,7 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Client;
 import org.opensearch.common.lucene.uid.Versions;
@@ -212,9 +213,10 @@ public class CorrelationAlertService {
         client.search(searchRequest, new ActionListener<SearchResponse>() {
             @Override
             public void onResponse(SearchResponse searchResponse) {
+                // Set the refresh policy on the BulkRequest
+                bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                 // Iterate through the search hits
                 for (SearchHit hit : searchResponse.getHits().getHits()) {
-                    // Construct a script to update the document with the new state and acknowledgedTime
                     // Construct a script to update the document with the new state and acknowledgedTime
                     Script script = new Script(ScriptType.INLINE, "painless",
                             "ctx._source.state = params.state; ctx._source.acknowledged_time = params.time",


### PR DESCRIPTION
### Description
* set the refresh policy to IMMEDIATE when acknowledging correlation alerts

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
