### PR TITLE
[Bug] Add exists check for IOCs index.

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchException;
+import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -35,6 +36,7 @@ import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.securityanalytics.threatIntel.common.StashedThreadContext;
 import org.opensearch.securityanalytics.threatIntel.model.DefaultIocStoreConfig;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
+import org.opensearch.transport.RemoteTransportException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -250,6 +252,11 @@ public class STIX2IOCFeedStore implements FeedStore {
                         listener.onResponse(r);
                     },
                     e -> {
+                        if (e instanceof ResourceAlreadyExistsException || (e instanceof RemoteTransportException && e.getCause() instanceof ResourceAlreadyExistsException)) {
+                            log.debug("index {} already exist", iocIndexMapping());
+                            listener.onResponse(null);
+                            return;
+                        }
                         log.error("Failed to create system index {}", feedIndexName);
                         listener.onFailure(e);
                     }

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
@@ -253,7 +253,7 @@ public class STIX2IOCFeedStore implements FeedStore {
                     },
                     e -> {
                         if (e instanceof ResourceAlreadyExistsException || (e instanceof RemoteTransportException && e.getCause() instanceof ResourceAlreadyExistsException)) {
-                            log.debug("index {} already exist", iocIndexMapping());
+                            log.debug("index {} already exist", feedIndexName);
                             listener.onResponse(null);
                             return;
                         }


### PR DESCRIPTION
### Description
Added check to prevent resource_already_exists_exception when indexing more than 10k iocs.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
