### PR TITLE
OCSF1.1 Fixes

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
@@ -232,10 +232,10 @@ public class MapperService {
                             for (LogType.Mapping mapping : mappings) {
                                 if (indexFields.contains(mapping.getRawField())) {
                                     aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getRawField()));
-                                } else if (indexFields.contains(mapping.getOcsf())) {
-                                    aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf()));
                                 } else if (indexFields.contains(mapping.getOcsf11())) {
                                     aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf11()));
+                                } else if (indexFields.contains(mapping.getOcsf())) {
+                                    aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf()));
                                 }
                             }
                             aliasMappingsObj.field("properties", aliasMappingFields);
@@ -484,8 +484,8 @@ public class MapperService {
                         for (LogType.Mapping requiredField : requiredFields) {
                             String alias = requiredField.getEcs();
                             String rawPath = requiredField.getRawField();
-                            String ocsfPath = requiredField.getOcsf();
                             String ocsf11Path = requiredField.getOcsf11();
+                            String ocsfPath = requiredField.getOcsf();
                             if (allFieldsFromIndex.contains(rawPath)) {
                                 // if the alias was already added into applyable aliases, then skip to avoid duplicates
                                 if (!applyableAliases.contains(alias) && !applyableAliases.contains(rawPath)) {
@@ -497,12 +497,12 @@ public class MapperService {
                                     }
                                     pathsOfApplyableAliases.add(rawPath);
                                 }
-                            } else if (allFieldsFromIndex.contains(ocsfPath)) {
-                                applyableAliases.add(alias);
-                                pathsOfApplyableAliases.add(ocsfPath);
                             } else if (allFieldsFromIndex.contains(ocsf11Path)) {
                                 applyableAliases.add(alias);
                                 pathsOfApplyableAliases.add(ocsf11Path);
+                            } else if (allFieldsFromIndex.contains(ocsfPath)) {
+                                applyableAliases.add(alias);
+                                pathsOfApplyableAliases.add(ocsfPath);
                             } else if ((alias == null && allFieldsFromIndex.contains(rawPath) == false) || allFieldsFromIndex.contains(alias) == false) {
                                 if (alias != null) {
                                     // we don't want to send back aliases which have same name as existing field in index
@@ -524,10 +524,10 @@ public class MapperService {
                         Map<String, Map<String, String>> aliasMappingFields = new HashMap<>();
                         XContentBuilder aliasMappingsObj = XContentFactory.jsonBuilder().startObject();
                         for (LogType.Mapping mapping : requiredFields) {
-                            if (allFieldsFromIndex.contains(mapping.getOcsf())) {
-                                aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf()));
-                            } else if (allFieldsFromIndex.contains(mapping.getOcsf11())) {
+                            if (allFieldsFromIndex.contains(mapping.getOcsf11())) {
                                 aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf11()));
+                            } else if (allFieldsFromIndex.contains(mapping.getOcsf())) {
+                                aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf()));
                             } else if (mapping.getEcs() != null) {
                                 shouldUpdateEcsMappingAndMaybeUpdates(mapping, aliasMappingFields, pathsOfApplyableAliases);
                             } else if (mapping.getEcs() == null) {

--- a/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
@@ -233,6 +233,8 @@ public class MapperService {
                                 if (indexFields.contains(mapping.getRawField())) {
                                     aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getRawField()));
                                 } else if (indexFields.contains(mapping.getOcsf11())) {
+                                    // it's important to first check for OCSF1.1 before checking for OCSF1.0
+                                    // changing this order leads to multiple ECS fields mapping to the same OCSF1.1 field
                                     aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf11()));
                                 } else if (indexFields.contains(mapping.getOcsf())) {
                                     aliasMappingFields.put(mapping.getEcs(), Map.of("type", "alias", "path", mapping.getOcsf()));

--- a/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
@@ -484,8 +484,8 @@ public class MapperService {
                         for (LogType.Mapping requiredField : requiredFields) {
                             String alias = requiredField.getEcs();
                             String rawPath = requiredField.getRawField();
-                            String ocsf11Path = requiredField.getOcsf11();
                             String ocsfPath = requiredField.getOcsf();
+                            String ocsf11Path = requiredField.getOcsf11();
                             if (allFieldsFromIndex.contains(rawPath)) {
                                 // if the alias was already added into applyable aliases, then skip to avoid duplicates
                                 if (!applyableAliases.contains(alias) && !applyableAliases.contains(rawPath)) {

--- a/src/main/resources/OSMapping/waf_logtype.json
+++ b/src/main/resources/OSMapping/waf_logtype.json
@@ -57,12 +57,12 @@
     {
       "raw_field":"httpRequest.headers.value",
       "ecs":"waf.request.headers.value",
-      "ocsf": "http_request.http_headers[].value"
+      "ocsf": "http_request.http_headers.value"
     },
     {
       "raw_field":"httpRequest.headers.name",
       "ecs":"waf.request.headers.name",
-      "ocsf": "http_request.http_headers[].name"
+      "ocsf": "http_request.http_headers.name"
     }
   ]
 }


### PR DESCRIPTION
### Description
Implements some fixes found in end-to-end validation of added OCSF1.1 field mappings on mock Security Lake data. Fixes include:
1. Removed `[]` from newly added WAF field mappings. The static mappings can parse fields in lists without being explicitly indicated that the field is a list, so the square brackets were being treated as part of the field name itself.
2. Checking for an OCSF1.1 field mapping before checking for an OCSF1.0 field mapping. This resolves a confusion the static mappings had on how to map OCSF1.1 fields `actor.user.uid`, `actor.user.uid_alt` to ECS fields `aws.cloudtrail.user_identity.principalId` and `aws.cloudtrail.user_identity.arn`.

Previously, in OCSF1.0, the field mappings for ECS fields were:
`aws.cloudtrail.user_identity.principalId` -> `actor.user.uid`
`aws.cloudtrail.user_identity.arn` -> `actor.user.uuid`

The new mappings for OCSF1.1 are:
`aws.cloudtrail.user_identity.principalId` -> `actor.user.uid_alt`
`aws.cloudtrail.user_identity.arn` -> `actor.user.uid`

Because we check for the OCSF1.0 mapping before the OCSF1.1 mapping, when OCSF1.1 logs are ingested, for ECS field `aws.cloudtrail.user_identity.principalId`, it would first find `actor.user.uid` before `actor.user.uid_alt`, so the mapping `aws.cloudtrail.user_identity.principalId` -> `actor.user.uid` would be created. For ECS field `aws.cloudtrail.user_identity.arn`, field `actor.user.uuid` is not used in OCSF1.1, so that gets skipped and the check lands on `actor.user.uid`, which does exist in OCSF1.1, leading to the mapping: `aws.cloudtrail.user_identity.arn` -> `actor.user.uid`. Now 2 ECS fields map to the same OCSF1.1 field `actor.user.uid`. 

By switching the order such that OCSF1.1 is checked first before OCSF1.0, we handle the above case. This is especially the case since SecurityLake customers are being pushed to use OCSF1.1 over OCSF1.0 (since Security Lake used a release candidate of OCSF1.0 rather than its official release).

Also added an integration test for fix 1 above. The rest of the fixes were validated end-to-end on mock Security Lake data.

### Check List
- [Y] New functionality includes testing.
- [N/A] New functionality has been documented.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [Y] Commits are signed per the DCO using `--signoff`.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
