### PR TITLE
Add validation for threat intel source config

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
@@ -24,7 +24,19 @@ public class SourceConfigDtoValidator {
     public List<String> validateSourceConfigDto(SATIFSourceConfigDto sourceConfigDto) {
         List<String> errorMsgs = new ArrayList<>();
 
-        if (sourceConfigDto.getIocTypes().isEmpty()) {
+        if (sourceConfigDto.getName() == null || sourceConfigDto.getName().isEmpty()) {
+            errorMsgs.add("Name must not be empty");
+        }
+
+        if (sourceConfigDto.getFormat() == null || sourceConfigDto.getFormat().isEmpty()) {
+            errorMsgs.add("Format must not be empty");
+        }
+
+        if (sourceConfigDto.getSource() == null) {
+            errorMsgs.add("Source must not be empty");
+        }
+
+        if (sourceConfigDto.getIocTypes() == null || sourceConfigDto.getIocTypes().isEmpty()) {
             errorMsgs.add("Must specify at least one IOC type");
         } else {
             for (String s: sourceConfigDto.getIocTypes()) {
@@ -34,34 +46,41 @@ public class SourceConfigDtoValidator {
             }
         }
 
-        switch (sourceConfigDto.getType()) {
-            case IOC_UPLOAD:
-                if (sourceConfigDto.isEnabled()) {
-                    errorMsgs.add("Job Scheduler cannot be enabled for IOC_UPLOAD type");
-                }
-                if (sourceConfigDto.getSchedule() != null) {
-                    errorMsgs.add("Cannot pass in schedule for IOC_UPLOAD type");
-                }
-                if (sourceConfigDto.getSource() != null && sourceConfigDto.getSource() instanceof IocUploadSource == false) {
-                    errorMsgs.add("Source must be IOC_UPLOAD type");
-                }
-                break;
-            case S3_CUSTOM:
-                if (sourceConfigDto.getSchedule() == null) {
-                    errorMsgs.add("Must pass in schedule for S3_CUSTOM type");
-                }
-                if (sourceConfigDto.getSource() != null && sourceConfigDto.getSource() instanceof S3Source == false) {
-                    errorMsgs.add("Source must be S3_CUSTOM type");
-                }
-                break;
-            case URL_DOWNLOAD:
-                if (sourceConfigDto.getSchedule() == null) {
-                    errorMsgs.add("Must pass in schedule for URL_DOWNLOAD source type");
-                }
-                if (sourceConfigDto.getSource() != null && sourceConfigDto.getSource() instanceof UrlDownloadSource == false) {
-                    errorMsgs.add("Source must be URL_DOWNLOAD source type");
-                }
-                break;
+        if (sourceConfigDto.getType() == null) {
+            errorMsgs.add("Type must not be empty");
+        } else {
+            switch (sourceConfigDto.getType()) {
+                case IOC_UPLOAD:
+                    if (sourceConfigDto.isEnabled()) {
+                        errorMsgs.add("Job Scheduler cannot be enabled for IOC_UPLOAD type");
+                    }
+                    if (sourceConfigDto.getSchedule() != null) {
+                        errorMsgs.add("Cannot pass in schedule for IOC_UPLOAD type");
+                    }
+                    if (sourceConfigDto.getSource() != null && sourceConfigDto.getSource() instanceof IocUploadSource == false) {
+                        errorMsgs.add("Source must be IOC_UPLOAD type");
+                    }
+                    if (sourceConfigDto.getSource() instanceof IocUploadSource && ((IocUploadSource) sourceConfigDto.getSource()).getIocs() == null) {
+                        errorMsgs.add("Ioc list must include at least one ioc");
+                    }
+                    break;
+                case S3_CUSTOM:
+                    if (sourceConfigDto.getSchedule() == null) {
+                        errorMsgs.add("Must pass in schedule for S3_CUSTOM type");
+                    }
+                    if (sourceConfigDto.getSource() != null && sourceConfigDto.getSource() instanceof S3Source == false) {
+                        errorMsgs.add("Source must be S3_CUSTOM type");
+                    }
+                    break;
+                case URL_DOWNLOAD:
+                    if (sourceConfigDto.getSchedule() == null) {
+                        errorMsgs.add("Must pass in schedule for URL_DOWNLOAD source type");
+                    }
+                    if (sourceConfigDto.getSource() != null && sourceConfigDto.getSource() instanceof UrlDownloadSource == false) {
+                        errorMsgs.add("Source must be URL_DOWNLOAD source type");
+                    }
+                    break;
+            }
         }
         return errorMsgs;
     }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.securityanalytics.threatIntel.common;
 
-import org.opensearch.securityanalytics.commons.model.IOC;
 import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.threatIntel.model.IocUploadSource;
 import org.opensearch.securityanalytics.threatIntel.model.S3Source;
@@ -13,9 +12,8 @@ import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
 import org.opensearch.securityanalytics.threatIntel.model.UrlDownloadSource;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.regex.Pattern;
 
 /**
  * Source config dto validator
@@ -24,12 +22,27 @@ public class SourceConfigDtoValidator {
     public List<String> validateSourceConfigDto(SATIFSourceConfigDto sourceConfigDto) {
         List<String> errorMsgs = new ArrayList<>();
 
+        String nameRegex = "^[a-zA-Z0-9 _-]{1,128}$";
+        Pattern namePattern = Pattern.compile(nameRegex);
+
+        int MAX_RULE_DESCRIPTION_LENGTH = 65535;
+        String descriptionRegex = "^.{0," + MAX_RULE_DESCRIPTION_LENGTH + "}$";
+        Pattern descriptionPattern = Pattern.compile(descriptionRegex);
+
         if (sourceConfigDto.getName() == null || sourceConfigDto.getName().isEmpty()) {
             errorMsgs.add("Name must not be empty");
+        } else if (sourceConfigDto.getName() != null && namePattern.matcher(sourceConfigDto.getName()).matches() == false) {
+            errorMsgs.add("Name must be less than 128 characters and only consist of upper and lowercase letters, numbers 0-9, hyphens, spaces, and underscores");
         }
 
         if (sourceConfigDto.getFormat() == null || sourceConfigDto.getFormat().isEmpty()) {
             errorMsgs.add("Format must not be empty");
+        } else if (sourceConfigDto.getFormat() != null && sourceConfigDto.getFormat().length() > 50) {
+            errorMsgs.add("Format must be 50 characters or less");
+        }
+
+        if (sourceConfigDto.getDescription() != null && descriptionPattern.matcher(sourceConfigDto.getDescription()).matches() == false) {
+            errorMsgs.add("Description must be " + MAX_RULE_DESCRIPTION_LENGTH + " characters or less");
         }
 
         if (sourceConfigDto.getSource() == null) {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/SATIFSourceConfig.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/SATIFSourceConfig.java
@@ -92,7 +92,7 @@ public class SATIFSourceConfig implements TIFSourceConfig, Writeable, ScheduledJ
 
     public SATIFSourceConfig(String id, Long version, String name, String format, SourceConfigType type, String description, User createdByUser, Instant createdAt, Source source,
                              Instant enabledTime, Instant lastUpdateTime, Schedule schedule, TIFJobState state, RefreshType refreshType, Instant lastRefreshedTime, User lastRefreshedUser,
-                             Boolean isEnabled, IocStoreConfig iocStoreConfig, List<String> iocTypes, boolean enabledForScan) {
+                             boolean isEnabled, IocStoreConfig iocStoreConfig, List<String> iocTypes, boolean enabledForScan) {
         this.id = id == null ? UUIDs.base64UUID() : id;
         this.version = version != null ? version : NO_VERSION;
         this.name = name;
@@ -289,7 +289,7 @@ public class SATIFSourceConfig implements TIFSourceConfig, Writeable, ScheduledJ
         RefreshType refreshType = null;
         Instant lastRefreshedTime = null;
         User lastRefreshedUser = null;
-        Boolean isEnabled = null;
+        boolean isEnabled = true;
         boolean enabledForScan = true;
         IocStoreConfig iocStoreConfig = null;
         List<String> iocTypes = new ArrayList<>();
@@ -303,16 +303,28 @@ public class SATIFSourceConfig implements TIFSourceConfig, Writeable, ScheduledJ
                 case SOURCE_CONFIG_FIELD:
                     break;
                 case NAME_FIELD:
-                    name = xcp.text();
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        name = null;
+                    } else {
+                        name = xcp.text();
+                    }
                     break;
                 case VERSION_FIELD:
                     version = xcp.longValue();
                     break;
                 case FORMAT_FIELD:
-                    format = xcp.text();
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        format = null;
+                    } else {
+                        format = xcp.text();
+                    }
                     break;
                 case TYPE_FIELD:
-                    sourceConfigType = toSourceConfigType(xcp.text());
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        sourceConfigType = null;
+                    } else {
+                        sourceConfigType = toSourceConfigType(xcp.text());
+                    }
                     break;
                 case DESCRIPTION_FIELD:
                     if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/SATIFSourceConfigDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/SATIFSourceConfigDto.java
@@ -123,7 +123,7 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
 
     public SATIFSourceConfigDto(String id, Long version, String name, String format, SourceConfigType type, String description, User createdByUser, Instant createdAt, Source source,
                                 Instant enabledTime, Instant lastUpdateTime, Schedule schedule, TIFJobState state, RefreshType refreshType, Instant lastRefreshedTime, User lastRefreshedUser,
-                                Boolean isEnabled, List<String> iocTypes, boolean enabledForScan) {
+                                boolean isEnabled, List<String> iocTypes, boolean enabledForScan) {
         this.id = id == null ? UUIDs.base64UUID() : id;
         this.version = version != null ? version : NO_VERSION;
         this.name = name;
@@ -314,7 +314,7 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
         RefreshType refreshType = null;
         Instant lastRefreshedTime = null;
         User lastRefreshedUser = null;
-        Boolean isEnabled = null;
+        boolean isEnabled = true;
         List<String> iocTypes = new ArrayList<>();
         boolean enabledForScan = true;
 
@@ -326,13 +326,25 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
                 case SOURCE_CONFIG_FIELD:
                     break;
                 case NAME_FIELD:
-                    name = xcp.text();
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        name = null;
+                    } else {
+                        name = xcp.text();
+                    }
                     break;
                 case FORMAT_FIELD:
-                    format = xcp.text();
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        format = null;
+                    } else {
+                        format = xcp.text();
+                    }
                     break;
                 case TYPE_FIELD:
-                    sourceConfigType = toSourceConfigType(xcp.text());
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        sourceConfigType = null;
+                    } else {
+                        sourceConfigType = toSourceConfigType(xcp.text());
+                    }
                     break;
                 case DESCRIPTION_FIELD:
                     if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
@@ -426,7 +438,6 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
                 case ENABLED_FIELD:
                     isEnabled = xcp.booleanValue();
                     break;
-
                 case ENABLED_FOR_SCAN_FIELD:
                     enabledForScan = xcp.booleanValue();
                     break;

--- a/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigRequestTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigRequestTests.java
@@ -5,6 +5,7 @@
 package org.opensearch.securityanalytics.action;
 
 import org.junit.Assert;
+import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.rest.RestRequest;
@@ -32,5 +33,41 @@ public class IndexTIFSourceConfigRequestTests extends OpenSearchTestCase {
         Assert.assertEquals(id, request.getTIFConfigId());
         Assert.assertEquals(RestRequest.Method.POST, newRequest.getMethod());
         Assert.assertNotNull(newRequest.getTIFConfigDto());
+    }
+
+    public void testValidateSourceConfigPostRequest() {
+        // Source config with invalid: name, format, source, ioc type, source config type
+        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                null,
+                true
+        );
+        String id = saTifSourceConfigDto.getId();
+        SAIndexTIFSourceConfigRequest request = new SAIndexTIFSourceConfigRequest(id, RestRequest.Method.POST, saTifSourceConfigDto);
+        Assert.assertNotNull(request);
+
+        ActionRequestValidationException exception = request.validate();
+        assertEquals(5, exception.validationErrors().size());
+        assertTrue(exception.validationErrors().contains("Name must not be empty"));
+        assertTrue(exception.validationErrors().contains("Format must not be empty"));
+        assertTrue(exception.validationErrors().contains("Source must not be empty"));
+        assertTrue(exception.validationErrors().contains("Must specify at least one IOC type"));
+        assertTrue(exception.validationErrors().contains("Type must not be empty"));
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigDtoTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigDtoTests.java
@@ -10,11 +10,15 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+import org.opensearch.securityanalytics.threatIntel.common.SourceConfigType;
 import org.opensearch.securityanalytics.threatIntel.model.S3Source;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 import static org.opensearch.securityanalytics.TestHelpers.randomSATIFSourceConfigDto;
 
@@ -31,6 +35,34 @@ public class SATIFSourceConfigDtoTests extends OpenSearchTestCase {
 
     public void testParseFunction() throws IOException {
         SATIFSourceConfigDto saTifSourceConfigDto = randomSATIFSourceConfigDto();
+        String json = toJsonString(saTifSourceConfigDto);
+        SATIFSourceConfigDto newSaTifSourceConfigDto = SATIFSourceConfigDto.parse(getParser(json), saTifSourceConfigDto.getId(), null);
+        assertEqualsSaTifSourceConfigDtos(saTifSourceConfigDto, newSaTifSourceConfigDto);
+    }
+
+    public void testParseFunctionWithNullValues() throws IOException {
+        // Source config with invalid name and format
+        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+                "randomId",
+                null,
+                null,
+                null,
+                SourceConfigType.S3_CUSTOM,
+                null,
+                null,
+                null,
+                new S3Source("bucket", "objectkey", "region", "rolearn"),
+                null,
+                null,
+                new org.opensearch.jobscheduler.spi.schedule.IntervalSchedule(Instant.now(), 1, ChronoUnit.DAYS),
+                null,
+                null,
+                null,
+                null,
+                true,
+                List.of("ip"),
+                true
+        );
         String json = toJsonString(saTifSourceConfigDto);
         SATIFSourceConfigDto newSaTifSourceConfigDto = SATIFSourceConfigDto.parse(getParser(json), saTifSourceConfigDto.getId(), null);
         assertEqualsSaTifSourceConfigDtos(saTifSourceConfigDto, newSaTifSourceConfigDto);

--- a/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigTests.java
@@ -10,12 +10,17 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+import org.opensearch.securityanalytics.commons.model.IOCType;
+import org.opensearch.securityanalytics.threatIntel.common.SourceConfigType;
 import org.opensearch.securityanalytics.threatIntel.model.DefaultIocStoreConfig;
 import org.opensearch.securityanalytics.threatIntel.model.S3Source;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 import static org.opensearch.securityanalytics.TestHelpers.randomSATIFSourceConfig;
 
@@ -32,6 +37,35 @@ public class SATIFSourceConfigTests extends OpenSearchTestCase {
 
     public void testParseFunction() throws IOException {
         SATIFSourceConfig saTifSourceConfig = randomSATIFSourceConfig();
+        String json = toJsonString(saTifSourceConfig);
+        SATIFSourceConfig newSaTifSourceConfig = SATIFSourceConfig.parse(getParser(json), saTifSourceConfig.getId(), null);
+        assertEqualsSaTifSourceConfigs(saTifSourceConfig, newSaTifSourceConfig);
+    }
+
+    public void testParseFunctionWithNullValues() throws IOException {
+        // Source config with invalid name and format
+        SATIFSourceConfig saTifSourceConfig = new SATIFSourceConfig(
+                null,
+                null,
+                null,
+                null,
+                SourceConfigType.S3_CUSTOM,
+                null,
+                null,
+                null,
+                new S3Source("bucket", "objectkey", "region", "rolearn"),
+                null,
+                null,
+                new org.opensearch.jobscheduler.spi.schedule.IntervalSchedule(Instant.now(), 1, ChronoUnit.DAYS),
+                null,
+                null,
+                null,
+                null,
+                true,
+                new DefaultIocStoreConfig(List.of(new DefaultIocStoreConfig.IocToIndexDetails(new IOCType(IOCType.DOMAIN_NAME_TYPE), "indexPattern", "writeIndex"))),
+                List.of("ip"),
+                true
+        );
         String json = toJsonString(saTifSourceConfig);
         SATIFSourceConfig newSaTifSourceConfig = SATIFSourceConfig.parse(getParser(json), saTifSourceConfig.getId(), null);
         assertEqualsSaTifSourceConfigs(saTifSourceConfig, newSaTifSourceConfig);


### PR DESCRIPTION
### Description
Add source config validation so source config cannot be created without valid `name`, `type`, `format`, `source`, and `ioc type`. Additionally allows source configs with null values to still be read and deleted.

### Related Issues
Resolves #1366

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
