### PR TITLE
Adding various OCSF 1.1 fields to log type static mappings

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -563,6 +563,9 @@ public class LogTypeService {
                         if (mapping.getOcsf() != null) {
                             schemaFields.put("ocsf", mapping.getOcsf());
                         }
+                        if (mapping.getOcsf11() != null) {
+                            schemaFields.put("ocsf11", mapping.getOcsf11());
+                        }
                         fieldMappingMap.put(
                                 key,
                                 new FieldMappingDoc(
@@ -574,6 +577,7 @@ public class LogTypeService {
                     } else {
                         // merge with existing doc
                         existingDoc.getSchemaFields().put("ocsf", mapping.getOcsf());
+                        existingDoc.getSchemaFields().put("ocsf11", mapping.getOcsf11());
                         existingDoc.getLogTypes().add(logType.getName());
                     }
                 }));
@@ -702,7 +706,7 @@ public class LogTypeService {
                         (delegatedListener, fieldMappingDocs) -> {
                             List<LogType.Mapping> ruleFieldMappings = new ArrayList<>();
                             fieldMappingDocs.forEach( e -> {
-                                ruleFieldMappings.add(new LogType.Mapping(e.getRawField(), e.getSchemaFields().get("ecs"), e.getSchemaFields().get("ocsf")));
+                                ruleFieldMappings.add(new LogType.Mapping(e.getRawField(), e.getSchemaFields().get("ecs"), e.getSchemaFields().get("ocsf"), e.getSchemaFields().get("ocsf11")));
                             });
                             delegatedListener.onResponse(ruleFieldMappings);
                         }
@@ -725,7 +729,8 @@ public class LogTypeService {
                                 LogType.Mapping requiredField = new LogType.Mapping(
                                         e.getRawField(),
                                         e.getSchemaFields().get(defaultSchemaField),
-                                        e.getSchemaFields().get("ocsf")
+                                        e.getSchemaFields().get("ocsf"),
+                                        e.getSchemaFields().get("ocsf11")
                                 );
                                 requiredFields.add(requiredField);
                             });

--- a/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
@@ -234,6 +234,8 @@ public class MapperService {
                                     aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getRawField()));
                                 } else if (indexFields.contains(mapping.getOcsf())) {
                                     aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf()));
+                                } else if (indexFields.contains(mapping.getOcsf11())) {
+                                    aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf11()));
                                 }
                             }
                             aliasMappingsObj.field("properties", aliasMappingFields);
@@ -483,6 +485,7 @@ public class MapperService {
                             String alias = requiredField.getEcs();
                             String rawPath = requiredField.getRawField();
                             String ocsfPath = requiredField.getOcsf();
+                            String ocsf11Path = requiredField.getOcsf11();
                             if (allFieldsFromIndex.contains(rawPath)) {
                                 // if the alias was already added into applyable aliases, then skip to avoid duplicates
                                 if (!applyableAliases.contains(alias) && !applyableAliases.contains(rawPath)) {
@@ -497,6 +500,9 @@ public class MapperService {
                             } else if (allFieldsFromIndex.contains(ocsfPath)) {
                                 applyableAliases.add(alias);
                                 pathsOfApplyableAliases.add(ocsfPath);
+                            } else if (allFieldsFromIndex.contains(ocsf11Path)) {
+                                applyableAliases.add(alias);
+                                pathsOfApplyableAliases.add(ocsf11Path);
                             } else if ((alias == null && allFieldsFromIndex.contains(rawPath) == false) || allFieldsFromIndex.contains(alias) == false) {
                                 if (alias != null) {
                                     // we don't want to send back aliases which have same name as existing field in index
@@ -520,6 +526,8 @@ public class MapperService {
                         for (LogType.Mapping mapping : requiredFields) {
                             if (allFieldsFromIndex.contains(mapping.getOcsf())) {
                                 aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf()));
+                            } else if (allFieldsFromIndex.contains(mapping.getOcsf11())) {
+                                aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf11()));
                             } else if (mapping.getEcs() != null) {
                                 shouldUpdateEcsMappingAndMaybeUpdates(mapping, aliasMappingFields, pathsOfApplyableAliases);
                             } else if (mapping.getEcs() == null) {

--- a/src/main/java/org/opensearch/securityanalytics/model/LogType.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/LogType.java
@@ -27,6 +27,7 @@ public class LogType implements Writeable {
     private static final String RAW_FIELD = "raw_field";
     public static final String ECS = "ecs";
     public static final String OCSF = "ocsf";
+    public static final String OCSF11 = "ocsf11";
     public static final String IOC_FIELDS = "ioc_fields";
     public static final String IOC = "ioc";
     public static final String FIELDS = "fields";
@@ -67,7 +68,7 @@ public class LogType implements Writeable {
         if (mappings.size() > 0) {
             this.mappings = new ArrayList<>(mappings.size());
             this.mappings = mappings.stream().map(e ->
-                    new Mapping(e.get(RAW_FIELD), e.get(ECS), e.get(OCSF))
+                    new Mapping(e.get(RAW_FIELD), e.get(ECS), e.get(OCSF), e.get(OCSF11))
             ).collect(Collectors.toList());
         }
         if (logTypeAsMap.containsKey(IOC_FIELDS)) {
@@ -120,17 +121,20 @@ public class LogType implements Writeable {
         private String rawField;
         private String ecs;
         private String ocsf;
+        private String ocsf11;
 
         public Mapping(StreamInput sin) throws IOException {
             this.rawField = sin.readString();
             this.ecs = sin.readOptionalString();
             this.ocsf = sin.readOptionalString();
+            this.ocsf11 = sin.readOptionalString();
         }
 
-        public Mapping(String rawField, String ecs, String ocsf) {
+        public Mapping(String rawField, String ecs, String ocsf, String ocsf11) {
             this.rawField = rawField;
             this.ecs = ecs;
             this.ocsf = ocsf;
+            this.ocsf11 = ocsf11;
         }
 
         public String getRawField() {
@@ -145,11 +149,14 @@ public class LogType implements Writeable {
             return ocsf;
         }
 
+        public String getOcsf11() { return ocsf11; }
+
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(rawField);
             out.writeOptionalString(ecs);
             out.writeOptionalString(ocsf);
+            out.writeOptionalString(ocsf11);
         }
 
         public static Mapping readFrom(StreamInput sin) throws IOException {

--- a/src/main/resources/OSMapping/cloudtrail_logtype.json
+++ b/src/main/resources/OSMapping/cloudtrail_logtype.json
@@ -34,6 +34,7 @@
     {
       "raw_field":"eventType",
       "ecs":"aws.cloudtrail.event_type",
+      "ocsf" : "unmapped.eventType",
       "ocsf11": "metadata.event_code"
     },
     {
@@ -125,12 +126,14 @@
     {
       "raw_field":"requestParameters.userName",
       "ecs":"aws.cloudtrail.request_parameters.username",
-      "ocsf": "user.name"
+      "ocsf": "unmapped.requestParameters.userName",
+      "ocsf11": "user.name"
     },
     {
       "raw_field":"requestParameters.roleArn",
       "ecs":"aws.cloudtrail.request_parameters.roleArn",
-      "ocsf": "user.uid"
+      "ocsf": "user.uuid",
+      "ocsf11": "user.uid"
     },
     {
       "raw_field":"requestParameters.roleSessionName",
@@ -150,12 +153,14 @@
     {
       "raw_field":"userIdentity.principalId",
       "ecs":"aws.cloudtrail.user_identity.principalId",
+      "ocsf": "actor.user.uid",
       "ocsf11":"actor.user.uid_alt"
     },
     {
       "raw_field":"userIdentity.arn",
       "ecs":"aws.cloudtrail.user_identity.arn",
-      "ocsf": "actor.user.uid"
+      "ocsf": "actor.user.uuid",
+      "ocsf11": "actor.user.uid"
     },
     {
       "raw_field":"userIdentity.accountId",

--- a/src/main/resources/OSMapping/cloudtrail_logtype.json
+++ b/src/main/resources/OSMapping/cloudtrail_logtype.json
@@ -34,7 +34,7 @@
     {
       "raw_field":"eventType",
       "ecs":"aws.cloudtrail.event_type",
-      "ocsf": "unmapped.eventType"
+      "ocsf11": "metadata.event_code"
     },
     {
       "raw_field":"eventCategory",
@@ -69,7 +69,8 @@
     {
       "raw_field":"additionalEventData.MFAUsed",
       "ecs":"aws.cloudtrail.additional_event_data.mfaUsed",
-      "ocsf": "mfa"
+      "ocsf": "mfa",
+      "ocsf11": "is_mfa"
     },
     {
       "raw_field":"responseElements",
@@ -124,12 +125,12 @@
     {
       "raw_field":"requestParameters.userName",
       "ecs":"aws.cloudtrail.request_parameters.username",
-      "ocsf": "unmapped.requestParameters.userName"
+      "ocsf": "user.name"
     },
     {
       "raw_field":"requestParameters.roleArn",
       "ecs":"aws.cloudtrail.request_parameters.roleArn",
-      "ocsf": "user.uuid"
+      "ocsf": "user.uid"
     },
     {
       "raw_field":"requestParameters.roleSessionName",
@@ -149,17 +150,18 @@
     {
       "raw_field":"userIdentity.principalId",
       "ecs":"aws.cloudtrail.user_identity.principalId",
-      "ocsf": "actor.user.uid"
+      "ocsf11":"actor.user.uid_alt"
     },
     {
       "raw_field":"userIdentity.arn",
       "ecs":"aws.cloudtrail.user_identity.arn",
-      "ocsf": "actor.user.uuid"
+      "ocsf": "actor.user.uid"
     },
     {
       "raw_field":"userIdentity.accountId",
       "ecs":"aws.cloudtrail.user_identity.accountId",
-      "ocsf": "actor.user.account_uid"
+      "ocsf": "actor.user.account_uid",
+      "ocsf11": "actor.user.account.uid"
     },
     {
       "raw_field":"userIdentity.accessKeyId",
@@ -199,7 +201,8 @@
     {
       "raw_field":"userIdentity.sessionContext.attributes.mfaAuthenticated",
       "ecs":"aws.cloudtrail.user_identity.session_context.attributes.mfaAuthenticated",
-      "ocsf": "actor.session.mfa"
+      "ocsf": "actor.session.mfa",
+      "ocsf11": "actor.session.is_mfa"
     },
     {
       "raw_field":"userIdentity.webIdFederationData.federatedProvider",

--- a/src/main/resources/OSMapping/dns_logtype.json
+++ b/src/main/resources/OSMapping/dns_logtype.json
@@ -54,7 +54,8 @@
     {
       "raw_field":"account_id",
       "ecs":"aws.route53.account_id",
-      "ocsf": "cloud.account_uid"
+      "ocsf": "cloud.account_uid",
+      "ocsf11": "cloud.account.uid"
     },
     {
       "raw_field":"region",
@@ -114,12 +115,22 @@
     {
       "raw_field":"firewall_rule_action",
       "ecs":"aws.route53.srcids.firewall_rule_action",
-      "ocsf": "disposition_id"
+      "ocsf": "disposition"
     },
     {
       "raw_field":"creationTime",
       "ecs":"timestamp",
       "ocsf": "unmapped.creationTime"
+    },
+    {
+      "raw_field":"rcode",
+      "ecs":"aws.route53.rcode",
+      "ocsf":"rcode"
+    },
+    {
+      "raw_field":"firewall_rule_group_id",
+      "ecs":"aws.route53.srcids.firewall_rule_group_id",
+      "ocsf":"firewall_rule.uid"
     }
   ]
 }

--- a/src/main/resources/OSMapping/dns_logtype.json
+++ b/src/main/resources/OSMapping/dns_logtype.json
@@ -115,7 +115,8 @@
     {
       "raw_field":"firewall_rule_action",
       "ecs":"aws.route53.srcids.firewall_rule_action",
-      "ocsf": "disposition"
+      "ocsf": "disposition_id",
+      "ocsf11": "disposition"
     },
     {
       "raw_field":"creationTime",

--- a/src/main/resources/OSMapping/network_logtype.json
+++ b/src/main/resources/OSMapping/network_logtype.json
@@ -14,131 +14,168 @@
   "mappings":[
     {
       "raw_field":"action",
-      "ecs":"netflow.firewall_event"
+      "ecs":"netflow.firewall_event",
+      "ocsf": "unmapped.action"
     },
     {
       "raw_field":"certificate.serial",
-      "ecs":"zeek.x509.certificate.serial"
+      "ecs":"zeek.x509.certificate.serial",
+      "ocsf": "unmapped.certificate.serial"
     },
     {
       "raw_field":"name",
-      "ecs":"zeek.smb_files.name"
+      "ecs":"zeek.smb_files.name",
+      "ocsf": "unmapped.name"
     },
     {
       "raw_field":"path",
-      "ecs":"zeek.smb_files.path"
+      "ecs":"zeek.smb_files.path",
+      "ocsf": "unmapped.path"
     },
     {
       "raw_field":"dst_port",
-      "ecs":"destination.port"
+      "ecs":"destination.port",
+      "ocsf": "unmapped.dst_port"
     },
     {
       "raw_field":"qtype_name",
-      "ecs":"zeek.dns.qtype_name"
+      "ecs":"zeek.dns.qtype_name",
+      "ocsf": "query.type"
     },
     {
       "raw_field":"operation",
-      "ecs":"zeek.dce_rpc.operation"
+      "ecs":"zeek.dce_rpc.operation",
+      "ocsf": "unmapped.operation"
     },
     {
       "raw_field":"endpoint",
-      "ecs":"zeek.dce_rpc.endpoint"
+      "ecs":"zeek.dce_rpc.endpoint",
+      "ocsf": "unmapped.endpoint"
     },
     {
       "raw_field":"zeek.dce_rpc.endpoint",
-      "ecs":"zeek.dce_rpc.endpoint"
+      "ecs":"zeek.dce_rpc.endpoint",
+      "ocsf": "unmapped.zeek.dce_rpc.endpoint"
     },
     {
       "raw_field":"answers",
-      "ecs":"zeek.dns.answers"
+      "ecs":"zeek.dns.answers",
+      "ocsf": "answers.rdata"
     },
     {
       "raw_field":"query",
-      "ecs":"zeek.dns.query"
+      "ecs":"zeek.dns.query",
+      "ocsf": "query.hostname"
     },
     {
       "raw_field":"client_header_names",
-      "ecs":"zeek.http.client_header_names"
+      "ecs":"zeek.http.client_header_names",
+      "ocsf": "unmapped.client_header_names"
     },
     {
       "raw_field":"resp_mime_types",
-      "ecs":"zeek.http.resp_mime_types"
+      "ecs":"zeek.http.resp_mime_types",
+      "ocsf": "unmapped.resp_mime_types"
     },
     {
       "raw_field":"cipher",
-      "ecs":"zeek.kerberos.cipher"
+      "ecs":"zeek.kerberos.cipher",
+      "ocsf": "cipher"
     },
     {
       "raw_field":"request_type",
-      "ecs":"zeek.kerberos.request_type"
+      "ecs":"zeek.kerberos.request_type",
+      "ocsf": "unmapped.request_type"
     },
     {
       "raw_field":"creationTime",
-      "ecs":"timestamp"
+      "ecs":"timestamp",
+      "ocsf": "unmapped.creationTime"
     },
     {
       "raw_field":"method",
-      "ecs":"http.request.method"
+      "ecs":"http.request.method",
+      "ocsf": "unmapped.method"
     },
     {
       "raw_field":"id.resp_p",
-      "ecs":"id.resp_p"
+      "ecs":"id.resp_p",
+      "ocsf": "dst_endpoint.port"
     },
     {
       "raw_field":"blocked",
-      "ecs":"blocked-flag"
+      "ecs":"blocked-flag",
+      "ocsf": "unmapped.blocked"
+    },
+    {
+      "raw_field": "id.orig_p",
+      "ecs": "id.orig_p",
+      "ocsf": "src_endpoint.port"
     },
     {
       "raw_field":"id.orig_h",
-      "ecs":"id.orig_h"
+      "ecs":"id.orig_h",
+      "ocsf": "src_endpoint.ip"
     },
     {
       "raw_field":"Z",
-      "ecs":"Z-flag"
+      "ecs":"Z-flag",
+      "ocsf": "answers.flag_ids.99"
     },
     {
       "raw_field":"id.resp_h",
-      "ecs":"id.resp_h"
+      "ecs":"id.resp_h",
+      "ocsf": "dst_endpoint.ip"
     },
     {
       "raw_field":"uri",
-      "ecs":"url.path"
+      "ecs":"url.path",
+      "ocsf": "unmapped.uri"
     },
     {
       "raw_field":"c-uri",
-      "ecs":"url.path"
+      "ecs":"url.path",
+      "ocsf": "unmapped.c-uri"
     },
     {
       "raw_field":"c-useragent",
-      "ecs":"user_agent.name"
+      "ecs":"user_agent.name",
+      "ocsf": "unmapped.c-useragent"
     },
     {
       "raw_field":"status_code",
-      "ecs":"http.response.status_code"
+      "ecs":"http.response.status_code",
+      "ocsf": "unmapped.status_code"
     },
     {
       "raw_field":"rejected",
-      "ecs":"rejected"
+      "ecs":"rejected",
+      "ocsf": "unmapped.rejected"
     },
     {
       "raw_field":"dst_ip",
-      "ecs":"destination.ip"
+      "ecs":"destination.ip",
+      "ocsf": "unmapped.dst_ip"
     },
     {
       "raw_field":"src_ip",
-      "ecs":"source.ip"
+      "ecs":"source.ip",
+      "ocsf": "unmapped.src_ip"
     },
     {
       "raw_field":"user_agent",
-      "ecs":"user_agent.name"
+      "ecs":"user_agent.name",
+      "ocsf": "unmapped.user_agent"
     },
     {
       "raw_field":"request_body_len",
-      "ecs":"http.request.body.bytes"
+      "ecs":"http.request.body.bytes",
+      "ocsf": "unmapped.request_body_len"
     },
     {
       "raw_field":"service",
-      "ecs":"service"
+      "ecs":"service",
+      "ocsf": "unmapped.service"
     }
   ]
 }

--- a/src/main/resources/OSMapping/vpcflow_logtype.json
+++ b/src/main/resources/OSMapping/vpcflow_logtype.json
@@ -20,7 +20,8 @@
     {
       "raw_field":"account_id",
       "ecs":"netflow.account_id",
-      "ocsf": "cloud.account_uid"
+      "ocsf": "cloud.account_uid",
+      "ocsf11":  "cloud.account.uid"
     },
     {
       "raw_field":"region",
@@ -90,12 +91,12 @@
     {
       "raw_field":"action",
       "ecs":"netflow.action",
-      "ocsf": "disposition_id"
+      "ocsf": "disposition"
     },
     {
       "raw_field":"traffic_path",
       "ecs":"netflow.traffic_path",
-      "ocsf": "boundary_id"
+      "ocsf": "connection_info.boundary_id"
     },
     {
       "raw_field":"flow_direction",

--- a/src/main/resources/OSMapping/vpcflow_logtype.json
+++ b/src/main/resources/OSMapping/vpcflow_logtype.json
@@ -91,12 +91,14 @@
     {
       "raw_field":"action",
       "ecs":"netflow.action",
-      "ocsf": "disposition"
+      "ocsf": "disposition_id",
+      "ocsf11": "disposition"
     },
     {
       "raw_field":"traffic_path",
       "ecs":"netflow.traffic_path",
-      "ocsf": "connection_info.boundary_id"
+      "ocsf": "boundary_id",
+      "ocsf11": "connection_info.boundary_id"
     },
     {
       "raw_field":"flow_direction",

--- a/src/main/resources/OSMapping/waf_logtype.json
+++ b/src/main/resources/OSMapping/waf_logtype.json
@@ -55,12 +55,12 @@
       "ocsf": "unmapped.timestamp"
     },
     {
-      "raw_field":"httpRequest.headers[].value",
+      "raw_field":"httpRequest.headers.value",
       "ecs":"waf.request.headers.value",
       "ocsf": "http_request.http_headers[].value"
     },
     {
-      "raw_field":"httpRequest.headers[].name",
+      "raw_field":"httpRequest.headers.name",
       "ecs":"waf.request.headers.name",
       "ocsf": "http_request.http_headers[].name"
     }

--- a/src/main/resources/OSMapping/waf_logtype.json
+++ b/src/main/resources/OSMapping/waf_logtype.json
@@ -6,51 +6,63 @@
   "mappings":[
     {
       "raw_field":"cs-method",
-      "ecs":"waf.request.method"
+      "ecs":"waf.request.method",
+      "ocsf": "unmapped.cs-method"
     },
     {
       "raw_field":"httpRequest.httpMethod",
-      "ecs":"waf.request.method"
+      "ecs":"waf.request.method",
+      "ocsf": "http_request.http_method"
     },
     {
       "raw_field":"cs-uri-query",
-      "ecs":"waf.request.uri_query"
+      "ecs":"waf.request.uri_query",
+      "ocsf": "unmapped.cs-uri-query"
     },
     {
       "raw_field":"httpRequest.uri",
-      "ecs":"waf.request.uri_query"
+      "ecs":"waf.request.uri_query",
+      "ocsf": "http_request.url.path"
     },
     {
       "raw_field":"httpRequest.args",
-      "ecs":"waf.request.uri_query"
+      "ecs":"waf.request.uri_query",
+      "ocsf": "http_request.args"
     },
     {
       "raw_field":"cs-user-agent",
-      "ecs":"waf.request.headers.user_agent"
+      "ecs":"waf.request.headers.user_agent",
+      "ocsf": "unmapped.cs-user-agent"
     },
     {
       "raw_field":"httpRequest.headers",
-      "ecs":"waf.request.headers"
+      "ecs":"waf.request.headers",
+      "ocsf": "unmapped.httpRequest.headers"
     },
     {
       "raw_field":"sc-status",
-      "ecs":"waf.response.code"
+      "ecs":"waf.response.code",
+      "ocsf": "unmapped.sc-status"
     },
     {
       "raw_field":"responseCodeSent",
-      "ecs":"waf.response.code"
+      "ecs":"waf.response.code",
+      "ocsf": "status_code"
     },
     {
       "raw_field":"timestamp",
-      "ecs":"timestamp"
+      "ecs":"timestamp",
+      "ocsf": "unmapped.timestamp"
     },
     {
-      "raw_field":"httpRequest.headers.value",
-      "ecs":"waf.request.headers.value"
+      "raw_field":"httpRequest.headers[].value",
+      "ecs":"waf.request.headers.value",
+      "ocsf": "http_request.http_headers[].value"
     },
     {
-      "raw_field":"httpRequest.headers.name",
-      "ecs":"waf.request.headers.name"
+      "raw_field":"httpRequest.headers[].name",
+      "ecs":"waf.request.headers.name",
+      "ocsf": "http_request.http_headers[].name"
     }
   ]
 }

--- a/src/main/resources/OSMapping/windows_logtype.json
+++ b/src/main/resources/OSMapping/windows_logtype.json
@@ -15,7 +15,8 @@
     },
     {
       "raw_field":"AuthenticationPackageName",
-      "ecs":"winlog.event_data.AuthenticationPackageName"
+      "ecs":"winlog.event_data.AuthenticationPackageName",
+      "ocsf": "auth_protocol"
     },
     {
       "raw_field":"Channel",
@@ -27,7 +28,8 @@
     },
     {
       "raw_field":"ComputerName",
-      "ecs":"winlog.computer_name"
+      "ecs":"winlog.computer_name",
+      "ocsf": "device.name"
     },
     {
       "raw_field":"Description",
@@ -71,11 +73,13 @@
     },
     {
       "raw_field":"LogonProcessName",
-      "ecs":"winlog.event_data.LogonProcessName"
+      "ecs":"winlog.event_data.LogonProcessName",
+      "ocsf": "logon_process.name"
     },
     {
       "raw_field":"LogonType",
-      "ecs":"winlog.event_data.LogonType"
+      "ecs":"winlog.event_data.LogonType",
+      "ocsf": "logon_type_id"
     },
     {
       "raw_field":"OriginalFilename",
@@ -91,7 +95,8 @@
     },
     {
       "raw_field":"ProcessId",
-      "ecs":"winlog.event_data.ProcessId"
+      "ecs":"winlog.event_data.ProcessId",
+      "ocsf": "actor.process.pid"
     },
     {
       "raw_field":"Product",
@@ -127,11 +132,13 @@
     },
     {
       "raw_field":"Status",
-      "ecs":"winlog.event_data.Status"
+      "ecs":"winlog.event_data.Status",
+      "ocsf": "status"
     },
     {
       "raw_field":"SubjectDomainName",
-      "ecs":"winlog.event_data.SubjectDomainName"
+      "ecs":"winlog.event_data.SubjectDomainName",
+      "ocsf": "actor.user.domain"
     },
     {
       "raw_field":"SubjectLogonId",
@@ -139,11 +146,13 @@
     },
     {
       "raw_field":"SubjectUserName",
-      "ecs":"winlog.event_data.SubjectUserName"
+      "ecs":"winlog.event_data.SubjectUserName",
+      "ocsf": "actor.user.name"
     },
     {
       "raw_field":"SubjectUserSid",
-      "ecs":"winlog.event_data.SubjectUserSid"
+      "ecs":"winlog.event_data.SubjectUserSid",
+      "ocsf": "actor.user.uid"
     },
     {
       "raw_field":"TargetLogonId",
@@ -159,11 +168,13 @@
     },
     {
       "raw_field":"TargetUserName",
-      "ecs":"winlog.event_data.TargetUserName"
+      "ecs":"winlog.event_data.TargetUserName",
+      "ocsf": "process.user.domain"
     },
     {
       "raw_field":"TargetUserSid",
-      "ecs":"winlog.event_data.TargetUserSid"
+      "ecs":"winlog.event_data.TargetUserSid",
+      "ocsf": "process.user.uid"
     },
     {
       "raw_field":"TaskName",
@@ -183,11 +194,13 @@
     },
     {
       "raw_field":"Workstation",
-      "ecs":"winlog.event_data.Workstation"
+      "ecs":"winlog.event_data.Workstation",
+      "ocsf": "src_endpoint.name"
     },
     {
       "raw_field":"WorkstationName",
-      "ecs":"winlog.event_data.Workstation"
+      "ecs":"winlog.event_data.Workstation",
+      "ocsf": "src_endpoint.name"
     },
     {
       "raw_field":"event_uid",
@@ -219,7 +232,8 @@
     },
     {
       "raw_field":"ProcessName",
-      "ecs":"winlog.event_data.ProcessName"
+      "ecs":"winlog.event_data.ProcessName",
+      "ocsf": "actor.process.file"
     },
     {
       "raw_field":"ObjectName",
@@ -615,7 +629,8 @@
     },
     {
       "raw_field":"Message",
-      "ecs":"winlog.event_data.Message"
+      "ecs":"winlog.event_data.Message",
+      "ocsf": "message"
     },
     {
       "raw_field":"ShareName",
@@ -623,11 +638,13 @@
     },
     {
       "raw_field":"SourcePort",
-      "ecs":"source.port"
+      "ecs":"source.port",
+      "ocsf":"src_endpoint.port"
     },
     {
       "raw_field":"CallerProcessName",
-      "ecs":"winlog.event_data.CallerProcessName"
+      "ecs":"winlog.event_data.CallerProcessName",
+      "ocsf": "actor.process.file"
     },
     {
       "raw_field":"ServiceFileName",

--- a/src/test/java/org/opensearch/securityanalytics/LogTypeServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/LogTypeServiceTests.java
@@ -47,9 +47,9 @@ public class LogTypeServiceTests extends OpenSearchIntegTestCase {
             List<LogType> dummyLogTypes = List.of(
                 new LogType(null, "test_logtype", "", true,
                         List.of(
-                                new LogType.Mapping("rawFld1", "ecsFld1", "ocsfFld1"),
-                                new LogType.Mapping("rawFld2", "ecsFld2", "ocsfFld2"),
-                                new LogType.Mapping("rawFld3", "ecsFld3", "ocsfFld3")
+                                new LogType.Mapping("rawFld1", "ecsFld1", "ocsfFld1", "ocsf11Fld1"),
+                                new LogType.Mapping("rawFld2", "ecsFld2", "ocsfFld2", "ocsf11Fld2"),
+                                new LogType.Mapping("rawFld3", "ecsFld3", "ocsfFld3", "ocsf11Fld3")
                         ),
                         List.of(new LogType.IocFields("ip", List.of("dst.ip")))
                 )

--- a/src/test/java/org/opensearch/securityanalytics/model/WriteableTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/WriteableTests.java
@@ -77,7 +77,7 @@ public class WriteableTests extends OpenSearchTestCase {
     public void testLogTypeAsStreamRawFieldOnly() throws IOException {
         LogType logType = new LogType(
                 "1", "my_log_type", "description", false,
-                List.of(new LogType.Mapping("rawField", null, null)),
+                List.of(new LogType.Mapping("rawField", null, null, null)),
                 List.of(new LogType.IocFields("ip", List.of("dst.ip")))
         );
         BytesStreamOutput out = new BytesStreamOutput();
@@ -94,7 +94,7 @@ public class WriteableTests extends OpenSearchTestCase {
     public void testLogTypeAsStreamFull() throws IOException {
         LogType logType = new LogType(
                 "1", "my_log_type", "description", false,
-                List.of(new LogType.Mapping("rawField", "some_ecs_field", "some_ocsf_field")),
+                List.of(new LogType.Mapping("rawField", "some_ecs_field", "some_ocsf_field", "some_ocsf11_field")),
                 List.of(new LogType.IocFields("ip", List.of("dst.ip")))
         );
         BytesStreamOutput out = new BytesStreamOutput();

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/OCSFDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/OCSFDetectorRestApiIT.java
@@ -430,13 +430,14 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> respMap = responseAsMap(response);
         // Verify alias mappings
         Map<String, Object> props = (Map<String, Object>) respMap.get("properties");
-        Assert.assertEquals(18, props.size());
+        Assert.assertEquals(17, props.size());
         // Verify unmapped index fields
         List<String> unmappedIndexFields = (List<String>) respMap.get("unmapped_index_fields");
-        assertEquals(20, unmappedIndexFields.size());
+        assertEquals(21, unmappedIndexFields.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
-        assertEquals(24, unmappedFieldAliases.size());
+        assertEquals(25, unmappedFieldAliases.size());
+        throw new IllegalArgumentException("respMap: " + respMap);
     }
 
     @SuppressWarnings("unchecked")
@@ -452,13 +453,13 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> respMap = responseAsMap(response);
         // Verify alias mappings
         Map<String, Object> props = (Map<String, Object>) respMap.get("properties");
-        Assert.assertEquals(18, props.size());
+        Assert.assertEquals(17, props.size());
         // Verify unmapped index fields
         List<String> unmappedIndexFields = (List<String>) respMap.get("unmapped_index_fields");
-        assertEquals(20, unmappedIndexFields.size());
+        assertEquals(21, unmappedIndexFields.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
-        assertEquals(24, unmappedFieldAliases.size());
+        assertEquals(25, unmappedFieldAliases.size());
 
         // create a cloudtrail rule with a raw field
         String rule = randomRuleWithRawField();
@@ -472,13 +473,13 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> respMap2 = responseAsMap(response2);
         // Verify alias mappings
         Map<String, Object> props2 = (Map<String, Object>) respMap2.get("properties");
-        Assert.assertEquals(18, props2.size());
+        Assert.assertEquals(17, props2.size());
         // Verify unmapped index fields
         List<String> unmappedIndexFields2 = (List<String>) respMap2.get("unmapped_index_fields");
-        assertEquals(20, unmappedIndexFields2.size());
+        assertEquals(21, unmappedIndexFields2.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases2 = (List<String>) respMap2.get("unmapped_field_aliases");
-        assertEquals(24, unmappedFieldAliases2.size());
+        assertEquals(25, unmappedFieldAliases2.size());
         // Verify that first response and second response are the same after rule was indexed
         assertEquals(props, props2);
         assertEquals(unmappedIndexFields, unmappedIndexFields2);
@@ -498,13 +499,13 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> respMap = responseAsMap(response);
         // Verify alias mappings
         Map<String, Object> props = (Map<String, Object>) respMap.get("properties");
-        Assert.assertEquals(20, props.size());
+        Assert.assertEquals(21, props.size());
         // Verify unmapped index fields
         List<String> unmappedIndexFields = (List<String>) respMap.get("unmapped_index_fields");
-        assertEquals(26, unmappedIndexFields.size());
+        assertEquals(25, unmappedIndexFields.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
-        assertEquals(5, unmappedFieldAliases.size());
+        assertEquals(4, unmappedFieldAliases.size());
     }
 
     @SuppressWarnings("unchecked")
@@ -520,13 +521,13 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> respMap = responseAsMap(response);
         // Verify alias mappings
         Map<String, Object> props = (Map<String, Object>) respMap.get("properties");
-        Assert.assertEquals(11, props.size());
+        Assert.assertEquals(12, props.size());
         // Verify unmapped index fields
         List<String> unmappedIndexFields = (List<String>) respMap.get("unmapped_index_fields");
-        assertEquals(28, unmappedIndexFields.size());
+        assertEquals(27, unmappedIndexFields.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
-        assertEquals(11, unmappedFieldAliases.size());
+        assertEquals(12, unmappedFieldAliases.size());
     }
 
     @SuppressWarnings("unchecked")
@@ -586,10 +587,10 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> respMap = responseAsMap(response);
         // Verify alias mappings
         Map<String, Object> props = (Map<String, Object>) respMap.get("properties");
-        Assert.assertEquals(14, props.size());
+        Assert.assertEquals(16, props.size());
         // Verify unmapped index fields
         List<String> unmappedIndexFields = (List<String>) respMap.get("unmapped_index_fields");
-        assertEquals(6, unmappedIndexFields.size());
+        assertEquals(4, unmappedIndexFields.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
         assertEquals(8, unmappedFieldAliases.size());

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/OCSFDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/OCSFDetectorRestApiIT.java
@@ -430,13 +430,13 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> respMap = responseAsMap(response);
         // Verify alias mappings
         Map<String, Object> props = (Map<String, Object>) respMap.get("properties");
-        Assert.assertEquals(17, props.size());
+        Assert.assertEquals(18, props.size());
         // Verify unmapped index fields
         List<String> unmappedIndexFields = (List<String>) respMap.get("unmapped_index_fields");
-        assertEquals(21, unmappedIndexFields.size());
+        assertEquals(20, unmappedIndexFields.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
-        assertEquals(25, unmappedFieldAliases.size());
+        assertEquals(24, unmappedFieldAliases.size());
     }
 
     @SuppressWarnings("unchecked")
@@ -452,13 +452,13 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> respMap = responseAsMap(response);
         // Verify alias mappings
         Map<String, Object> props = (Map<String, Object>) respMap.get("properties");
-        Assert.assertEquals(17, props.size());
+        Assert.assertEquals(18, props.size());
         // Verify unmapped index fields
         List<String> unmappedIndexFields = (List<String>) respMap.get("unmapped_index_fields");
-        assertEquals(21, unmappedIndexFields.size());
+        assertEquals(20, unmappedIndexFields.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
-        assertEquals(25, unmappedFieldAliases.size());
+        assertEquals(24, unmappedFieldAliases.size());
 
         // create a cloudtrail rule with a raw field
         String rule = randomRuleWithRawField();
@@ -472,13 +472,13 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Map<String, Object> respMap2 = responseAsMap(response2);
         // Verify alias mappings
         Map<String, Object> props2 = (Map<String, Object>) respMap2.get("properties");
-        Assert.assertEquals(17, props2.size());
+        Assert.assertEquals(18, props2.size());
         // Verify unmapped index fields
         List<String> unmappedIndexFields2 = (List<String>) respMap2.get("unmapped_index_fields");
-        assertEquals(21, unmappedIndexFields2.size());
+        assertEquals(20, unmappedIndexFields2.size());
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases2 = (List<String>) respMap2.get("unmapped_field_aliases");
-        assertEquals(25, unmappedFieldAliases2.size());
+        assertEquals(24, unmappedFieldAliases2.size());
         // Verify that first response and second response are the same after rule was indexed
         assertEquals(props, props2);
         assertEquals(unmappedIndexFields, unmappedIndexFields2);

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/OCSFDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/OCSFDetectorRestApiIT.java
@@ -437,7 +437,6 @@ public class OCSFDetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         // Verify unmapped field aliases
         List<String> unmappedFieldAliases = (List<String>) respMap.get("unmapped_field_aliases");
         assertEquals(25, unmappedFieldAliases.size());
-        throw new IllegalArgumentException("respMap: " + respMap);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/opensearch/securityanalytics/writable/LogTypeTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/writable/LogTypeTests.java
@@ -21,7 +21,7 @@ public class LogTypeTests {
     public void testLogTypeAsStreamRawFieldOnly() throws IOException {
         LogType logType = new LogType(
                 "1", "my_log_type", "description", false,
-                List.of(new LogType.Mapping("rawField", null, null)),
+                List.of(new LogType.Mapping("rawField", null, null, null)),
                 List.of(new LogType.IocFields("ip", List.of("dst.ip")))
         );
         BytesStreamOutput out = new BytesStreamOutput();
@@ -41,7 +41,7 @@ public class LogTypeTests {
     public void testLogTypeAsStreamFull() throws IOException {
         LogType logType = new LogType(
                 "1", "my_log_type", "description", false,
-                List.of(new LogType.Mapping("rawField", "some_ecs_field", "some_ocsf_field")),
+                List.of(new LogType.Mapping("rawField", "some_ecs_field", "some_ocsf_field", "some_ocsf11_field")),
                 List.of(new LogType.IocFields("ip", List.of("dst.ip")))
         );
         BytesStreamOutput out = new BytesStreamOutput();


### PR DESCRIPTION
### Description
Adds various OCSF 1.1 field mappings to the static mappings repository in Security Analytics, allowing for more automatic field mappings during detector creation on indices ingesting OCSF 1.1 logs from Security Lake.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
