### PR TITLE
Adds support for uploading threat intelligence in Custom Format JSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,9 @@ dependencies {
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
     compileOnly "org.opensearch.alerting:alerting-spi:${alerting_spi_build}"
     implementation "org.apache.commons:commons-csv:1.10.0"
+    implementation 'com.jayway.jsonpath:json-path:2.9.0'
+    implementation 'net.minidev:json-smart:2.5.0'
+    implementation 'net.minidev:accessors-smart:2.5.0'
     compileOnly "com.google.guava:guava:32.1.3-jre"
 
     // TODO uncomment once SA commons is published to maven central

--- a/src/main/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/DetailedSTIX2IOCDto.java
@@ -12,14 +12,12 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
-import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.commons.model.STIX2;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * A data transfer object for STIX2IOC containing additional details.
@@ -58,7 +56,7 @@ public class DetailedSTIX2IOCDto implements Writeable, ToXContentObject {
         }
 
         String name = null;
-        IOCType type = null;
+        String type = null;
         String value = null;
         String severity = null;
         Instant created = null;
@@ -89,7 +87,7 @@ public class DetailedSTIX2IOCDto implements Writeable, ToXContentObject {
                     name = xcp.text();
                     break;
                 case STIX2.TYPE_FIELD:
-                    type = new IOCType(xcp.text().toLowerCase(Locale.ROOT));
+                    type = xcp.text();
                     break;
                 case STIX2.VALUE_FIELD:
                     value = xcp.text();

--- a/src/main/java/org/opensearch/securityanalytics/model/STIX2IOC.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/STIX2IOC.java
@@ -199,15 +199,27 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
 
             switch (fieldName) {
                 case NAME_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        break;
+                    }
                     name = xcp.text();
                     break;
                 case TYPE_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        break;
+                    }
                     type = xcp.text();
                     break;
                 case VALUE_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        break;
+                    }
                     value = xcp.text();
                     break;
                 case SEVERITY_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        break;
+                    }
                     severity = xcp.text();
                     break;
                 case CREATED_FIELD:
@@ -239,6 +251,9 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
                     }
                     break;
                 case DESCRIPTION_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        break;
+                    }
                     description = xcp.text();
                     break;
                 case LABELS_FIELD:
@@ -251,12 +266,21 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
                     }
                     break;
                 case SPEC_VERSION_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        break;
+                    }
                     specVersion = xcp.text();
                     break;
                 case FEED_ID_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        break;
+                    }
                     feedId = xcp.text();
                     break;
                 case FEED_NAME_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        break;
+                    }
                     feedName = xcp.text();
                     break;
                 default:

--- a/src/main/java/org/opensearch/securityanalytics/model/STIX2IOC.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/STIX2IOC.java
@@ -11,22 +11,17 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
-import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.commons.model.STIX2;
-import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
 import org.opensearch.securityanalytics.util.XContentUtils;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.UUID;
 
 public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
@@ -46,7 +41,7 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
     public STIX2IOC(
             String id,
             String name,
-            IOCType type,
+            String type,
             String value,
             String severity,
             Instant created,
@@ -86,7 +81,7 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
         this(
                 sin.readString(), // id
                 sin.readString(), // name
-                new IOCType(sin.readString()), // type
+                sin.readString(), // type
                 sin.readString(), // value
                 sin.readString(), // severity
                 sin.readInstant(), // created
@@ -186,7 +181,7 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
         }
 
         String name = null;
-        IOCType type = null;
+        String type = null;
         String value = null;
         String severity = null;
         Instant created = null;
@@ -207,18 +202,7 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
                     name = xcp.text();
                     break;
                 case TYPE_FIELD:
-                    String typeString = xcp.text();
-                    try {
-                        type = new IOCType(typeString);
-                    } catch (Exception e) {
-                        String error = String.format(
-                                "Couldn't parse IOC type '%s' while deserializing STIX2IOC with ID '%s': ",
-                                typeString,
-                                id
-                        );
-                        logger.error(error, e);
-                        throw new SecurityAnalyticsException(error, RestStatus.BAD_REQUEST, e);
-                    }
+                    type = xcp.text();
                     break;
                 case VALUE_FIELD:
                     value = xcp.text();
@@ -305,9 +289,6 @@ public class STIX2IOC extends STIX2 implements Writeable, ToXContentObject {
     public void validate() throws IllegalArgumentException {
         if (super.getType() == null) {
             throw new IllegalArgumentException(String.format("[%s] is required.", TYPE_FIELD));
-        } else if (!IOCType.supportedType(super.getType().toString())) {
-            logger.debug("Unsupported IOCType: {}", super.getType().toString());
-            throw new IllegalArgumentException(String.format("[%s] is not supported.", TYPE_FIELD));
         }
 
         if (super.getValue() == null || super.getValue().isEmpty()) {

--- a/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
@@ -174,16 +174,24 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                     }
                     break;
                 case STIX2.NAME_FIELD:
-                    name = xcp.text();
+                    if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        name = xcp.text();
+                    }
                     break;
                 case STIX2.TYPE_FIELD:
-                    type = xcp.text();
+                    if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        type = xcp.text();
+                    }
                     break;
                 case STIX2.VALUE_FIELD:
-                    value = xcp.text();
+                    if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        value = xcp.text();
+                    }
                     break;
                 case STIX2.SEVERITY_FIELD:
-                    severity = xcp.text();
+                    if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        severity = xcp.text();
+                    }
                     break;
                 case STIX2.CREATED_FIELD:
                     if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
@@ -214,7 +222,9 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                     }
                     break;
                 case STIX2.DESCRIPTION_FIELD:
-                    description = xcp.text();
+                    if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        description = xcp.text();
+                    }
                     break;
                 case STIX2.LABELS_FIELD:
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
@@ -226,13 +236,19 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                     }
                     break;
                 case STIX2.SPEC_VERSION_FIELD:
-                    specVersion = xcp.text();
+                    if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        specVersion = xcp.text();
+                    }
                     break;
                 case STIX2IOC.FEED_ID_FIELD:
-                    feedId = xcp.text();
+                    if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        feedId = xcp.text();
+                    }
                     break;
                 case STIX2IOC.FEED_NAME_FIELD:
-                    feedName = xcp.text();
+                    if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        feedName = xcp.text();
+                    }
                     break;
                 default:
                     xcp.skipChildren();

--- a/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/STIX2IOCDto.java
@@ -10,14 +10,11 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
-import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.commons.model.STIX2;
-import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -32,7 +29,7 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
 
     private String id;
     private String name;
-    private IOCType type;
+    private String type;
     private String value;
     private String severity;
     private Instant created;
@@ -50,7 +47,7 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
     public STIX2IOCDto(
             String id,
             String name,
-            IOCType type,
+            String type,
             String value,
             String severity,
             Instant created,
@@ -149,7 +146,7 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
         }
 
         String name = null;
-        IOCType type = null;
+        String type = null;
         String value = null;
         String severity = null;
         Instant created = null;
@@ -180,18 +177,7 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
                     name = xcp.text();
                     break;
                 case STIX2.TYPE_FIELD:
-                    String typeString = xcp.text();
-                    try {
-                        type = new IOCType(typeString);
-                    } catch (Exception e) {
-                        String error = String.format(
-                                "Couldn't parse IOC type '%s' while deserializing STIX2IOCDto with ID '%s': ",
-                                typeString,
-                                id
-                        );
-                        logger.error(error, e);
-                        throw new SecurityAnalyticsException(error, RestStatus.BAD_REQUEST, e);
-                    }
+                    type = xcp.text();
                     break;
                 case STIX2.VALUE_FIELD:
                     value = xcp.text();
@@ -286,11 +272,11 @@ public class STIX2IOCDto implements Writeable, ToXContentObject {
         this.name = name;
     }
 
-    public IOCType getType() {
+    public String getType() {
         return type;
     }
 
-    public void setType(IOCType type) {
+    public void setType(String type) {
         this.type = type;
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/services/JsonPathAwareInputCodec.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/JsonPathAwareInputCodec.java
@@ -1,0 +1,42 @@
+package org.opensearch.securityanalytics.services;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.securityanalytics.commons.connector.codec.InputCodec;
+import org.opensearch.securityanalytics.model.STIX2IOC;
+import org.opensearch.securityanalytics.threatIntel.model.JsonPathIocSchema;
+import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
+import org.opensearch.securityanalytics.threatIntel.service.JsonPathIocSchemaThreatIntelHandler;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * An implementation of InputCodec used to parse input stream using JsonPath notations from {@link JsonPathIocSchema} and build a list of {@link STIX2IOC} objects
+ */
+public class JsonPathAwareInputCodec implements InputCodec<STIX2IOC> {
+    private static final Logger logger = LogManager.getLogger(JsonPathAwareInputCodec.class);
+    private final SATIFSourceConfig satifSourceConfig;
+
+    public JsonPathAwareInputCodec(SATIFSourceConfig satifSourceConfig) {
+        this.satifSourceConfig = satifSourceConfig;
+    }
+
+    @Override
+    public void parse(final InputStream inputStream, final Consumer<STIX2IOC> consumer) {
+        try {
+            List<STIX2IOC> stix2IOCS = JsonPathIocSchemaThreatIntelHandler.parseCustomSchema(
+                    (JsonPathIocSchema) satifSourceConfig.getIocSchema(), inputStream, satifSourceConfig.getName(), satifSourceConfig.getId());
+            stix2IOCS.forEach(ioc -> {
+                try {
+                    consumer.accept(ioc);
+                } catch (Exception e) {
+                    logger.error(String.format("Error while indexing STIX2Ioc - type [%s], value [%s]"), e);
+                }
+            });
+        } catch (Exception e) {
+            logger.error(String.format("Error while downloading and indexing STIX2Ioc"), e);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCConnectorFactory.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCConnectorFactory.java
@@ -18,6 +18,7 @@ import org.opensearch.securityanalytics.commons.factory.UnaryParameterCachingFac
 import org.opensearch.securityanalytics.commons.model.FeedConfiguration;
 import org.opensearch.securityanalytics.commons.model.FeedLocation;
 import org.opensearch.securityanalytics.commons.model.STIX2;
+import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.List;
@@ -35,16 +36,34 @@ public class STIX2IOCConnectorFactory extends UnaryParameterCachingFactory<FeedC
     protected Connector<STIX2> doCreate(FeedConfiguration feedConfiguration) {
         final FeedLocation feedLocation = FeedLocation.fromFeedConfiguration(feedConfiguration);
         logger.debug("FeedLocation: {}", feedLocation);
-        switch(feedLocation) {
-            case S3: return createS3Connector(feedConfiguration);
-            default: throw new IllegalArgumentException("Unsupported feedLocation: " + feedLocation);
+        switch (feedLocation) {
+            case S3:
+                return createS3Connector(feedConfiguration, null);
+            default:
+                throw new IllegalArgumentException("Unsupported feedLocation: " + feedLocation);
         }
     }
 
-    private S3Connector<STIX2> createS3Connector(final FeedConfiguration feedConfiguration) {
+    protected Connector<STIX2> doCreate(FeedConfiguration feedConfiguration, SATIFSourceConfig satifSourceConfig) {
+        final FeedLocation feedLocation = FeedLocation.fromFeedConfiguration(feedConfiguration);
+        logger.debug("FeedLocation: {}", feedLocation);
+        switch (feedLocation) {
+            case S3:
+                return createS3Connector(feedConfiguration, satifSourceConfig);
+            default:
+                throw new IllegalArgumentException("Unsupported feedLocation: " + feedLocation);
+        }
+    }
+
+    private S3Connector<STIX2> createS3Connector(final FeedConfiguration feedConfiguration, SATIFSourceConfig satifSourceConfig) {
         final S3ConnectorConfig s3ConnectorConfig = feedConfiguration.getS3ConnectorConfig();
         final S3Client s3Client = s3ClientFactory.create(s3ConnectorConfig.getRoleArn(), s3ConnectorConfig.getRegion());
-        final InputCodec inputCodec = inputCodecFactory.create(feedConfiguration.getIocSchema().getModelClass(), feedConfiguration.getInputCodecSchema());
+        final InputCodec inputCodec;
+        if (satifSourceConfig.getIocSchema() != null) {
+            inputCodec = new JsonPathAwareInputCodec(satifSourceConfig);
+        } else {
+            inputCodec = inputCodecFactory.create(feedConfiguration.getIocSchema().getModelClass(), feedConfiguration.getInputCodecSchema());
+        }
         return new S3Connector<>(s3ConnectorConfig, s3Client, inputCodec);
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCConsumer.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCConsumer.java
@@ -42,15 +42,6 @@ public class STIX2IOCConsumer implements Consumer<STIX2> {
                 feedStore.getSaTifSourceConfig().getName()
         );
 
-        // If the IOC received is not a type listed for the config, do not add it to the queue
-        if (!feedStore.getSaTifSourceConfig().getIocTypes().contains(stix2IOC.getType().toString())) {
-            log.error("{} is not a supported Ioc type for tif source config {}. Skipping IOC {}: of type {} value {}",
-                    stix2IOC.getType().toString(), feedStore.getSaTifSourceConfig().getId(),
-                    stix2IOC.getId(), stix2IOC.getType(), stix2IOC.getValue()
-            );
-            return;
-        }
-
         if (queue.offer(stix2IOC)) {
             return;
         }

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
@@ -28,7 +28,6 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.securityanalytics.commons.model.IOC;
-import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.commons.model.UpdateAction;
 import org.opensearch.securityanalytics.commons.store.FeedStore;
 import org.opensearch.securityanalytics.model.STIX2IOC;
@@ -224,7 +223,7 @@ public class STIX2IOCFeedStore implements FeedStore {
                     saTifSourceConfig.getIocTypes().forEach(type -> {
                         if (saTifSourceConfig.getIocStoreConfig() instanceof DefaultIocStoreConfig) {
                             DefaultIocStoreConfig.IocToIndexDetails iocToIndexDetails =
-                                    new DefaultIocStoreConfig.IocToIndexDetails(new IOCType(type), iocIndexPattern, newActiveIndex);
+                                    new DefaultIocStoreConfig.IocToIndexDetails(type, iocIndexPattern, newActiveIndex);
                             ((DefaultIocStoreConfig) saTifSourceConfig.getIocStoreConfig()).getIocToIndexDetails().add(iocToIndexDetails);
                         }
                     });

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
@@ -149,7 +149,7 @@ public class STIX2IOCFetchService {
             return;
         }
 
-        Connector<STIX2> s3Connector = constructS3Connector(s3ConnectorConfig);
+        Connector<STIX2> s3Connector = constructS3Connector(s3ConnectorConfig, saTifSourceConfig);
         STIX2IOCFeedStore feedStore = new STIX2IOCFeedStore(client, clusterService, saTifSourceConfig, listener);
         STIX2IOCConsumer consumer = new STIX2IOCConsumer(batchSize, feedStore, UpdateType.REPLACE);
 
@@ -226,7 +226,7 @@ public class STIX2IOCFetchService {
 
     private void testS3ClientConnection(S3ConnectorConfig s3ConnectorConfig, ActionListener<TestS3ConnectionResponse> listener) {
         try {
-            S3Connector<STIX2> connector = (S3Connector<STIX2>) constructS3Connector(s3ConnectorConfig);
+            S3Connector<STIX2> connector = (S3Connector<STIX2>) constructS3Connector(s3ConnectorConfig, null);
             HeadObjectResponse response = connector.testS3Connection(s3ConnectorConfig);
             listener.onResponse(new TestS3ConnectionResponse(RestStatus.fromCode(response.sdkHttpResponse().statusCode()), ""));
         } catch (NoSuchKeyException noSuchKeyException) {
@@ -251,7 +251,7 @@ public class STIX2IOCFetchService {
 
     private void testAmazonS3Connection(S3ConnectorConfig s3ConnectorConfig, ActionListener<TestS3ConnectionResponse> listener) {
         try {
-            S3Connector<STIX2> connector = (S3Connector<STIX2>) constructS3Connector(s3ConnectorConfig);
+            S3Connector<STIX2> connector = (S3Connector<STIX2>) constructS3Connector(s3ConnectorConfig, null);
             boolean response = connector.testAmazonS3Connection(s3ConnectorConfig);
             listener.onResponse(new TestS3ConnectionResponse(response ? RestStatus.OK : RestStatus.FORBIDDEN, ""));
         } catch (AmazonServiceException e) {
@@ -268,20 +268,26 @@ public class STIX2IOCFetchService {
         }
     }
 
-    private Connector<STIX2> constructS3Connector(S3ConnectorConfig s3ConnectorConfig) {
-        FeedConfiguration feedConfiguration = new FeedConfiguration(IOCSchema.STIX2, InputCodecSchema.ND_JSON, s3ConnectorConfig);
-        if (internalAuthEndpoint.isEmpty()) {
-            return constructS3ClientConnector(feedConfiguration);
+    private Connector<STIX2> constructS3Connector(S3ConnectorConfig s3ConnectorConfig, SATIFSourceConfig saTifSourceConfig) {
+        FeedConfiguration feedConfiguration;
+        if(saTifSourceConfig != null && saTifSourceConfig.getIocSchema() != null) {
+            feedConfiguration = new FeedConfiguration(IOCSchema.STIX2, InputCodecSchema.ND_JSON, s3ConnectorConfig);
         } else {
-            return constructAmazonS3Connector(feedConfiguration);
+            feedConfiguration = new FeedConfiguration(IOCSchema.STIX2, InputCodecSchema.ND_JSON, s3ConnectorConfig);
+        }
+
+        if (internalAuthEndpoint.isEmpty()) {
+            return constructS3ClientConnector(feedConfiguration, saTifSourceConfig);
+        } else {
+            return constructAmazonS3Connector(feedConfiguration, saTifSourceConfig);
         }
     }
 
-    private Connector<STIX2> constructS3ClientConnector(FeedConfiguration feedConfiguration) {
-        return connectorFactory.doCreate(feedConfiguration);
+    private Connector<STIX2> constructS3ClientConnector(FeedConfiguration feedConfiguration, SATIFSourceConfig saTifSourceConfig) {
+        return connectorFactory.doCreate(feedConfiguration, saTifSourceConfig);
     }
 
-    private Connector<STIX2> constructAmazonS3Connector(FeedConfiguration feedConfiguration) {
+    private Connector<STIX2> constructAmazonS3Connector(FeedConfiguration feedConfiguration, SATIFSourceConfig saTifSourceConfig) {
         List<String> clusterTuple = List.of(clusterService.getClusterName().value().split(":"));
         return connectorFactory.createAmazonS3Connector(feedConfiguration, clusterTuple);
     }

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFetchService.java
@@ -373,7 +373,7 @@ public class STIX2IOCFetchService {
             STIX2IOC stix2IOC = new STIX2IOC(
                     UUID.randomUUID().toString(),
                     UUID.randomUUID().toString(),
-                    iocType == null ? new IOCType(IOCType.IPV4_TYPE) : new IOCType(iocType),
+                    iocType,
                     iocValue,
                     "high",
                     now,

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/ListIOCsActionRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/ListIOCsActionRequest.java
@@ -11,7 +11,6 @@ import org.opensearch.action.ValidateActions;
 import org.opensearch.commons.alerting.model.Table;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
-import org.opensearch.securityanalytics.commons.model.IOCType;
 
 import java.io.IOException;
 import java.util.List;
@@ -63,19 +62,20 @@ public class ListIOCsActionRequest extends ActionRequest {
         } else if (table.getSize() < 0 || table.getSize() > 10000) {
             validationException = ValidateActions
                     .addValidationError(String.format("size param must be between 0 and 10,000."), validationException);
-        } else {
-            for (String type : types) {
-                if (!ALL_TYPES_FILTER.equalsIgnoreCase(type)) {
-                    try {
-                        IOCType.fromString(type);
-                    } catch (IllegalArgumentException e) {
-                        validationException = ValidateActions
-                                .addValidationError(String.format("Unrecognized [%s] param.", TYPE_FIELD), validationException);
-                        break;
-                    }
-                }
-            }
         }
+//        else {
+//            for (String type : types) {
+//                if (!ALL_TYPES_FILTER.equalsIgnoreCase(type)) {
+//                    try {
+//                        IOCType.fromString(type);
+//                    } catch (IllegalArgumentException e) {
+//                        validationException = ValidateActions
+//                                .addValidationError(String.format("Unrecognized [%s] param.", TYPE_FIELD), validationException);
+//                        break;
+//                    }
+//                }
+//            }
+//        }
         return validationException;
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
@@ -6,6 +6,7 @@
 package org.opensearch.securityanalytics.threatIntel.common;
 
 import org.opensearch.securityanalytics.commons.model.IOCType;
+import org.opensearch.securityanalytics.threatIntel.model.CustomSchemaIocUploadSource;
 import org.opensearch.securityanalytics.threatIntel.model.IocUploadSource;
 import org.opensearch.securityanalytics.threatIntel.model.S3Source;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
@@ -14,6 +15,8 @@ import org.opensearch.securityanalytics.threatIntel.model.UrlDownloadSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import static org.apache.logging.log4j.util.Strings.isBlank;
 
 /**
  * Source config dto validator
@@ -76,6 +79,23 @@ public class SourceConfigDtoValidator {
                     if (sourceConfigDto.getSource() instanceof IocUploadSource && ((IocUploadSource) sourceConfigDto.getSource()).getIocs() == null) {
                         errorMsgs.add("Ioc list must include at least one ioc");
                     }
+                    break;
+                case CUSTOM_SCHEMA_IOC_UPLOAD:
+                    if (sourceConfigDto.isEnabled()) {
+                        errorMsgs.add("Job Scheduler cannot be enabled for CUSTOM_SCHEMA_IOC_UPLOAD type");
+                    }
+                    if (sourceConfigDto.getSchedule() != null) {
+                        errorMsgs.add("Cannot pass in schedule for CUSTOM_SCHEMA_IOC_UPLOAD type");
+                    }
+                    if (sourceConfigDto.getSource() != null && sourceConfigDto.getSource() instanceof CustomSchemaIocUploadSource == false) {
+                        errorMsgs.add("Source must be CUSTOM_SCHEMA_IOC_UPLOAD type");
+                    }
+                    if (sourceConfigDto.getSource() instanceof CustomSchemaIocUploadSource &&
+                            isBlank(((CustomSchemaIocUploadSource) sourceConfigDto.getSource()).getIocs())
+                    ) {
+                        errorMsgs.add("Ioc list must include at least one ioc");
+                    }
+                    // TODO validate the iocs are in format defined in schema
                     break;
                 case S3_CUSTOM:
                     if (sourceConfigDto.getSchedule() == null) {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigDtoValidator.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.securityanalytics.threatIntel.common;
 
-import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.threatIntel.model.CustomSchemaIocUploadSource;
 import org.opensearch.securityanalytics.threatIntel.model.IocUploadSource;
 import org.opensearch.securityanalytics.threatIntel.model.S3Source;
@@ -50,16 +49,6 @@ public class SourceConfigDtoValidator {
 
         if (sourceConfigDto.getSource() == null) {
             errorMsgs.add("Source must not be empty");
-        }
-
-        if (sourceConfigDto.getIocTypes() == null || sourceConfigDto.getIocTypes().isEmpty()) {
-            errorMsgs.add("Must specify at least one IOC type");
-        } else {
-            for (String s: sourceConfigDto.getIocTypes()) {
-                if (!IOCType.supportedType(s)) {
-                    errorMsgs.add("Invalid IOC type: " + s);
-                }
-            }
         }
 
         if (sourceConfigDto.getType() == null) {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigType.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/common/SourceConfigType.java
@@ -11,16 +11,6 @@ package org.opensearch.securityanalytics.threatIntel.common;
 public enum SourceConfigType {
     S3_CUSTOM,
     IOC_UPLOAD,
+    CUSTOM_SCHEMA_IOC_UPLOAD,
     URL_DOWNLOAD
-
-//    LICENSED,
-//
-//    OPEN_SOURCED,
-//
-//    INTERNAL,
-//
-//    DEFAULT_OPEN_SOURCED,
-//
-//    EXTERNAL_LICENSED,
-
 }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/IoCScanService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/IoCScanService.java
@@ -126,7 +126,7 @@ public abstract class IoCScanService<Data extends Object> implements IoCScanServ
         Map<String, Set<String>> docIdToIocsMap = new HashMap<>();
         for (Data datum : data) {
             for (PerIocTypeScanInput iocTypeToIndexFieldMapping : context.getThreatIntelInput().getPerIocTypeScanInputList()) {
-                String iocType = iocTypeToIndexFieldMapping.getIocType().toLowerCase();
+                String iocType = iocTypeToIndexFieldMapping.getIocType();
                 String concreteIndex = getIndexName(datum);
                 if (context.getConcreteIndexToMonitorInputIndicesMap().containsKey(concreteIndex)) {
                     // if concrete index resolves to multiple monitor input indices, it's undesirable. We just pick any one of the monitor input indices to get fields for each ioc.
@@ -177,7 +177,7 @@ public abstract class IoCScanService<Data extends Object> implements IoCScanServ
             for (STIX2IOC ioc : iocs) {
                 String iocValue = ioc.getValue();
                 if (false == iocValueToType.containsKey(iocValue))
-                    iocValueToType.put(iocValue, ioc.getType().toString());
+                    iocValueToType.put(iocValue, ioc.getType());
                 iocValueToFeedIds
                         .computeIfAbsent(iocValue, k -> new HashSet<>())
                         .add(new IocWithFeeds(ioc.getId(), ioc.getFeedId(), ioc.getFeedName(), "")); //todo figure how to store index

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/SaIoCScanService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/SaIoCScanService.java
@@ -260,7 +260,7 @@ public class SaIoCScanService extends IoCScanService<SearchHit> {
         for (String iocType : iocsPerType.keySet()) {
             List<String> indices = iocTypeToIndices.get(iocType);
             Set<String> iocs = iocsPerType.get(iocType);
-            if (iocTypeToIndices.containsKey(iocType.toLowerCase())) {
+            if (iocTypeToIndices.containsKey(iocType)) {
                 if (indices.isEmpty()) {
                     log.debug(
                             "Threat intel monitor {} : No ioc indices of type {} found so no scan performed.",
@@ -384,7 +384,7 @@ public class SaIoCScanService extends IoCScanService<SearchHit> {
         // add the iocs sublist
         boolQueryBuilder.must(new TermsQueryBuilder(STIX2.VALUE_FIELD, iocsSublist));
         // add ioc type filter
-        boolQueryBuilder.must(new TermsQueryBuilder(STIX2.TYPE_FIELD, iocType.toLowerCase(Locale.ROOT)));
+        boolQueryBuilder.must(new TermsQueryBuilder(STIX2.TYPE_FIELD, iocType));
         searchRequest.source().query(boolQueryBuilder);
         return searchRequest;
     }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/CustomSchemaIocUploadSource.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/CustomSchemaIocUploadSource.java
@@ -1,0 +1,101 @@
+package org.opensearch.securityanalytics.threatIntel.model;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.xcontent.XContentParserUtils;
+import org.opensearch.securityanalytics.model.STIX2IOCDto;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.opensearch.securityanalytics.threatIntel.model.Source.CUSTOM_SCHEMA_IOC_UPLOAD_FIELD;
+
+public class CustomSchemaIocUploadSource extends Source implements Writeable, ToXContent {
+    public static final String IOCS_FIELD = "iocs";
+    public static final String FILE_NAME_FIELD = "file_name";
+    private String fileName;
+    private String iocs;
+
+    public CustomSchemaIocUploadSource(String fileName, String iocs) {
+        this.fileName = fileName;
+        this.iocs = iocs;
+    }
+
+    public CustomSchemaIocUploadSource(StreamInput sin) throws IOException {
+        this (
+                sin.readOptionalString(), // file name
+                sin.readOptionalString() // iocs
+        );
+    }
+
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(fileName);
+        out.writeOptionalString(iocs);
+    }
+
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.startObject(CUSTOM_SCHEMA_IOC_UPLOAD_FIELD);
+        if (fileName != null) {
+            builder.field(FILE_NAME_FIELD, fileName);
+        }
+        if(iocs != null) {
+            builder.field(IOCS_FIELD, iocs);
+        }
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    String name() {
+        return CUSTOM_SCHEMA_IOC_UPLOAD_FIELD;
+    }
+
+    public static CustomSchemaIocUploadSource parse(XContentParser xcp) throws IOException {
+        String fileName = null;
+        String iocs = null;
+
+        while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = xcp.currentName();
+            xcp.nextToken();
+            switch (fieldName) {
+                case FILE_NAME_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        fileName = null;
+                    } else {
+                        fileName = xcp.text();
+                    }
+                    break;
+                case IOCS_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        iocs = null;
+                    } else {
+                        iocs = xcp.text();
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        return new CustomSchemaIocUploadSource(fileName, iocs);
+    }
+
+    public String getIocs() {
+        return iocs;
+    }
+
+    public void setIocs(String iocs) {
+        this.iocs = iocs;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/DefaultIocStoreConfig.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/DefaultIocStoreConfig.java
@@ -9,7 +9,6 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
-import org.opensearch.securityanalytics.commons.model.IOCType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -90,11 +89,11 @@ public class DefaultIocStoreConfig extends IocStoreConfig implements Writeable, 
         public static final String IOC_TYPE_FIELD = "ioc_type";
         public static final String INDEX_PATTERN_FIELD = "index_pattern";
         public static final String ACTIVE_INDEX_FIELD = "active_index";
-        private final IOCType iocType;
+        private final String iocType;
         private final String indexPattern;
         private final String activeIndex;
 
-        public IocToIndexDetails(IOCType iocType, String indexPattern, String activeIndex) {
+        public IocToIndexDetails(String iocType, String indexPattern, String activeIndex) {
             this.iocType = iocType;
             this.indexPattern = indexPattern;
             this.activeIndex = activeIndex;
@@ -102,7 +101,7 @@ public class DefaultIocStoreConfig extends IocStoreConfig implements Writeable, 
 
         public IocToIndexDetails(StreamInput sin) throws IOException {
             this(
-                    new IOCType(sin.readString()),
+                    new String(sin.readString()),
                     sin.readString(),
                     sin.readString()
             );
@@ -124,7 +123,7 @@ public class DefaultIocStoreConfig extends IocStoreConfig implements Writeable, 
         }
 
         public static IocToIndexDetails parse(XContentParser xcp) throws IOException {
-            IOCType iocType = null;
+            String iocType = null;
             String indexPattern = null;
             String activeIndex = null;
 
@@ -135,7 +134,7 @@ public class DefaultIocStoreConfig extends IocStoreConfig implements Writeable, 
 
                 switch (fieldName) {
                     case IOC_TYPE_FIELD:
-                        iocType = toIocType(xcp.text());
+                        iocType = xcp.text();
                         break;
                     case INDEX_PATTERN_FIELD:
                         indexPattern = xcp.text();
@@ -150,16 +149,7 @@ public class DefaultIocStoreConfig extends IocStoreConfig implements Writeable, 
             return new IocToIndexDetails(iocType, indexPattern, activeIndex);
         }
 
-        public static IOCType toIocType(String name) {
-            try {
-                return new IOCType(name);
-            } catch (IllegalArgumentException e) {
-                log.error("Invalid Ioc type, cannot be parsed.", e);
-                return null;
-            }
-        }
-
-        public IOCType getIocType() {
+        public String getIocType() {
             return iocType;
         }
 

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocSchema.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocSchema.java
@@ -1,5 +1,7 @@
 package org.opensearch.securityanalytics.threatIntel.model;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentObject;
@@ -13,7 +15,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
  * Stores the schema defined by users who upload threat intelligence in a custom format.
  */
 public abstract class IocSchema<Notation> implements Writeable, ToXContentObject {
-
+    private static final Logger log = LogManager.getLogger(IocSchema.class);
     abstract String getFormat(); // data format like json, xml, csv etc.
 
     abstract Notation getId();
@@ -57,6 +59,7 @@ public abstract class IocSchema<Notation> implements Writeable, ToXContentObject
                     schema = JsonPathIocSchema.parse(xcp);
                     break;
                 default:
+                    log.error("Unexpected ioc schema format [" + fieldName + "] found while parsing");
                     throw new IllegalStateException("Unexpected ioc schema format [" + fieldName + "] found while parsing");
             }
         }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocSchema.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocSchema.java
@@ -1,181 +1,65 @@
 package org.opensearch.securityanalytics.threatIntel.model;
 
-import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentObject;
-import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.core.xcontent.XContentParserUtils;
 
 import java.io.IOException;
 
-public class IocSchema implements Writeable, ToXContentObject {
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
-    public static final String FIELD_ID = "id";
-    public static final String FIELD_NAME = "name";
-    public static final String FIELD_TYPE = "type";
-    public static final String FIELD_VALUE = "value";
-    public static final String FIELD_SEVERITY = "severity";
-    public static final String FIELD_CREATED = "created";
-    public static final String FIELD_MODIFIED = "modified";
-    public static final String FIELD_DESCRIPTION = "description";
-    public static final String FIELD_LABELS = "labels";
-    public static final String FIELD_SPEC_VERSION = "spec_version";
+/**
+ * Stores the schema defined by users who upload threat intelligence in a custom format.
+ */
+public abstract class IocSchema<Notation> implements Writeable, ToXContentObject {
 
-    private final SchemaField id;
-    private final SchemaField name;
-    private final SchemaField type;
-    private final SchemaField value;
-    private final SchemaField severity;
-    private final SchemaField created;
-    private final SchemaField modified;
-    private final SchemaField description;
-    private final SchemaField labels;
-    private final SchemaField specVersion;
+    abstract String getFormat(); // data format like json, xml, csv etc.
 
-    public IocSchema(String idPath, String namePath, String typePath, String valuePath,
-                     String severityPath, String createdPath, String modifiedPath,
-                     String descriptionPath, String labelsPath, String specVersionPath) {
-        this.id = new SchemaField(FIELD_ID, idPath);
-        this.name = new SchemaField(FIELD_NAME, namePath);
-        this.type = new SchemaField(FIELD_TYPE, typePath);
-        this.value = new SchemaField(FIELD_VALUE, valuePath);
-        this.severity = new SchemaField(FIELD_SEVERITY, severityPath);
-        this.created = new SchemaField(FIELD_CREATED, createdPath);
-        this.modified = new SchemaField(FIELD_MODIFIED, modifiedPath);
-        this.description = new SchemaField(FIELD_DESCRIPTION, descriptionPath);
-        this.labels = new SchemaField(FIELD_LABELS, labelsPath);
-        this.specVersion = new SchemaField(FIELD_SPEC_VERSION, specVersionPath);
+    abstract Notation getId();
+
+    abstract Notation getName();
+
+    abstract Notation getType();
+
+    abstract Notation getValue();
+
+    abstract Notation getSeverity();
+
+    abstract Notation getCreated();
+
+    abstract Notation getModified();
+
+    abstract Notation getDescription();
+
+    abstract Notation getLabels();
+
+    abstract Notation getSpecVersion();
+
+    static JsonPathIocSchema readFrom(StreamInput sin) throws IOException {
+        String format = sin.readString();
+        switch (format) {
+            case JsonPathIocSchema.JSON_PATH_DATA_FORMAT:
+                return new JsonPathIocSchema(sin);
+            default:
+                throw new IllegalStateException("Unexpected ioc schema format [" + format + "] found while reading parse stream");
+        }
     }
 
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        id.writeTo(out);
-        name.writeTo(out);
-        type.writeTo(out);
-        value.writeTo(out);
-        severity.writeTo(out);
-        created.writeTo(out);
-        modified.writeTo(out);
-        description.writeTo(out);
-        labels.writeTo(out);
-        specVersion.writeTo(out);
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        builder.field(FIELD_ID, id.toXContent(builder, params));
-        builder.field(FIELD_NAME, name.toXContent(builder, params));
-        builder.field(FIELD_TYPE, type.toXContent(builder, params));
-        builder.field(FIELD_VALUE, value.toXContent(builder, params));
-        builder.field(FIELD_SEVERITY, severity.toXContent(builder, params));
-        builder.field(FIELD_CREATED, created.toXContent(builder, params));
-        builder.field(FIELD_MODIFIED, modified.toXContent(builder, params));
-        builder.field(FIELD_DESCRIPTION, description.toXContent(builder, params));
-        builder.field(FIELD_LABELS, labels.toXContent(builder, params));
-        builder.field(FIELD_SPEC_VERSION, specVersion.toXContent(builder, params));
-        return builder.endObject();
-    }
-
-    public static IocSchema parse(XContentParser parser) throws IOException {
-        String idPath = null;
-        String namePath = null;
-        String typePath = null;
-        String valuePath = null;
-        String severityPath = null;
-        String createdPath = null;
-        String modifiedPath = null;
-        String descriptionPath = null;
-        String labelsPath = null;
-        String specVersionPath = null;
-
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            String fieldName = parser.currentName();
-            parser.nextToken();
-
+    static IocSchema parse(XContentParser xcp) throws IOException {
+        IocSchema schema = null;
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
+        while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = xcp.currentName();
+            xcp.nextToken();
             switch (fieldName) {
-                case FIELD_ID:
-                    idPath = parser.text();
-                    break;
-                case FIELD_NAME:
-                    namePath = parser.text();
-                    break;
-                case FIELD_TYPE:
-                    typePath = parser.text();
-                    break;
-                case FIELD_VALUE:
-                    valuePath = parser.text();
-                    break;
-                case FIELD_SEVERITY:
-                    severityPath = parser.text();
-                    break;
-                case FIELD_CREATED:
-                    createdPath = parser.text();
-                    break;
-                case FIELD_MODIFIED:
-                    modifiedPath = parser.text();
-                    break;
-                case FIELD_DESCRIPTION:
-                    descriptionPath = parser.text();
-                    break;
-                case FIELD_LABELS:
-                    labelsPath = parser.text();
-                    break;
-                case FIELD_SPEC_VERSION:
-                    specVersionPath = parser.text();
+                case JsonPathIocSchema.JSON_PATH_DATA_FORMAT:
+                    schema = JsonPathIocSchema.parse(xcp);
                     break;
                 default:
-                    parser.skipChildren();
+                    throw new IllegalStateException("Unexpected ioc schema format [" + fieldName + "] found while parsing");
             }
         }
-
-        return new IocSchema(
-                idPath, namePath, typePath, valuePath,
-                severityPath, createdPath, modifiedPath,
-                descriptionPath, labelsPath, specVersionPath
-        );
-    }
-
-    /** Encapsulates data required to extract value for a field from data based on schema*/
-    private static class SchemaField implements Writeable, ToXContentObject {
-        private final String fieldName;
-        private final String jsonPath;
-        private final boolean isKey;
-
-        public SchemaField(String fieldName, String jsonPath) {
-            this(fieldName, jsonPath, false);
-        }
-
-        public SchemaField(String fieldName, String jsonPath, boolean isKey) {
-            this.fieldName = fieldName;
-            this.jsonPath = jsonPath;
-            this.isKey = isKey;
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(fieldName);
-            out.writeString(jsonPath);
-            out.writeBoolean(isKey);
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
-            builder.field("fieldName", fieldName);
-            builder.field("jsonPath", jsonPath);
-            builder.field("isKey", isKey);
-            return builder.endObject();
-        }
-
-        public String getJsonPath() {
-            return jsonPath;
-        }
-
-        public boolean isKey() {
-            return isKey;
-        }
+        return schema;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocSchema.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocSchema.java
@@ -1,0 +1,181 @@
+package org.opensearch.securityanalytics.threatIntel.model;
+
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.xcontent.XContentParserUtils;
+
+import java.io.IOException;
+
+public class IocSchema implements Writeable, ToXContentObject {
+
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_TYPE = "type";
+    public static final String FIELD_VALUE = "value";
+    public static final String FIELD_SEVERITY = "severity";
+    public static final String FIELD_CREATED = "created";
+    public static final String FIELD_MODIFIED = "modified";
+    public static final String FIELD_DESCRIPTION = "description";
+    public static final String FIELD_LABELS = "labels";
+    public static final String FIELD_SPEC_VERSION = "spec_version";
+
+    private final SchemaField id;
+    private final SchemaField name;
+    private final SchemaField type;
+    private final SchemaField value;
+    private final SchemaField severity;
+    private final SchemaField created;
+    private final SchemaField modified;
+    private final SchemaField description;
+    private final SchemaField labels;
+    private final SchemaField specVersion;
+
+    public IocSchema(String idPath, String namePath, String typePath, String valuePath,
+                     String severityPath, String createdPath, String modifiedPath,
+                     String descriptionPath, String labelsPath, String specVersionPath) {
+        this.id = new SchemaField(FIELD_ID, idPath);
+        this.name = new SchemaField(FIELD_NAME, namePath);
+        this.type = new SchemaField(FIELD_TYPE, typePath);
+        this.value = new SchemaField(FIELD_VALUE, valuePath);
+        this.severity = new SchemaField(FIELD_SEVERITY, severityPath);
+        this.created = new SchemaField(FIELD_CREATED, createdPath);
+        this.modified = new SchemaField(FIELD_MODIFIED, modifiedPath);
+        this.description = new SchemaField(FIELD_DESCRIPTION, descriptionPath);
+        this.labels = new SchemaField(FIELD_LABELS, labelsPath);
+        this.specVersion = new SchemaField(FIELD_SPEC_VERSION, specVersionPath);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        id.writeTo(out);
+        name.writeTo(out);
+        type.writeTo(out);
+        value.writeTo(out);
+        severity.writeTo(out);
+        created.writeTo(out);
+        modified.writeTo(out);
+        description.writeTo(out);
+        labels.writeTo(out);
+        specVersion.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(FIELD_ID, id.toXContent(builder, params));
+        builder.field(FIELD_NAME, name.toXContent(builder, params));
+        builder.field(FIELD_TYPE, type.toXContent(builder, params));
+        builder.field(FIELD_VALUE, value.toXContent(builder, params));
+        builder.field(FIELD_SEVERITY, severity.toXContent(builder, params));
+        builder.field(FIELD_CREATED, created.toXContent(builder, params));
+        builder.field(FIELD_MODIFIED, modified.toXContent(builder, params));
+        builder.field(FIELD_DESCRIPTION, description.toXContent(builder, params));
+        builder.field(FIELD_LABELS, labels.toXContent(builder, params));
+        builder.field(FIELD_SPEC_VERSION, specVersion.toXContent(builder, params));
+        return builder.endObject();
+    }
+
+    public static IocSchema parse(XContentParser parser) throws IOException {
+        String idPath = null;
+        String namePath = null;
+        String typePath = null;
+        String valuePath = null;
+        String severityPath = null;
+        String createdPath = null;
+        String modifiedPath = null;
+        String descriptionPath = null;
+        String labelsPath = null;
+        String specVersionPath = null;
+
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case FIELD_ID:
+                    idPath = parser.text();
+                    break;
+                case FIELD_NAME:
+                    namePath = parser.text();
+                    break;
+                case FIELD_TYPE:
+                    typePath = parser.text();
+                    break;
+                case FIELD_VALUE:
+                    valuePath = parser.text();
+                    break;
+                case FIELD_SEVERITY:
+                    severityPath = parser.text();
+                    break;
+                case FIELD_CREATED:
+                    createdPath = parser.text();
+                    break;
+                case FIELD_MODIFIED:
+                    modifiedPath = parser.text();
+                    break;
+                case FIELD_DESCRIPTION:
+                    descriptionPath = parser.text();
+                    break;
+                case FIELD_LABELS:
+                    labelsPath = parser.text();
+                    break;
+                case FIELD_SPEC_VERSION:
+                    specVersionPath = parser.text();
+                    break;
+                default:
+                    parser.skipChildren();
+            }
+        }
+
+        return new IocSchema(
+                idPath, namePath, typePath, valuePath,
+                severityPath, createdPath, modifiedPath,
+                descriptionPath, labelsPath, specVersionPath
+        );
+    }
+
+    /** Encapsulates data required to extract value for a field from data based on schema*/
+    private static class SchemaField implements Writeable, ToXContentObject {
+        private final String fieldName;
+        private final String jsonPath;
+        private final boolean isKey;
+
+        public SchemaField(String fieldName, String jsonPath) {
+            this(fieldName, jsonPath, false);
+        }
+
+        public SchemaField(String fieldName, String jsonPath, boolean isKey) {
+            this.fieldName = fieldName;
+            this.jsonPath = jsonPath;
+            this.isKey = isKey;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(fieldName);
+            out.writeString(jsonPath);
+            out.writeBoolean(isKey);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("fieldName", fieldName);
+            builder.field("jsonPath", jsonPath);
+            builder.field("isKey", isKey);
+            return builder.endObject();
+        }
+
+        public String getJsonPath() {
+            return jsonPath;
+        }
+
+        public boolean isKey() {
+            return isKey;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchema.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchema.java
@@ -1,0 +1,287 @@
+package org.opensearch.securityanalytics.threatIntel.model;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.xcontent.XContentParserUtils;
+
+import java.io.IOException;
+
+/**
+ * Stores the schema defined by users who upload threat intelligence in a custom format.
+ * Each field is defined and extracted using {@link com.jayway.jsonpath.JsonPath} annotation.
+ * Each field is of type {@link JsonPathSchemaField}
+ * If value of any given field is stored in format {"<key>": "<value>"}, then value of {@link JsonPathSchemaField#isKey()} field should be set as false.
+ * Else if value is stored in key itself, then value of {@link JsonPathSchemaField#isKey()} field should be set to true.
+ */
+public class JsonPathIocSchema extends IocSchema<JsonPathIocSchema.JsonPathSchemaField> {
+
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_TYPE = "type";
+    public static final String FIELD_VALUE = "value";
+    public static final String FIELD_SEVERITY = "severity";
+    public static final String FIELD_CREATED = "created";
+    public static final String FIELD_MODIFIED = "modified";
+    public static final String FIELD_DESCRIPTION = "description";
+    public static final String FIELD_LABELS = "labels";
+    public static final String FIELD_SPEC_VERSION = "spec_version";
+    public static final String JSON_PATH_DATA_FORMAT = "JSON_PATH";
+
+    private final JsonPathSchemaField id;
+    private final JsonPathSchemaField name;
+    private final JsonPathSchemaField type;
+    private final JsonPathSchemaField value;
+    private final JsonPathSchemaField severity;
+    private final JsonPathSchemaField created;
+    private final JsonPathSchemaField modified;
+    private final JsonPathSchemaField description;
+    private final JsonPathSchemaField labels;
+    private final JsonPathSchemaField specVersion;
+
+    public JsonPathIocSchema(JsonPathSchemaField id, JsonPathSchemaField name, JsonPathSchemaField type, JsonPathSchemaField value, JsonPathSchemaField severity,
+                             JsonPathSchemaField created, JsonPathSchemaField modified, JsonPathSchemaField description, JsonPathSchemaField labels,
+                             JsonPathSchemaField specVersion) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.value = value;
+        this.severity = severity;
+        this.created = created;
+        this.modified = modified;
+        this.description = description;
+        this.labels = labels;
+        this.specVersion = specVersion;
+    }
+
+    public JsonPathIocSchema(StreamInput in) throws IOException {
+        this(
+                readOptionalSchemaField(in), //id
+                readOptionalSchemaField(in), //name
+                readOptionalSchemaField(in), //type
+                readOptionalSchemaField(in), //value
+                readOptionalSchemaField(in), //severity
+                readOptionalSchemaField(in), //created
+                readOptionalSchemaField(in), //modified
+                readOptionalSchemaField(in), //description
+                readOptionalSchemaField(in), //labels
+                readOptionalSchemaField(in) //specVersion
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        writeOptionalSchemaField(id, out);
+        writeOptionalSchemaField(name, out);
+        writeOptionalSchemaField(type, out);
+        writeOptionalSchemaField(value, out);
+        writeOptionalSchemaField(severity, out);
+        writeOptionalSchemaField(created, out);
+        writeOptionalSchemaField(modified, out);
+        writeOptionalSchemaField(description, out);
+        writeOptionalSchemaField(labels, out);
+        writeOptionalSchemaField(specVersion, out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(FIELD_ID, id.toXContent(builder, params));
+        builder.field(FIELD_NAME, name.toXContent(builder, params));
+        builder.field(FIELD_TYPE, type.toXContent(builder, params));
+        builder.field(FIELD_VALUE, value.toXContent(builder, params));
+        builder.field(FIELD_SEVERITY, severity.toXContent(builder, params));
+        builder.field(FIELD_CREATED, created.toXContent(builder, params));
+        builder.field(FIELD_MODIFIED, modified.toXContent(builder, params));
+        builder.field(FIELD_DESCRIPTION, description.toXContent(builder, params));
+        builder.field(FIELD_LABELS, labels.toXContent(builder, params));
+        builder.field(FIELD_SPEC_VERSION, specVersion.toXContent(builder, params));
+        return builder.endObject();
+    }
+
+    public static JsonPathIocSchema parse(XContentParser parser) throws IOException {
+        JsonPathSchemaField idPath = null;
+        JsonPathSchemaField namePath = null;
+        JsonPathSchemaField typePath = null;
+        JsonPathSchemaField valuePath = null;
+        JsonPathSchemaField severityPath = null;
+        JsonPathSchemaField createdPath = null;
+        JsonPathSchemaField modifiedPath = null;
+        JsonPathSchemaField descriptionPath = null;
+        JsonPathSchemaField labelsPath = null;
+        JsonPathSchemaField specVersionPath = null;
+
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case FIELD_ID:
+                    idPath = JsonPathSchemaField.parse(parser);
+                    break;
+                case FIELD_NAME:
+                    namePath = JsonPathSchemaField.parse(parser);
+                    break;
+                case FIELD_TYPE:
+                    typePath = JsonPathSchemaField.parse(parser);
+                    break;
+                case FIELD_VALUE:
+                    valuePath = JsonPathSchemaField.parse(parser);
+                    break;
+                case FIELD_SEVERITY:
+                    severityPath = JsonPathSchemaField.parse(parser);
+                    break;
+                case FIELD_CREATED:
+                    createdPath = JsonPathSchemaField.parse(parser);
+                    break;
+                case FIELD_MODIFIED:
+                    modifiedPath = JsonPathSchemaField.parse(parser);
+                    break;
+                case FIELD_DESCRIPTION:
+                    descriptionPath = JsonPathSchemaField.parse(parser);
+                    break;
+                case FIELD_LABELS:
+                    labelsPath = JsonPathSchemaField.parse(parser);
+                    break;
+                case FIELD_SPEC_VERSION:
+                    specVersionPath = JsonPathSchemaField.parse(parser);
+                    break;
+                default:
+                    parser.skipChildren();
+            }
+        }
+
+        return new JsonPathIocSchema(
+                idPath, namePath, typePath, valuePath,
+                severityPath, createdPath, modifiedPath,
+                descriptionPath, labelsPath, specVersionPath
+        );
+    }
+
+    public JsonPathSchemaField getId() {
+        return id;
+    }
+
+    public JsonPathSchemaField getName() {
+        return name;
+    }
+
+    public JsonPathSchemaField getType() {
+        return type;
+    }
+
+    public JsonPathSchemaField getValue() {
+        return value;
+    }
+
+    public JsonPathSchemaField getSeverity() {
+        return severity;
+    }
+
+    public JsonPathSchemaField getCreated() {
+        return created;
+    }
+
+    public JsonPathSchemaField getModified() {
+        return modified;
+    }
+
+    public JsonPathSchemaField getDescription() {
+        return description;
+    }
+
+    public JsonPathSchemaField getLabels() {
+        return labels;
+    }
+
+    public JsonPathSchemaField getSpecVersion() {
+        return specVersion;
+    }
+
+    @Override
+    public String getFormat() {
+        return JSON_PATH_DATA_FORMAT;
+    }
+
+    private static void writeOptionalSchemaField(JsonPathSchemaField jsonPathSchemaField, StreamOutput out) throws IOException {
+        if (jsonPathSchemaField == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            jsonPathSchemaField.writeTo(out);
+        }
+    }
+
+    private static JsonPathSchemaField readOptionalSchemaField(StreamInput in) throws IOException {
+        return in.readBoolean() ? new JsonPathSchemaField(in) : null;
+    }
+
+    /**
+     * Encapsulates data required to extract value for a field from data based on schema
+     */
+    static class JsonPathSchemaField implements Writeable, ToXContentObject {
+        public static final String JSON_PATH_FIELD = "jsonPath";
+        public static final String IS_KEY_FIELD = "isKey";
+
+        private final String jsonPath;
+        private final boolean isKey;
+
+        public JsonPathSchemaField(String jsonPath, boolean isKey) {
+            this.jsonPath = jsonPath;
+            this.isKey = isKey;
+        }
+
+        public JsonPathSchemaField(StreamInput in) throws IOException {
+            this(in.readString(), in.readBoolean());
+        }
+
+        public static JsonPathSchemaField parse(XContentParser xcp) throws IOException {
+            String fieldName1 = "";
+            String jsonPath1 = "";
+            boolean isKey1 = false;
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
+            while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                String fieldName = xcp.currentName();
+                xcp.nextToken();
+
+                switch (fieldName) {
+                    case JSON_PATH_FIELD:
+                        jsonPath1 = xcp.text();
+                        break;
+                    case IS_KEY_FIELD:
+                        isKey1 = xcp.booleanValue();
+                        break;
+                    default:
+                        xcp.skipChildren();
+                }
+            }
+            return new JsonPathSchemaField(jsonPath1, isKey1);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(jsonPath);
+            out.writeBoolean(isKey);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(JSON_PATH_FIELD, jsonPath);
+            builder.field(IS_KEY_FIELD, isKey);
+            return builder.endObject();
+        }
+
+        public String getJsonPath() {
+            return jsonPath;
+        }
+
+        public boolean isKey() {
+            return isKey;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchema.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchema.java
@@ -1,5 +1,7 @@
 package org.opensearch.securityanalytics.threatIntel.model;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -18,7 +20,7 @@ import java.io.IOException;
  * Else if value is stored in key itself, then value of {@link JsonPathSchemaField#isKey()} field should be set to true.
  */
 public class JsonPathIocSchema extends IocSchema<JsonPathIocSchema.JsonPathSchemaField> {
-
+    private static final Logger log = LogManager.getLogger(JsonPathIocSchema.class);
     public static final String FIELD_ID = "id";
     public static final String FIELD_NAME = "name";
     public static final String FIELD_TYPE = "type";
@@ -89,17 +91,26 @@ public class JsonPathIocSchema extends IocSchema<JsonPathIocSchema.JsonPathSchem
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(FIELD_ID, id.toXContent(builder, params));
-        builder.field(FIELD_NAME, name.toXContent(builder, params));
-        builder.field(FIELD_TYPE, type.toXContent(builder, params));
-        builder.field(FIELD_VALUE, value.toXContent(builder, params));
-        builder.field(FIELD_SEVERITY, severity.toXContent(builder, params));
-        builder.field(FIELD_CREATED, created.toXContent(builder, params));
-        builder.field(FIELD_MODIFIED, modified.toXContent(builder, params));
-        builder.field(FIELD_DESCRIPTION, description.toXContent(builder, params));
-        builder.field(FIELD_LABELS, labels.toXContent(builder, params));
-        builder.field(FIELD_SPEC_VERSION, specVersion.toXContent(builder, params));
+        builder.startObject(JSON_PATH_DATA_FORMAT);
+        jsonPathSchemaFieldToXcontent(builder, params, id, FIELD_ID);
+        jsonPathSchemaFieldToXcontent(builder, params, name, FIELD_NAME);
+        jsonPathSchemaFieldToXcontent(builder, params, type, FIELD_TYPE);
+        jsonPathSchemaFieldToXcontent(builder, params, value, FIELD_VALUE);
+        jsonPathSchemaFieldToXcontent(builder, params, severity, FIELD_SEVERITY);
+        jsonPathSchemaFieldToXcontent(builder, params, created, FIELD_CREATED);
+        jsonPathSchemaFieldToXcontent(builder, params, modified, FIELD_MODIFIED);
+        jsonPathSchemaFieldToXcontent(builder, params, description, FIELD_DESCRIPTION);
+        jsonPathSchemaFieldToXcontent(builder, params, labels, FIELD_LABELS);
+        jsonPathSchemaFieldToXcontent(builder, params, specVersion, FIELD_SPEC_VERSION);
+        builder.endObject();
         return builder.endObject();
+    }
+
+    // performs null check before converting to Xcontent
+    private void jsonPathSchemaFieldToXcontent(XContentBuilder builder, Params params, JsonPathSchemaField jsonPathSchemaField, String fieldName) throws IOException {
+        if (jsonPathSchemaField != null) {
+            builder.field(fieldName, jsonPathSchemaField);
+        }
     }
 
     public static JsonPathIocSchema parse(XContentParser parser) throws IOException {
@@ -223,7 +234,7 @@ public class JsonPathIocSchema extends IocSchema<JsonPathIocSchema.JsonPathSchem
     /**
      * Encapsulates data required to extract value for a field from data based on schema
      */
-    static class JsonPathSchemaField implements Writeable, ToXContentObject {
+    public static class JsonPathSchemaField implements Writeable, ToXContentObject {
         public static final String JSON_PATH_FIELD = "jsonPath";
         public static final String IS_KEY_FIELD = "isKey";
 
@@ -240,7 +251,6 @@ public class JsonPathIocSchema extends IocSchema<JsonPathIocSchema.JsonPathSchem
         }
 
         public static JsonPathSchemaField parse(XContentParser xcp) throws IOException {
-            String fieldName1 = "";
             String jsonPath1 = "";
             boolean isKey1 = false;
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchema.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchema.java
@@ -4,8 +4,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
-import org.opensearch.core.common.io.stream.Writeable;
-import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
@@ -19,7 +17,7 @@ import java.io.IOException;
  * If value of any given field is stored in format  "key": "value", then value of {@link JsonPathSchemaField#isKey()} field should be set as false.
  * Else if value is stored in key itself, then value of {@link JsonPathSchemaField#isKey()} field should be set to true.
  */
-public class JsonPathIocSchema extends IocSchema<JsonPathIocSchema.JsonPathSchemaField> {
+public class JsonPathIocSchema extends IocSchema<JsonPathSchemaField> {
     private static final Logger log = LogManager.getLogger(JsonPathIocSchema.class);
     public static final String FIELD_ID = "id";
     public static final String FIELD_NAME = "name";
@@ -31,7 +29,7 @@ public class JsonPathIocSchema extends IocSchema<JsonPathIocSchema.JsonPathSchem
     public static final String FIELD_DESCRIPTION = "description";
     public static final String FIELD_LABELS = "labels";
     public static final String FIELD_SPEC_VERSION = "spec_version";
-    public static final String JSON_PATH_DATA_FORMAT = "JSON_PATH";
+    public static final String JSON_PATH_DATA_FORMAT = "json_path_schema";
 
     private final JsonPathSchemaField id;
     private final JsonPathSchemaField name;
@@ -231,67 +229,4 @@ public class JsonPathIocSchema extends IocSchema<JsonPathIocSchema.JsonPathSchem
         return in.readBoolean() ? new JsonPathSchemaField(in) : null;
     }
 
-    /**
-     * Encapsulates data required to extract value for a field from data based on schema
-     */
-    public static class JsonPathSchemaField implements Writeable, ToXContentObject {
-        public static final String JSON_PATH_FIELD = "jsonPath";
-        public static final String IS_KEY_FIELD = "isKey";
-
-        private final String jsonPath;
-        private final boolean isKey;
-
-        public JsonPathSchemaField(String jsonPath, boolean isKey) {
-            this.jsonPath = jsonPath;
-            this.isKey = isKey;
-        }
-
-        public JsonPathSchemaField(StreamInput in) throws IOException {
-            this(in.readString(), in.readBoolean());
-        }
-
-        public static JsonPathSchemaField parse(XContentParser xcp) throws IOException {
-            String jsonPath1 = "";
-            boolean isKey1 = false;
-            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
-            while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
-                String fieldName = xcp.currentName();
-                xcp.nextToken();
-
-                switch (fieldName) {
-                    case JSON_PATH_FIELD:
-                        jsonPath1 = xcp.text();
-                        break;
-                    case IS_KEY_FIELD:
-                        isKey1 = xcp.booleanValue();
-                        break;
-                    default:
-                        xcp.skipChildren();
-                }
-            }
-            return new JsonPathSchemaField(jsonPath1, isKey1);
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(jsonPath);
-            out.writeBoolean(isKey);
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
-            builder.field(JSON_PATH_FIELD, jsonPath);
-            builder.field(IS_KEY_FIELD, isKey);
-            return builder.endObject();
-        }
-
-        public String getJsonPath() {
-            return jsonPath;
-        }
-
-        public boolean isKey() {
-            return isKey;
-        }
-    }
 }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchema.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchema.java
@@ -16,7 +16,7 @@ import java.io.IOException;
  * Stores the schema defined by users who upload threat intelligence in a custom format.
  * Each field is defined and extracted using {@link com.jayway.jsonpath.JsonPath} annotation.
  * Each field is of type {@link JsonPathSchemaField}
- * If value of any given field is stored in format {"<key>": "<value>"}, then value of {@link JsonPathSchemaField#isKey()} field should be set as false.
+ * If value of any given field is stored in format  "key": "value", then value of {@link JsonPathSchemaField#isKey()} field should be set as false.
  * Else if value is stored in key itself, then value of {@link JsonPathSchemaField#isKey()} field should be set to true.
  */
 public class JsonPathIocSchema extends IocSchema<JsonPathIocSchema.JsonPathSchemaField> {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathSchemaField.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathSchemaField.java
@@ -1,0 +1,75 @@
+package org.opensearch.securityanalytics.threatIntel.model;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.xcontent.XContentParserUtils;
+
+import java.io.IOException;
+
+/**
+ * Encapsulates data required to extract value for a field from data based on schema
+ */
+public class JsonPathSchemaField implements Writeable, ToXContentObject {
+    public static final String JSON_PATH_FIELD = "json_path";
+    public static final String IS_KEY_FIELD = "is_key";
+
+    private final String jsonPath;
+    private final boolean isKey;
+
+    public JsonPathSchemaField(String jsonPath, boolean isKey) {
+        this.jsonPath = jsonPath;
+        this.isKey = isKey;
+    }
+
+    public JsonPathSchemaField(StreamInput in) throws IOException {
+        this(in.readString(), in.readBoolean());
+    }
+
+    public static JsonPathSchemaField parse(XContentParser xcp) throws IOException {
+        String jsonPath1 = "";
+        boolean isKey1 = false;
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
+        while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = xcp.currentName();
+            xcp.nextToken();
+
+            switch (fieldName) {
+                case JSON_PATH_FIELD:
+                    jsonPath1 = xcp.text();
+                    break;
+                case IS_KEY_FIELD:
+                    isKey1 = xcp.booleanValue();
+                    break;
+                default:
+                    xcp.skipChildren();
+            }
+        }
+        return new JsonPathSchemaField(jsonPath1, isKey1);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(jsonPath);
+        out.writeBoolean(isKey);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(JSON_PATH_FIELD, jsonPath);
+        builder.field(IS_KEY_FIELD, isKey);
+        return builder.endObject();
+    }
+
+    public String getJsonPath() {
+        return jsonPath;
+    }
+
+    public boolean isKey() {
+        return isKey;
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/SATIFSourceConfigDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/SATIFSourceConfigDto.java
@@ -167,7 +167,7 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
                 sin.readBoolean(), // is enabled
                 sin.readStringList(), // ioc types
                 sin.readBoolean(),
-                IocSchema.readFrom(sin)
+                sin.readBoolean() ? IocSchema.readFrom(sin) : null
         );
     }
 
@@ -207,7 +207,10 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
         out.writeBoolean(enabledForScan);
         out.writeBoolean(iocSchema != null);
         if (iocSchema != null) {
+            out.writeBoolean(true);
             iocSchema.writeTo(out);
+        } else {
+            out.writeBoolean(false);
         }
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/SATIFSourceConfigDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/SATIFSourceConfigDto.java
@@ -10,7 +10,6 @@ package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.common.UUIDs;
 import org.opensearch.commons.authuser.User;
@@ -25,8 +24,6 @@ import org.opensearch.core.xcontent.XContentParserUtils;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.jobscheduler.spi.schedule.Schedule;
 import org.opensearch.jobscheduler.spi.schedule.ScheduleParser;
-import org.opensearch.securityanalytics.model.STIX2IOC;
-import org.opensearch.securityanalytics.model.STIX2IOCDto;
 import org.opensearch.securityanalytics.threatIntel.common.SourceConfigType;
 import org.opensearch.securityanalytics.threatIntel.common.RefreshType;
 import org.opensearch.securityanalytics.threatIntel.common.TIFJobState;
@@ -38,7 +35,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 /**
  * Implementation of TIF Config Dto to store the source configuration metadata as DTO object
@@ -72,6 +68,7 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
     public static final String LAST_REFRESHED_USER_FIELD = "last_refreshed_user";
     public static final String ENABLED_FIELD = "enabled";
     public static final String IOC_TYPES_FIELD = "ioc_types";
+    public static final String IOC_SCHEMA_FIELD = "ioc_schema";
 
     private String id;
     private Long version;
@@ -92,6 +89,7 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
     private Boolean isEnabled;
     private List<String> iocTypes;
     private final boolean enabledForScan;
+    private final IocSchema iocSchema;
 
     public SATIFSourceConfigDto(SATIFSourceConfig saTifSourceConfig) {
         this.id = saTifSourceConfig.getId();
@@ -113,17 +111,12 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
         this.isEnabled = saTifSourceConfig.isEnabled();
         this.iocTypes = saTifSourceConfig.getIocTypes();
         this.enabledForScan = saTifSourceConfig.isEnabledForScan();
-    }
-
-    private List<STIX2IOCDto> convertToIocDtos(List<STIX2IOC> stix2IocList) {
-        return stix2IocList.stream()
-                .map(STIX2IOCDto::new)
-                .collect(Collectors.toList());
+        this.iocSchema = saTifSourceConfig.getIocSchema();
     }
 
     public SATIFSourceConfigDto(String id, Long version, String name, String format, SourceConfigType type, String description, User createdByUser, Instant createdAt, Source source,
                                 Instant enabledTime, Instant lastUpdateTime, Schedule schedule, TIFJobState state, RefreshType refreshType, Instant lastRefreshedTime, User lastRefreshedUser,
-                                boolean isEnabled, List<String> iocTypes, boolean enabledForScan) {
+                                boolean isEnabled, List<String> iocTypes, boolean enabledForScan, IocSchema iocSchema) {
         this.id = id == null ? UUIDs.base64UUID() : id;
         this.version = version != null ? version : NO_VERSION;
         this.name = name;
@@ -133,7 +126,7 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
         this.createdByUser = createdByUser;
         this.source = source;
         this.createdAt = createdAt != null ? createdAt : Instant.now();
-
+        this.iocSchema = iocSchema;
         if (isEnabled && enabledTime == null) {
             this.enabledTime = Instant.now();
         } else if (!isEnabled) {
@@ -173,7 +166,8 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
                 sin.readBoolean() ? new User(sin) : null, // last refreshed user
                 sin.readBoolean(), // is enabled
                 sin.readStringList(), // ioc types
-                sin.readBoolean()
+                sin.readBoolean(),
+                IocSchema.readFrom(sin)
         );
     }
 
@@ -211,6 +205,10 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
         out.writeBoolean(isEnabled);
         out.writeStringCollection(iocTypes);
         out.writeBoolean(enabledForScan);
+        out.writeBoolean(iocSchema != null);
+        if (iocSchema != null) {
+            iocSchema.writeTo(out);
+        }
     }
 
     @Override
@@ -237,6 +235,12 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
             builder.nullField(SOURCE_FIELD);
         } else {
             builder.field(SOURCE_FIELD, source);
+        }
+
+        if (iocSchema == null) {
+            builder.nullField(IOC_SCHEMA_FIELD);
+        } else {
+            builder.field(IOC_SCHEMA_FIELD, iocSchema);
         }
 
         if (createdAt == null) {
@@ -317,6 +321,7 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
         boolean isEnabled = true;
         List<String> iocTypes = new ArrayList<>();
         boolean enabledForScan = true;
+        IocSchema iocSchema = null;
 
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -375,6 +380,13 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
                         source = null;
                     } else {
                         source = Source.parse(xcp);
+                    }
+                    break;
+                case IOC_SCHEMA_FIELD:
+                    if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        iocSchema = null;
+                    } else {
+                        iocSchema = IocSchema.parse(xcp);
                     }
                     break;
                 case ENABLED_TIME_FIELD:
@@ -477,7 +489,8 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
                 lastRefreshedUser,
                 isEnabled,
                 iocTypes,
-                enabledForScan
+                enabledForScan,
+                iocSchema
         );
     }
 
@@ -640,6 +653,10 @@ public class SATIFSourceConfigDto implements Writeable, ToXContentObject, TIFSou
 
     public boolean isEnabled() {
         return this.isEnabled;
+    }
+
+    public IocSchema getIocSchema() {
+        return iocSchema;
     }
 
     /**

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/Source.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/Source.java
@@ -22,6 +22,7 @@ public abstract class Source {
     abstract String name();
     public static final String S3_FIELD = "s3";
     public static final String IOC_UPLOAD_FIELD = "ioc_upload";
+    public static final String CUSTOM_SCHEMA_IOC_UPLOAD_FIELD = "custom_schema_ioc_upload";
     public static final String URL_DOWNLOAD_FIELD = "url_download";
 
     static Source readFrom(StreamInput sin) throws IOException {
@@ -31,6 +32,8 @@ public abstract class Source {
                 return new S3Source(sin);
             case IOC_UPLOAD:
                 return new IocUploadSource(sin);
+            case CUSTOM_SCHEMA_IOC_UPLOAD:
+                return new CustomSchemaIocUploadSource(sin);
             case URL_DOWNLOAD:
                 return new UrlDownloadSource(sin);
             default:
@@ -51,6 +54,9 @@ public abstract class Source {
                     break;
                 case IOC_UPLOAD_FIELD:
                     source = IocUploadSource.parse(xcp);
+                    break;
+                case CUSTOM_SCHEMA_IOC_UPLOAD_FIELD:
+                    source = CustomSchemaIocUploadSource.parse(xcp);
                     break;
                 case URL_DOWNLOAD_FIELD:
                     source = UrlDownloadSource.parse(xcp);
@@ -73,7 +79,9 @@ public abstract class Source {
 
         IOC_UPLOAD(),
 
-        URL_DOWNLOAD();
+        URL_DOWNLOAD(),
+
+        CUSTOM_SCHEMA_IOC_UPLOAD();
 
         @Override
         public String toString() {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/CustomIocSchemaThreatIntelHandler.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/CustomIocSchemaThreatIntelHandler.java
@@ -7,7 +7,6 @@ import com.jayway.jsonpath.Option;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.model.STIX2IOC;
 import org.opensearch.securityanalytics.threatIntel.model.CustomSchemaIocUploadSource;
 import org.opensearch.securityanalytics.threatIntel.model.JsonPathIocSchema;
@@ -105,10 +104,6 @@ public class CustomIocSchemaThreatIntelHandler {
                         log.error("Skipping parsing some iocs since type is blank in threat intel source " + saTifSourceConfig.getName());
                         continue;
                     }
-                    if (false == IOCType.supportedType(type)) {
-                        log.error("Skipping parsing some iocs since type {} is blank in threat intel source {}", type, saTifSourceConfig.getName());
-                        continue;
-                    }
                     for (String value : valsList) {
                         if (!isBlank(value)) {
                             parsedTuples.add(new Tuple<>(type, value));
@@ -145,11 +140,11 @@ public class CustomIocSchemaThreatIntelHandler {
     }
 
     private static STIX2IOC getStix2IOC(SATIFSourceConfig saTifSourceConfig, Tuple<String, String> it) {
-        IOCType iocType = new IOCType(it.v1());
+
         return new STIX2IOC(
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
-                iocType,
+                it.v1(),
                 it.v2(),
                 "",
                 null,

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/CustomIocSchemaThreatIntelHandler.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/CustomIocSchemaThreatIntelHandler.java
@@ -82,6 +82,10 @@ public class CustomIocSchemaThreatIntelHandler {
             if (typesList.size() == 1 && false == isBlank(typesList.get(0).toString()) && valuesList.size() > 1) { // handle case where iocs json looks
                 for (int i = 0; i < valuesList.size(); i++) {
                     List<String> valsList = handleIocValueFieldParsing(valuesList, i);
+                    if (typesList.get(i) == null) {
+                        log.error("Skipping parsing some iocs since type is null in threat intel source " + saTifSourceConfig.getName());
+                        continue;
+                    }
                     String type = String.valueOf(typesList.get(0));
                     if (isBlank(type)) {
                         log.error("Skipping parsing some iocs since type is blank in threat intel source " + saTifSourceConfig.getName());
@@ -97,6 +101,7 @@ public class CustomIocSchemaThreatIntelHandler {
                 for (int i = 0; i < Math.min(valuesList.size(), typesList.size()); i++) { // since we are building tuples manually from json annotation we will assume 1:1 mapping of ioc type ot ioc value
                     List<String> valsList = handleIocValueFieldParsing(valuesList, i);
                     if (typesList.get(i) == null) {
+                        log.error("Skipping parsing some iocs since type is null in threat intel source " + saTifSourceConfig.getName());
                         continue;
                     }
                     String type = String.valueOf(typesList.get(i));

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/CustomIocSchemaThreatIntelHandler.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/CustomIocSchemaThreatIntelHandler.java
@@ -1,0 +1,167 @@
+package org.opensearch.securityanalytics.threatIntel.service;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.securityanalytics.commons.model.IOCType;
+import org.opensearch.securityanalytics.model.STIX2IOC;
+import org.opensearch.securityanalytics.threatIntel.model.CustomSchemaIocUploadSource;
+import org.opensearch.securityanalytics.threatIntel.model.JsonPathIocSchema;
+import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+import static org.apache.logging.log4j.util.Strings.isBlank;
+
+public class CustomIocSchemaThreatIntelHandler {
+    public static final Logger log = LogManager.getLogger(CustomIocSchemaThreatIntelHandler.class);
+
+    /**
+     * Parses the Iocs based on the JsonPath notation in {@link SATIFSourceConfig#getIocSchema()}
+     * and extracts iocs from the JSON string {@link CustomSchemaIocUploadSource#getIocs()}
+     * <p>
+     * Method can support parsing two types of variations:
+     * values and types are tuples i.e. there are equal number of tuples
+     *
+     * @return
+     */
+    public static List<STIX2IOC> parseCustomSchema(SATIFSourceConfig saTifSourceConfig) {
+        //TODO handle s3 download
+        CustomSchemaIocUploadSource source = (CustomSchemaIocUploadSource) saTifSourceConfig.getSource();
+        if (isBlank(source.getIocs())) {
+            log.error("Ioc Schema set as null when creating {} source config name {}.",
+                    saTifSourceConfig.getType(), saTifSourceConfig.getName()
+            );
+            throw new IllegalArgumentException(String.format(saTifSourceConfig.getName(), "Iocs cannot be empty when creating/updating %s source config."));
+
+        }
+        if (saTifSourceConfig.getIocSchema() == null) {
+            log.error("Ioc Schema set as null when creating {} source config [{}].",
+                    saTifSourceConfig.getType(), saTifSourceConfig.getName()
+            );
+            throw new IllegalArgumentException(String.format("Iocs cannot be null or empty when creating %s source config.", saTifSourceConfig.getName()));
+        }
+        JsonPathIocSchema iocSchema = (JsonPathIocSchema) saTifSourceConfig.getIocSchema();
+        if (iocSchema.getValue() == null || isBlank(iocSchema.getValue().getJsonPath())
+                || iocSchema.getType() == null || isBlank(iocSchema.getType().getJsonPath())
+        ) {
+            log.error("Custom Format Ioc Schema is missing the json path notation to extract ioc 'value' and/or" +
+                            "ioc 'type' when parsing indicators from custom format threat intel source {}.",
+                    saTifSourceConfig.getName()
+            );
+            throw new IllegalArgumentException(String.format("Custom Ioc Schema jsonPath notation for ioc 'value' and/or ioc 'type' cannot be blank"));
+        }
+        String iocs = source.getIocs();
+        Configuration conf = Configuration.defaultConfiguration()
+                .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL)
+                .addOptions(Option.ALWAYS_RETURN_LIST)
+                .addOptions(Option.SUPPRESS_EXCEPTIONS);
+        List<Tuple<String, String>> parsedTuples = new ArrayList<>();
+
+        try {
+            // Try to read as lists first
+            // Use DocumentContext to parse the JSON once
+            DocumentContext context = JsonPath.using(conf).parse(iocs);
+            List<Object> valuesList = context.read(iocSchema.getValue().getJsonPath());
+            List<Object> typesList = context.read(iocSchema.getType().getJsonPath());
+
+            if (typesList.isEmpty() || typesList.stream().allMatch(Objects::isNull)) {
+                throw new IllegalArgumentException("No valid ioc type parsed from custom schema threat intel source" + saTifSourceConfig.getName());
+            } else if (valuesList.isEmpty() || valuesList.stream().allMatch(Objects::isNull)) {
+                throw new IllegalArgumentException("No valid ioc value parsed from custom schema threat intel source" + saTifSourceConfig.getName());
+            }
+            // Handle case where we get lists of values and one type
+            if (typesList.size() == 1 && false == isBlank(typesList.get(0).toString()) && valuesList.size() > 1) { // handle case where iocs json looks
+                for (int i = 0; i < valuesList.size(); i++) {
+                    List<String> valsList = handleIocValueFieldParsing(valuesList, i);
+                    String type = String.valueOf(typesList.get(0));
+                    if (isBlank(type)) {
+                        log.error("Skipping parsing some iocs since type is blank in threat intel source " + saTifSourceConfig.getName());
+                        continue;
+                    }
+                    for (String value : valsList) {
+                        if (!isBlank(value)) {
+                            parsedTuples.add(new Tuple<>(type, value));
+                        }
+                    }
+                }
+            } else {
+                for (int i = 0; i < Math.min(valuesList.size(), typesList.size()); i++) { // since we are building tuples manually from json annotation we will assume 1:1 mapping of ioc type ot ioc value
+                    List<String> valsList = handleIocValueFieldParsing(valuesList, i);
+                    if (typesList.get(i) == null) {
+                        continue;
+                    }
+                    String type = String.valueOf(typesList.get(i));
+                    if (isBlank(type)) {
+                        log.error("Skipping parsing some iocs since type is blank in threat intel source " + saTifSourceConfig.getName());
+                        continue;
+                    }
+                    if (false == IOCType.supportedType(type)) {
+                        log.error("Skipping parsing some iocs since type {} is blank in threat intel source {}", type, saTifSourceConfig.getName());
+                        continue;
+                    }
+                    for (String value : valsList) {
+                        if (!isBlank(value)) {
+                            parsedTuples.add(new Tuple<>(type, value));
+                        }
+                    }
+                }
+            }
+
+        } catch (Exception ex) {
+            log.error(String.format("Unexpected failure while parsing custom ioc schema threat intel source %s", saTifSourceConfig.getName()), ex);
+            throw new IllegalArgumentException("Failed to parse threat intel ioc JSON with provided paths for source " + saTifSourceConfig.getName(), ex);
+        }
+
+        if (parsedTuples.isEmpty()) {
+            log.error("No valid IOCs found while parsing custom ioc schema threat intel source " + saTifSourceConfig.getName());
+            throw new IllegalArgumentException("No valid IOCs found while parsing custom ioc schema threat intel source " + saTifSourceConfig.getName());
+        }
+
+        return parsedTuples.stream().map(it -> getStix2IOC(saTifSourceConfig, it)).collect(Collectors.toList());
+    }
+
+    /**
+     * Handle Ioc Value being an array or single field
+     */
+    private static List<String> handleIocValueFieldParsing(List<Object> valuesList, int i) {
+        List<String> valsList = new ArrayList<>();
+        if (valuesList.get(i) instanceof List) { // handle case where the value is a list of ioc-values encompassed in an array like "<value>" : ["1.2.3.4", "0.0.0.0"]
+            valsList.addAll(((List<String>) valuesList.get(i)));
+        } else if (valuesList.get(i) instanceof String) {  // handle case where the value is a string with a single ioc-value  like "<value>" : "1.2.3.4"
+            String value = String.valueOf(valuesList.get(i));
+            valsList.add(value);
+        }
+        return valsList;
+    }
+
+    private static STIX2IOC getStix2IOC(SATIFSourceConfig saTifSourceConfig, Tuple<String, String> it) {
+        IOCType iocType = new IOCType(it.v1());
+        return new STIX2IOC(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                iocType,
+                it.v2(),
+                "",
+                null,
+                null,
+                "",
+                emptyList(),
+                "",
+                isBlank(saTifSourceConfig.getId()) ? null : saTifSourceConfig.getId(),
+                saTifSourceConfig.getName(),
+                1L
+        );
+    }
+
+
+}

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/DefaultTifSourceConfigLoaderService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/DefaultTifSourceConfigLoaderService.java
@@ -145,7 +145,8 @@ public class DefaultTifSourceConfigLoaderService {
                                 null,
                                 true,
                                 List.of(iocType),
-                                true
+                                true,
+                                null
                         ),
                         null,
                         RestRequest.Method.POST,

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -220,24 +220,12 @@ public class SATIFSourceConfigManagementService {
     // TODO move to CustomSchemaThreatIntelSourceHandler class
 
     private void saveLocalUploadedIocs(SATIFSourceConfig saTifSourceConfig, List<STIX2IOC> stix2IOCList, ActionListener<STIX2IOCFetchService.STIX2IOCFetchResponse> actionListener) {
-        List<STIX2IOC> validStix2IocList = new ArrayList<>();
-        // If the IOC received is not a type listed for the config, do not add it to the queue
-        for (STIX2IOC stix2IOC : stix2IOCList) {
-            if (saTifSourceConfig.getIocTypes().contains(stix2IOC.getType().toString())) {
-                validStix2IocList.add(stix2IOC);
-            } else {
-                log.error("{} is not a supported Ioc type for threat intel source config {}. Skipping IOC {}: of type {} value {}",
-                        stix2IOC.getType().toString(), saTifSourceConfig.getId(),
-                        stix2IOC.getId(), stix2IOC.getType().toString(), stix2IOC.getValue()
-                );
-            }
-        }
-        if (validStix2IocList.isEmpty()) {
+        if (stix2IOCList.isEmpty()) {
             log.error("No supported IOCs to index");
             actionListener.onFailure(SecurityAnalyticsException.wrap(new OpenSearchStatusException("No compatible Iocs were uploaded for threat intel source config " + saTifSourceConfig.getName(), RestStatus.BAD_REQUEST)));
             return;
         }
-        stix2IOCFetchService.onlyIndexIocs(saTifSourceConfig, validStix2IocList, actionListener);
+        stix2IOCFetchService.onlyIndexIocs(saTifSourceConfig, stix2IOCList, actionListener);
     }
 
     public void getTIFSourceConfig(

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -252,7 +252,6 @@ public class SATIFSourceConfigManagementService {
             throw new IllegalArgumentException(String.format("Custom Ioc Schema jsonPath notation for ioc 'value' and/or ioc 'type' cannot be blank in source [%s]", saTifSourceConfig.getName()));
         }
     }
-    // TODO move to CustomSchemaThreatIntelSourceHandler class
 
     private void saveLocalUploadedIocs(SATIFSourceConfig saTifSourceConfig, List<STIX2IOC> stix2IOCList, ActionListener<STIX2IOCFetchService.STIX2IOCFetchResponse> actionListener) {
         if (stix2IOCList.isEmpty()) {
@@ -260,6 +259,7 @@ public class SATIFSourceConfigManagementService {
             actionListener.onFailure(SecurityAnalyticsException.wrap(new OpenSearchStatusException("No compatible Iocs were uploaded for threat intel source config " + saTifSourceConfig.getName(), RestStatus.BAD_REQUEST)));
             return;
         }
+        saTifSourceConfig.setIocTypes(new ArrayList<>(stix2IOCList.stream().map(STIX2IOC::getType).collect(Collectors.toSet())));
         stix2IOCFetchService.onlyIndexIocs(saTifSourceConfig, stix2IOCList, actionListener);
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -304,7 +304,8 @@ public class SATIFSourceConfigManagementService {
                                     isEnabled,
                                     retrievedSaTifSourceConfig.getIocStoreConfig(),
                                     retrievedSaTifSourceConfig.getIocTypes(),
-                                    saTifSourceConfigDto.isEnabledForScan() // update only enabled_for_scan
+                                    saTifSourceConfigDto.isEnabledForScan(), // update only enabled_for_scan
+                                    saTifSourceConfigDto.getIocSchema()
                             );
                             internalUpdateTIFSourceConfig(config, ActionListener.wrap(
                                     r -> {
@@ -760,7 +761,8 @@ public class SATIFSourceConfigManagementService {
                 saTifSourceConfigDto.isEnabled(),
                 iocStoreConfig,
                 new ArrayList<>(iocTypes),
-                saTifSourceConfigDto.isEnabledForScan()
+                saTifSourceConfigDto.isEnabledForScan(),
+                saTifSourceConfigDto.getIocSchema()
         );
     }
 
@@ -787,7 +789,8 @@ public class SATIFSourceConfigManagementService {
                     saTifSourceConfig.isEnabled(),
                     saTifSourceConfig.getIocStoreConfig(),
                     saTifSourceConfig.getIocTypes(),
-                    saTifSourceConfigDto.isEnabledForScan()
+                    saTifSourceConfigDto.isEnabledForScan(),
+                    saTifSourceConfigDto.getIocSchema()
             );
         }
         if (false == saTifSourceConfig.getSource().getClass().equals(saTifSourceConfigDto.getSource().getClass())) {
@@ -815,7 +818,8 @@ public class SATIFSourceConfigManagementService {
                 saTifSourceConfigDto.isEnabled(),
                 saTifSourceConfig.getIocStoreConfig(),
                 new ArrayList<>(iocTypes),
-                saTifSourceConfigDto.isEnabledForScan()
+                saTifSourceConfigDto.isEnabledForScan(),
+                saTifSourceConfigDto.getIocSchema()
         );
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
@@ -174,7 +174,8 @@ public class SATIFSourceConfigService {
                 saTifSourceConfig.isEnabled(),
                 saTifSourceConfig.getIocStoreConfig(),
                 saTifSourceConfig.getIocTypes(),
-                saTifSourceConfig.isEnabledForScan()
+                saTifSourceConfig.isEnabledForScan(),
+                saTifSourceConfig.getIocSchema()
         );
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
@@ -47,7 +47,6 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
-import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.threatIntel.action.monitor.SearchThreatIntelMonitorAction;
 import org.opensearch.securityanalytics.threatIntel.action.monitor.request.SearchThreatIntelMonitorRequest;
 import org.opensearch.securityanalytics.threatIntel.common.TIFLockService;
@@ -636,7 +635,7 @@ public class SATIFSourceConfigService {
                             DefaultIocStoreConfig iocStoreConfig = (DefaultIocStoreConfig) config.getIocStoreConfig();
                             for (DefaultIocStoreConfig.IocToIndexDetails iocToindexDetails : iocStoreConfig.getIocToIndexDetails()) {
                                 String activeIndex = iocToindexDetails.getActiveIndex();
-                                IOCType iocType = iocToindexDetails.getIocType();
+                                String iocType = iocToindexDetails.getIocType();
                                 List<String> strings = cumulativeIocTypeToIndices.computeIfAbsent(iocType.toString(), k -> new ArrayList<>());
                                 strings.add(activeIndex);
                             }

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelMonitorUtils.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelMonitorUtils.java
@@ -1,7 +1,5 @@
 package org.opensearch.securityanalytics.threatIntel.util;
 
-import org.opensearch.common.xcontent.LoggingDeprecationHandler;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.alerting.model.Alert;
 import org.opensearch.commons.alerting.model.Monitor;
 import org.opensearch.commons.alerting.model.Trigger;
@@ -10,12 +8,8 @@ import org.opensearch.commons.alerting.model.remote.monitors.RemoteMonitorTrigge
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.core.xcontent.ToXContent;
-import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.securityanalytics.model.threatintel.IocFinding;
 import org.opensearch.securityanalytics.model.threatintel.ThreatIntelAlert;
@@ -175,7 +169,7 @@ public class ThreatIntelMonitorUtils {
             boolean iocTypeConditionMatch = false;
             if (threatIntelTrigger.getIocTypes() == null || threatIntelTrigger.getIocTypes().isEmpty()) {
                 iocTypeConditionMatch = true;
-            } else if (threatIntelTrigger.getIocTypes().contains(iocFinding.getIocType().toLowerCase())) {
+            } else if (threatIntelTrigger.getIocTypes().contains(iocFinding.getIocType())) {
                 iocTypeConditionMatch = true;
             }
             boolean dataSourcesConditionMatch = false;

--- a/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
+++ b/src/test/java/org/opensearch/securityanalytics/SecurityAnalyticsRestTestCase.java
@@ -83,7 +83,10 @@ import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -2344,5 +2347,16 @@ public class SecurityAnalyticsRestTestCase extends OpenSearchRestTestCase {
         public String windowsIndex;
         public String appLogsIndex;
         public String s3AccessLogsIndex;
+    }
+
+    public String readResource(String name) throws IOException {
+        try (InputStream inputStream = SecurityAnalyticsPlugin.class.getClassLoader().getResourceAsStream(name)) {
+            if (inputStream == null) {
+                throw new IOException("Resource not found: " + name);
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+                return reader.lines().collect(Collectors.joining("\n"));
+            }
+        }
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -2897,7 +2897,8 @@ public class TestHelpers {
                 lastRefreshedUser,
                 isEnabled,
                 iocTypes,
-                true
+                true,
+                null
         );
     }
 
@@ -2987,7 +2988,8 @@ public class TestHelpers {
                 isEnabled,
                 iocStoreConfig,
                 iocTypes,
-                true
+                true,
+                null
         );
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -2962,7 +2962,7 @@ public class TestHelpers {
             schedule = new org.opensearch.jobscheduler.spi.schedule.IntervalSchedule(Instant.now(), 1, ChronoUnit.DAYS);
         }
         if (iocStoreConfig == null) {
-            iocStoreConfig = new DefaultIocStoreConfig(List.of(new DefaultIocStoreConfig.IocToIndexDetails(new IOCType(IOCType.DOMAIN_NAME_TYPE), "indexPattern", "writeIndex")));
+            iocStoreConfig = new DefaultIocStoreConfig(List.of(new DefaultIocStoreConfig.IocToIndexDetails(IOCType.DOMAIN_NAME_TYPE, "indexPattern", "writeIndex")));
         }
         if (iocTypes == null) {
             iocTypes = List.of("ip");

--- a/src/test/java/org/opensearch/securityanalytics/action/GetTIFSourceConfigResponseTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/GetTIFSourceConfigResponseTests.java
@@ -54,7 +54,8 @@ public class GetTIFSourceConfigResponseTests extends OpenSearchTestCase {
                 null,
                 false,
                 iocTypes,
-                true
+                true,
+                null
         );
 
         SAGetTIFSourceConfigResponse response = new SAGetTIFSourceConfigResponse(saTifSourceConfigDto.getId(), saTifSourceConfigDto.getVersion(), RestStatus.OK, saTifSourceConfigDto);

--- a/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigRequestTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigRequestTests.java
@@ -56,7 +56,8 @@ public class IndexTIFSourceConfigRequestTests extends OpenSearchTestCase {
                 null,
                 false,
                 null,
-                true
+                true,
+                null
         );
         String id = saTifSourceConfigDto.getId();
         SAIndexTIFSourceConfigRequest request = new SAIndexTIFSourceConfigRequest(id, RestRequest.Method.POST, saTifSourceConfigDto);

--- a/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigRequestTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigRequestTests.java
@@ -64,11 +64,10 @@ public class IndexTIFSourceConfigRequestTests extends OpenSearchTestCase {
         Assert.assertNotNull(request);
 
         ActionRequestValidationException exception = request.validate();
-        assertEquals(5, exception.validationErrors().size());
+        assertEquals(4, exception.validationErrors().size());
         assertTrue(exception.validationErrors().contains("Name must not be empty"));
         assertTrue(exception.validationErrors().contains("Format must not be empty"));
         assertTrue(exception.validationErrors().contains("Source must not be empty"));
-        assertTrue(exception.validationErrors().contains("Must specify at least one IOC type"));
         assertTrue(exception.validationErrors().contains("Type must not be empty"));
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigResponseTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigResponseTests.java
@@ -50,7 +50,8 @@ public class IndexTIFSourceConfigResponseTests extends OpenSearchTestCase {
                 null,
                 false,
                 iocTypes,
-                true
+                true,
+                null
         );
 
         SAIndexTIFSourceConfigResponse response = new SAIndexTIFSourceConfigResponse(saTifSourceConfigDto.getId(), saTifSourceConfigDto.getVersion(), RestStatus.OK, saTifSourceConfigDto);

--- a/src/test/java/org/opensearch/securityanalytics/alerts/AlertsIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/alerts/AlertsIT.java
@@ -808,7 +808,7 @@ public class AlertsIT extends SecurityAnalyticsRestTestCase {
 
         Response createMappingResponse = client().performRequest(createMappingRequest);
 
-        assertEquals(org.apache.http.HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
+        assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
 
         String infoOpCode = "Info";
 
@@ -972,7 +972,7 @@ public class AlertsIT extends SecurityAnalyticsRestTestCase {
 
         Response createMappingResponse = client().performRequest(createMappingRequest);
 
-        assertEquals(org.apache.http.HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
+        assertEquals(HttpStatus.SC_OK, createMappingResponse.getStatusLine().getStatusCode());
 
         String infoOpCode = "Info";
         /** 1st agg rule*/

--- a/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
@@ -1549,17 +1549,6 @@ public class MapperRestApiIT extends SecurityAnalyticsRestTestCase {
 
     private final String DNS_MAPPINGS = "OSMapping/dns_logtype.json";
 
-    private String readResource(String name) throws IOException {
-        try (InputStream inputStream = SecurityAnalyticsPlugin.class.getClassLoader().getResourceAsStream(name)) {
-            if (inputStream == null) {
-                throw new IOException("Resource not found: " + name);
-            }
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
-                return reader.lines().collect(Collectors.joining("\n"));
-            }
-        }
-    }
-
     public void testReadResource() throws IOException {
         String content = readResource(DNS_SAMPLE);
         assertTrue(content.contains("query_type"));

--- a/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigDtoTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigDtoTests.java
@@ -61,7 +61,8 @@ public class SATIFSourceConfigDtoTests extends OpenSearchTestCase {
                 null,
                 true,
                 List.of("ip"),
-                true
+                true,
+                null
         );
         String json = toJsonString(saTifSourceConfigDto);
         SATIFSourceConfigDto newSaTifSourceConfigDto = SATIFSourceConfigDto.parse(getParser(json), saTifSourceConfigDto.getId(), null);

--- a/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigTests.java
@@ -64,7 +64,8 @@ public class SATIFSourceConfigTests extends OpenSearchTestCase {
                 true,
                 new DefaultIocStoreConfig(List.of(new DefaultIocStoreConfig.IocToIndexDetails(new IOCType(IOCType.DOMAIN_NAME_TYPE), "indexPattern", "writeIndex"))),
                 List.of("ip"),
-                true
+                true,
+                null
         );
         String json = toJsonString(saTifSourceConfig);
         SATIFSourceConfig newSaTifSourceConfig = SATIFSourceConfig.parse(getParser(json), saTifSourceConfig.getId(), null);

--- a/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigTests.java
@@ -62,7 +62,7 @@ public class SATIFSourceConfigTests extends OpenSearchTestCase {
                 null,
                 null,
                 true,
-                new DefaultIocStoreConfig(List.of(new DefaultIocStoreConfig.IocToIndexDetails(new IOCType(IOCType.DOMAIN_NAME_TYPE), "indexPattern", "writeIndex"))),
+                new DefaultIocStoreConfig(List.of(new DefaultIocStoreConfig.IocToIndexDetails(IOCType.DOMAIN_NAME_TYPE, "indexPattern", "writeIndex"))),
                 List.of("ip"),
                 true,
                 null

--- a/src/test/java/org/opensearch/securityanalytics/model/STIX2IOCDtoTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/STIX2IOCDtoTests.java
@@ -7,9 +7,7 @@ package org.opensearch.securityanalytics.model;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.securityanalytics.commons.model.IOCType;
-import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -36,25 +34,16 @@ public class STIX2IOCDtoTests extends OpenSearchTestCase {
         assertEqualIocDtos(ioc, newIoc);
     }
 
-    public void testParseFunction_invalidType() throws IOException {
+    public void testParseFunction_customType() throws IOException {
         // Execute test case for each IOCType
         for (String type : IOCType.types) {
-            STIX2IOCDto ioc = randomIocDto(new IOCType(type));
+            STIX2IOCDto ioc = randomIocDto(type);
             String json = toJsonString(ioc);
 
             // Replace the IOCType with a fake type
             String fakeType = "fake" + type;
             final String invalidJson = json.replace(type, fakeType);
-
-            SecurityAnalyticsException exception = assertThrows(SecurityAnalyticsException.class, () -> STIX2IOCDto.parse(parser(invalidJson), ioc.getId(), ioc.getVersion()));
-            assertEquals(RestStatus.BAD_REQUEST, exception.status());
-
-            String expectedError = String.format(
-                    "Couldn't parse IOC type '%s' while deserializing STIX2IOCDto with ID '%s': ",
-                    fakeType,
-                    ioc.getId()
-            );
-            assertTrue(exception.getMessage().contains(expectedError));
+            STIX2IOCDto.parse(parser(invalidJson), ioc.getId(), ioc.getVersion());
         }
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/model/STIX2IOCTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/STIX2IOCTests.java
@@ -36,25 +36,18 @@ public class STIX2IOCTests extends OpenSearchTestCase {
         assertEqualIOCs(ioc, newIoc);
     }
 
-    public void testParseFunction_invalidType() throws IOException {
+    public void testParseFunction_customType() throws IOException {
         // Execute test case for each IOCType
         for (String type : IOCType.types) {
-            STIX2IOC ioc = randomIOC(new IOCType(type));
+            STIX2IOC ioc = randomIOC(type);
             String json = toJsonString(ioc);
 
             // Replace the IOCType with a fake type
             String fakeType = "fake" + type;
             final String invalidJson = json.replace(type, fakeType);
 
-            SecurityAnalyticsException exception = assertThrows(SecurityAnalyticsException.class, () -> STIX2IOC.parse(parser(invalidJson), ioc.getId(), ioc.getVersion()));
-            assertEquals(RestStatus.BAD_REQUEST, exception.status());
-
-            String expectedError = String.format(
-                    "Couldn't parse IOC type '%s' while deserializing STIX2IOC with ID '%s': ",
-                    fakeType,
-                    ioc.getId()
-            );
-            assertTrue(exception.getMessage().contains(expectedError));
+            STIX2IOC parsedIoc = STIX2IOC.parse(parser(invalidJson), ioc.getId(), ioc.getVersion());
+            assertEquals(parsedIoc.getType(), fakeType);
         }
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/model/XContentTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/XContentTests.java
@@ -6,6 +6,13 @@ package org.opensearch.securityanalytics.model;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 import org.junit.Assert;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.ToXContent;
@@ -202,5 +209,14 @@ public class XContentTests extends OpenSearchTestCase {
         String tifdString = toJsonString(tifd);
         ThreatIntelFeedData parsedTifd = ThreatIntelFeedData.parse(parser(tifdString), null, null);
         Assert.assertEquals("Round tripping Threat intel feed data model doesn't work", tifd, parsedTifd);
+    }
+
+    public void testSimpleValueExtraction() {
+        String json = "{ \"store\": { \"book\": [ { \"category\": \"reference\", \"author\": \"Nigel Rees\", \"title\": \"Sayings of the Century\", \"price\": 8.95 }, { \"category\": \"fiction\", \"author\": \"Evelyn Waugh\", \"title\": \"Sword of Honour\", \"price\": 12.99 } ], \"bicycle\": { \"color\": \"red\", \"price\": 19.95 } } }";
+        List<Object> authors = JsonPath.read(json, "$.store.book[*].author");
+        authors.forEach(it -> System.out.println(it.toString()));
+        String author = JsonPath.read(json, "$.store.book[1].author");
+        System.out.println(author);
+
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
@@ -1,0 +1,603 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.securityanalytics.resthandler;
+
+import org.junit.Assert;
+import org.opensearch.client.Response;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
+import org.opensearch.securityanalytics.SecurityAnalyticsRestTestCase;
+import org.opensearch.securityanalytics.commons.model.IOCType;
+import org.opensearch.securityanalytics.model.STIX2IOCDto;
+import org.opensearch.securityanalytics.threatIntel.action.ListIOCsActionResponse;
+import org.opensearch.securityanalytics.threatIntel.common.SourceConfigType;
+import org.opensearch.securityanalytics.threatIntel.model.CustomSchemaIocUploadSource;
+import org.opensearch.securityanalytics.threatIntel.model.IocUploadSource;
+import org.opensearch.securityanalytics.threatIntel.model.JsonPathIocSchema;
+import org.opensearch.securityanalytics.threatIntel.model.JsonPathIocSchema.JsonPathSchemaField;
+import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
+import org.opensearch.securityanalytics.util.STIX2IOCGenerator;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTestCase {
+    /* Test scenarios
+     * 1. Valid schemas with isKey false and all fields present
+     * 2. Valid schemas with isKey false and optional fields absent
+     *    i.   Valid schemas with isKey false
+     *    ii.  Valid schema with key : value tuple (1:1)
+     *    iii. Valid schema with key : value nested (1:n)
+     * 3. Valid schemas with isKey true
+     * 4. Valid schemas but not communicating correct format
+     * 5. Valid schemas but mandatory fields missing in iocs string
+     * 6. Invalid schema json path in schema
+     * 7. Invalid Json in Iocs
+     * 8 Schema invalid because mandatory paths not passed*/
+    public void testCustomSchemaIocUploadWithSingleton_success() throws IOException {
+        String feedName = "test_ioc_upload";
+        String feedFormat = "STIX";
+        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
+
+
+
+        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
+                "{\"value\": \"value1\", \"type\":\"" + IOCType.IPV4_TYPE + "\", \"name\" : \"name\", \"id\":\"1\"}");
+        Boolean enabled = false;
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
+        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+                null,
+                null,
+                feedName,
+                feedFormat,
+                sourceConfigType,
+                null,
+                null,
+                null,
+                iocUploadSource,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                enabled,
+                iocTypes, true,
+                new JsonPathIocSchema(null,
+                        null,
+                        new JsonPathSchemaField("$.type", false),
+                        new JsonPathSchemaField("$.value", false),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)
+        );
+
+        Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
+        Assert.assertEquals(RestStatus.CREATED, restStatus(response));
+        Map<String, Object> responseBody = asMap(response);
+
+        String createdId = responseBody.get("_id").toString();
+        Assert.assertNotEquals("response is missing Id", SATIFSourceConfigDto.NO_ID, createdId);
+
+        int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+        Assert.assertTrue("incorrect version", createdVersion > 0);
+        Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, createdId), response.getHeader("Location"));
+
+        String request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match_all\":{\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+
+        // Retrieve all IOCs by feed Ids
+        Response iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId + ",random"), null);
+        Assert.assertEquals(RestStatus.OK, restStatus(iocResponse));
+        Map<String, Object> respMap = asMap(iocResponse);
+
+        // Evaluate response
+        int totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
+        assertEquals(1, totalHits);
+
+    }
+
+    public void testCustomSchemaIocUploadWithSingleIocTypeStringAndSingleIocValueArray_Success() throws IOException {
+        String feedName = "test_ioc_upload";
+        String feedFormat = "STIX";
+        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
+
+        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
+                "{\"value\": [\"value1\", \"value2\"], \"type\":\"" + IOCType.IPV4_TYPE + "\", \"name\" : \"name\", \"id\":\"1\"}");
+        Boolean enabled = false;
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
+        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+                null,
+                null,
+                feedName,
+                feedFormat,
+                sourceConfigType,
+                null,
+                null,
+                null,
+                iocUploadSource,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                enabled,
+                iocTypes, true,
+                new JsonPathIocSchema(null,
+                        null,
+                        new JsonPathSchemaField("$.type", false),
+                        new JsonPathSchemaField("$.value", false),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)
+        );
+
+        Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
+        Assert.assertEquals(RestStatus.CREATED, restStatus(response));
+        Map<String, Object> responseBody = asMap(response);
+
+        String createdId = responseBody.get("_id").toString();
+        Assert.assertNotEquals("response is missing Id", SATIFSourceConfigDto.NO_ID, createdId);
+
+        int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+        Assert.assertTrue("incorrect version", createdVersion > 0);
+        Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, createdId), response.getHeader("Location"));
+
+        String request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match_all\":{\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+
+        // Retrieve all IOCs by feed Ids
+        Response iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId + ",random"), null);
+        Assert.assertEquals(RestStatus.OK, restStatus(iocResponse));
+        Map<String, Object> respMap = asMap(iocResponse);
+
+        // Evaluate response
+        int totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
+        assertEquals(2, totalHits);
+
+    }
+
+    public void testCustomSchemaIocUploadWithMissingIocTypeStringAndSingleIocValue_Failure() throws IOException {
+        String feedName = "test_ioc_upload";
+        String feedFormat = "STIX";
+        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
+
+
+
+        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
+                "{\"value\": [\"value1\", \"value2\"], \"name\" : \"name\", \"id\":\"1\"}");
+        Boolean enabled = false;
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
+        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+                null,
+                null,
+                feedName,
+                feedFormat,
+                sourceConfigType,
+                null,
+                null,
+                null,
+                iocUploadSource,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                enabled,
+                iocTypes, true,
+                new JsonPathIocSchema(null,
+                        null,
+                        new JsonPathSchemaField("$.type", false),
+                        new JsonPathSchemaField("$.value", false),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)
+        );
+
+        try {
+            Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
+            fail();
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+
+
+    }
+
+    public void testCustomSchemaIocUploadWithInvalidJson_Failure() throws IOException {
+        String feedName = "test_ioc_upload";
+        String feedFormat = "STIX";
+        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
+        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
+                "{\"value\": [\"value1\", \"value2\"], \"name\" : \"name\", \"id\":\"1\"");
+        Boolean enabled = false;
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
+        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+                null,
+                null,
+                feedName,
+                feedFormat,
+                sourceConfigType,
+                null,
+                null,
+                null,
+                iocUploadSource,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                enabled,
+                iocTypes, true,
+                new JsonPathIocSchema(null,
+                        null,
+                        new JsonPathSchemaField("$.type", false),
+                        new JsonPathSchemaField("$.value", false),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)
+        );
+
+        try {
+            Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
+            fail();
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+
+
+    }
+
+    public void testCustomSchemaIocUploadWithMissingIocValueStringAndSingleIocType_Failure() throws IOException {
+        String feedName = "test_ioc_upload";
+        String feedFormat = "STIX";
+        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
+
+
+
+        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
+                "{\"type\": \"ipv4-addr\", \"name\" : \"name\", \"id\":\"1\"}");
+        Boolean enabled = false;
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
+        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+                null,
+                null,
+                feedName,
+                feedFormat,
+                sourceConfigType,
+                null,
+                null,
+                null,
+                iocUploadSource,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                enabled,
+                iocTypes, true,
+                new JsonPathIocSchema(null,
+                        null,
+                        new JsonPathSchemaField("$.type", false),
+                        new JsonPathSchemaField("$.value", false),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)
+        );
+
+        try {
+            Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
+            fail();
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+
+
+    }
+
+    public void testCustomSchemaIocUploadWithMultiptleTuplesOfIocTypeValue_PartialNulls_success() throws IOException {
+        String feedName = "test_ioc_upload";
+        String feedFormat = "STIX";
+        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
+
+        String jsonString = "{\"iocs\":[{\"ipath\":\"" + IOCType.IPV4_TYPE + "\"},{\"ivalue\":\"10.0.0.1\",\"ipath\":\"" + IOCType.IPV4_TYPE + "\"},{\"ivalue\":\"malware.com\",\"ipath\":\"" + IOCType.DOMAIN_NAME_TYPE + "\"}]}";
+
+        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
+                    jsonString);
+        Boolean enabled = false;
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE);
+        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+                null,
+                null,
+                feedName,
+                feedFormat,
+                sourceConfigType,
+                null,
+                null,
+                null,
+                iocUploadSource,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                enabled,
+                iocTypes, true,
+                new JsonPathIocSchema(null,
+                        null,
+                        new JsonPathSchemaField("$..ipath", false),
+                        new JsonPathSchemaField("$..ivalue", false),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)
+        );
+
+        Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
+        Assert.assertEquals(RestStatus.CREATED, restStatus(response));
+        Map<String, Object> responseBody = asMap(response);
+
+        String createdId = responseBody.get("_id").toString();
+        Assert.assertNotEquals("response is missing Id", SATIFSourceConfigDto.NO_ID, createdId);
+
+        int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+        Assert.assertTrue("incorrect version", createdVersion > 0);
+        Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, createdId), response.getHeader("Location"));
+
+        String request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match_all\":{\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+
+        // Retrieve all IOCs by feed Ids
+        Response iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId + ",random"), null);
+        Assert.assertEquals(RestStatus.OK, restStatus(iocResponse));
+        Map<String, Object> respMap = asMap(iocResponse);
+
+        // Evaluate response
+        int totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
+        assertEquals(2, totalHits);
+
+    }
+
+    public void testCustomSchemaIocUploadWithMultiptleTuplesOfIocTypeValue_InvalidIocTypes_success() throws IOException {
+        String feedName = "test_ioc_upload";
+        String feedFormat = "STIX";
+        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
+
+        String jsonString = "{\"iocs\":[{\"ipath\":\"" + IOCType.IPV4_TYPE+"invalid" + "\"},{\"ivalue\":[\"10.0.0.1\", \"10.0.0.2\"],\"ipath\":\"" + IOCType.IPV4_TYPE + "\"},{\"ivalue\":\"malware.com\",\"ipath\":\"" + IOCType.DOMAIN_NAME_TYPE + "\"}]}";
+
+        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
+                jsonString);
+        Boolean enabled = false;
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE);
+        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+                null,
+                null,
+                feedName,
+                feedFormat,
+                sourceConfigType,
+                null,
+                null,
+                null,
+                iocUploadSource,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                enabled,
+                iocTypes, true,
+                new JsonPathIocSchema(null,
+                        null,
+                        new JsonPathSchemaField("$..ipath", false),
+                        new JsonPathSchemaField("$..ivalue", false),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)
+        );
+
+        Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
+        Assert.assertEquals(RestStatus.CREATED, restStatus(response));
+        Map<String, Object> responseBody = asMap(response);
+
+        String createdId = responseBody.get("_id").toString();
+        Assert.assertNotEquals("response is missing Id", SATIFSourceConfigDto.NO_ID, createdId);
+
+        int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+        Assert.assertTrue("incorrect version", createdVersion > 0);
+        Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, createdId), response.getHeader("Location"));
+
+        String request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match_all\":{\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+
+        // Retrieve all IOCs by feed Ids
+        Response iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId + ",random"), null);
+        Assert.assertEquals(RestStatus.OK, restStatus(iocResponse));
+        Map<String, Object> respMap = asMap(iocResponse);
+
+        // Evaluate response
+        int totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
+        assertEquals(2, totalHits);
+
+    }
+
+    public void testCustomSchemaIocUploadWithMultiptleTuplesOfIocTypeValue_MixOfValueArrayAndStrings_success() throws IOException {
+        String feedName = "test_ioc_upload";
+        String feedFormat = "STIX";
+        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
+
+        String jsonString = "{\"iocs\":[{\"ipath\":\"" + IOCType.IPV4_TYPE+"invalid" + "\"},{\"ivalue\":[\"10.0.0.1\", \"10.0.0.2\"],\"ipath\":\"" + IOCType.IPV4_TYPE + "\"},{\"ivalue\":\"malware.com\",\"ipath\":\"" + IOCType.DOMAIN_NAME_TYPE + "\"}]}";
+
+        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
+                jsonString);
+        Boolean enabled = false;
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE);
+        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+                null,
+                null,
+                feedName,
+                feedFormat,
+                sourceConfigType,
+                null,
+                null,
+                null,
+                iocUploadSource,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                enabled,
+                iocTypes, true,
+                new JsonPathIocSchema(null,
+                        null,
+                        new JsonPathSchemaField("$..ipath", false),
+                        new JsonPathSchemaField("$..ivalue", false),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)
+        );
+
+        Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
+        Assert.assertEquals(RestStatus.CREATED, restStatus(response));
+        Map<String, Object> responseBody = asMap(response);
+
+        String createdId = responseBody.get("_id").toString();
+        Assert.assertNotEquals("response is missing Id", SATIFSourceConfigDto.NO_ID, createdId);
+
+        int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+        Assert.assertTrue("incorrect version", createdVersion > 0);
+        Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, createdId), response.getHeader("Location"));
+
+        String request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match_all\":{\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+
+        // Retrieve all IOCs by feed Ids
+        Response iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId + ",random"), null);
+        Assert.assertEquals(RestStatus.OK, restStatus(iocResponse));
+        Map<String, Object> respMap = asMap(iocResponse);
+
+        // Evaluate response
+        int totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
+        assertEquals(3, totalHits);
+
+    }
+
+
+    private static SATIFSourceConfigDto getSatifSourceConfigDto() {
+        String feedName = "test_ioc_upload";
+        String feedFormat = "STIX";
+        SourceConfigType sourceConfigType = SourceConfigType.IOC_UPLOAD;
+
+        List<STIX2IOCDto> iocs = List.of(new STIX2IOCDto(
+                "id",
+                "name",
+                new IOCType(IOCType.IPV4_TYPE),
+                "value",
+                "severity",
+                null,
+                null,
+                "description",
+                List.of("labels"),
+                "specversion",
+                "feedId",
+                "feedName",
+                1L));
+
+        IocUploadSource iocUploadSource = new IocUploadSource(null, iocs);
+        Boolean enabled = false;
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
+        return new SATIFSourceConfigDto(
+                null,
+                null,
+                feedName,
+                feedFormat,
+                sourceConfigType,
+                null,
+                null,
+                null,
+                iocUploadSource,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                enabled,
+                iocTypes, true,
+                null
+        );
+    }
+
+    @Override
+    protected boolean preserveIndicesUponCompletion() {
+        return false;
+    }
+}

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
@@ -434,7 +434,7 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
 
         // Evaluate response
         int totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
-        assertEquals(3, totalHits);
+        assertEquals(312, totalHits);
 
     }
 

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
@@ -14,11 +14,9 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
 import org.opensearch.securityanalytics.SecurityAnalyticsRestTestCase;
 import org.opensearch.securityanalytics.commons.model.IOCType;
-import org.opensearch.securityanalytics.model.STIX2IOCDto;
 import org.opensearch.securityanalytics.threatIntel.action.ListIOCsActionResponse;
 import org.opensearch.securityanalytics.threatIntel.common.SourceConfigType;
 import org.opensearch.securityanalytics.threatIntel.model.CustomSchemaIocUploadSource;
-import org.opensearch.securityanalytics.threatIntel.model.IocUploadSource;
 import org.opensearch.securityanalytics.threatIntel.model.JsonPathIocSchema;
 import org.opensearch.securityanalytics.threatIntel.model.JsonPathIocSchema.JsonPathSchemaField;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
@@ -54,36 +52,16 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
                 "{\"value\": \"value1\", \"type\":\"" + IOCType.IPV4_TYPE + "\", \"name\" : \"name\", \"id\":\"1\"}");
         Boolean enabled = false;
         List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
-        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+        SATIFSourceConfigDto saTifSourceConfigDto = getSaTifSourceConfigDto(feedName, feedFormat, sourceConfigType, iocUploadSource, enabled, iocTypes, new JsonPathIocSchema(null,
                 null,
-                null,
-                feedName,
-                feedFormat,
-                sourceConfigType,
-                null,
-                null,
-                null,
-                iocUploadSource,
+                new JsonPathSchemaField("$.type", false),
+                new JsonPathSchemaField("$.value", false),
                 null,
                 null,
                 null,
                 null,
                 null,
-                null,
-                null,
-                enabled,
-                iocTypes, true,
-                new JsonPathIocSchema(null,
-                        null,
-                        new JsonPathSchemaField("$.type", false),
-                        new JsonPathSchemaField("$.value", false),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null)
-        );
+                null));
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
         Assert.assertEquals(RestStatus.CREATED, restStatus(response));
@@ -123,36 +101,16 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
                 "{\"value\": [\"value1\", \"value2\"], \"type\":\"" + IOCType.IPV4_TYPE + "\", \"name\" : \"name\", \"id\":\"1\"}");
         Boolean enabled = false;
         List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
-        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+        SATIFSourceConfigDto saTifSourceConfigDto = getSaTifSourceConfigDto(feedName, feedFormat, sourceConfigType, iocUploadSource, enabled, iocTypes, new JsonPathIocSchema(null,
                 null,
-                null,
-                feedName,
-                feedFormat,
-                sourceConfigType,
-                null,
-                null,
-                null,
-                iocUploadSource,
+                new JsonPathSchemaField("$.type", false),
+                new JsonPathSchemaField("$.value", false),
                 null,
                 null,
                 null,
                 null,
                 null,
-                null,
-                null,
-                enabled,
-                iocTypes, true,
-                new JsonPathIocSchema(null,
-                        null,
-                        new JsonPathSchemaField("$.type", false),
-                        new JsonPathSchemaField("$.value", false),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null)
-        );
+                null));
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
         Assert.assertEquals(RestStatus.CREATED, restStatus(response));
@@ -194,36 +152,16 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
                 "{\"value\": [\"value1\", \"value2\"], \"name\" : \"name\", \"id\":\"1\"}");
         Boolean enabled = false;
         List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
-        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+        SATIFSourceConfigDto saTifSourceConfigDto = getSaTifSourceConfigDto(feedName, feedFormat, sourceConfigType, iocUploadSource, enabled, iocTypes, new JsonPathIocSchema(null,
                 null,
-                null,
-                feedName,
-                feedFormat,
-                sourceConfigType,
-                null,
-                null,
-                null,
-                iocUploadSource,
+                new JsonPathSchemaField("$.type", false),
+                new JsonPathSchemaField("$.value", false),
                 null,
                 null,
                 null,
                 null,
                 null,
-                null,
-                null,
-                enabled,
-                iocTypes, true,
-                new JsonPathIocSchema(null,
-                        null,
-                        new JsonPathSchemaField("$.type", false),
-                        new JsonPathSchemaField("$.value", false),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null)
-        );
+                null));
 
         try {
             Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -243,36 +181,16 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
                 "{\"value\": [\"value1\", \"value2\"], \"name\" : \"name\", \"id\":\"1\"");
         Boolean enabled = false;
         List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
-        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+        SATIFSourceConfigDto saTifSourceConfigDto = getSaTifSourceConfigDto(feedName, feedFormat, sourceConfigType, iocUploadSource, enabled, iocTypes, new JsonPathIocSchema(null,
                 null,
-                null,
-                feedName,
-                feedFormat,
-                sourceConfigType,
-                null,
-                null,
-                null,
-                iocUploadSource,
+                new JsonPathSchemaField("$.type", false),
+                new JsonPathSchemaField("$.value", false),
                 null,
                 null,
                 null,
                 null,
                 null,
-                null,
-                null,
-                enabled,
-                iocTypes, true,
-                new JsonPathIocSchema(null,
-                        null,
-                        new JsonPathSchemaField("$.type", false),
-                        new JsonPathSchemaField("$.value", false),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null)
-        );
+                null));
 
         try {
             Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -295,36 +213,16 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
                 "{\"type\": \"ipv4-addr\", \"name\" : \"name\", \"id\":\"1\"}");
         Boolean enabled = false;
         List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
-        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+        SATIFSourceConfigDto saTifSourceConfigDto = getSaTifSourceConfigDto(feedName, feedFormat, sourceConfigType, iocUploadSource, enabled, iocTypes, new JsonPathIocSchema(null,
                 null,
-                null,
-                feedName,
-                feedFormat,
-                sourceConfigType,
-                null,
-                null,
-                null,
-                iocUploadSource,
+                new JsonPathSchemaField("$.type", false),
+                new JsonPathSchemaField("$.value", false),
                 null,
                 null,
                 null,
                 null,
                 null,
-                null,
-                null,
-                enabled,
-                iocTypes, true,
-                new JsonPathIocSchema(null,
-                        null,
-                        new JsonPathSchemaField("$.type", false),
-                        new JsonPathSchemaField("$.value", false),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null)
-        );
+                null));
 
         try {
             Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -347,36 +245,16 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
                     jsonString);
         Boolean enabled = false;
         List<String> iocTypes = List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE);
-        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+        SATIFSourceConfigDto saTifSourceConfigDto = getSaTifSourceConfigDto(feedName, feedFormat, sourceConfigType, iocUploadSource, enabled, iocTypes, new JsonPathIocSchema(null,
                 null,
-                null,
-                feedName,
-                feedFormat,
-                sourceConfigType,
-                null,
-                null,
-                null,
-                iocUploadSource,
+                new JsonPathSchemaField("$..ipath", false),
+                new JsonPathSchemaField("$..ivalue", false),
                 null,
                 null,
                 null,
                 null,
                 null,
-                null,
-                null,
-                enabled,
-                iocTypes, true,
-                new JsonPathIocSchema(null,
-                        null,
-                        new JsonPathSchemaField("$..ipath", false),
-                        new JsonPathSchemaField("$..ivalue", false),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null)
-        );
+                null));
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
         Assert.assertEquals(RestStatus.CREATED, restStatus(response));
@@ -418,107 +296,16 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
                 jsonString);
         Boolean enabled = false;
         List<String> iocTypes = List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE);
-        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
+        SATIFSourceConfigDto saTifSourceConfigDto = getSaTifSourceConfigDto(feedName, feedFormat, sourceConfigType, iocUploadSource, enabled, iocTypes, new JsonPathIocSchema(null,
                 null,
-                null,
-                feedName,
-                feedFormat,
-                sourceConfigType,
-                null,
-                null,
-                null,
-                iocUploadSource,
+                new JsonPathSchemaField("$..ipath", false),
+                new JsonPathSchemaField("$..ivalue", false),
                 null,
                 null,
                 null,
                 null,
                 null,
-                null,
-                null,
-                enabled,
-                iocTypes, true,
-                new JsonPathIocSchema(null,
-                        null,
-                        new JsonPathSchemaField("$..ipath", false),
-                        new JsonPathSchemaField("$..ivalue", false),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null)
-        );
-
-        Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
-        Assert.assertEquals(RestStatus.CREATED, restStatus(response));
-        Map<String, Object> responseBody = asMap(response);
-
-        String createdId = responseBody.get("_id").toString();
-        Assert.assertNotEquals("response is missing Id", SATIFSourceConfigDto.NO_ID, createdId);
-
-        int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
-        Assert.assertTrue("incorrect version", createdVersion > 0);
-        Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, createdId), response.getHeader("Location"));
-
-        String request = "{\n" +
-                "   \"query\" : {\n" +
-                "     \"match_all\":{\n" +
-                "     }\n" +
-                "   }\n" +
-                "}";
-
-        // Retrieve all IOCs by feed Ids
-        Response iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId + ",random"), null);
-        Assert.assertEquals(RestStatus.OK, restStatus(iocResponse));
-        Map<String, Object> respMap = asMap(iocResponse);
-
-        // Evaluate response
-        int totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
-        assertEquals(2, totalHits);
-
-    }
-
-    public void testCustomSchemaIocUploadWithMultiptleTuplesOfIocTypeValue_MixOfValueArrayAndStrings_success() throws IOException {
-        String feedName = "test_ioc_upload";
-        String feedFormat = "STIX";
-        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
-
-        String jsonString = "{\"iocs\":[{\"ipath\":\"" + IOCType.IPV4_TYPE+"invalid" + "\"},{\"ivalue\":[\"10.0.0.1\", \"10.0.0.2\"],\"ipath\":\"" + IOCType.IPV4_TYPE + "\"},{\"ivalue\":\"malware.com\",\"ipath\":\"" + IOCType.DOMAIN_NAME_TYPE + "\"}]}";
-
-        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
-                jsonString);
-        Boolean enabled = false;
-        List<String> iocTypes = List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE);
-        SATIFSourceConfigDto saTifSourceConfigDto = new SATIFSourceConfigDto(
-                null,
-                null,
-                feedName,
-                feedFormat,
-                sourceConfigType,
-                null,
-                null,
-                null,
-                iocUploadSource,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                enabled,
-                iocTypes, true,
-                new JsonPathIocSchema(null,
-                        null,
-                        new JsonPathSchemaField("$..ipath", false),
-                        new JsonPathSchemaField("$..ivalue", false),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null)
-        );
+                null));
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
         Assert.assertEquals(RestStatus.CREATED, restStatus(response));
@@ -549,30 +336,109 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
 
     }
 
-
-    private static SATIFSourceConfigDto getSatifSourceConfigDto() {
+    public void testCustomSchemaIocUploadWithMultiptleTuplesOfIocTypeValue_MixOfValueArrayAndStrings_success() throws IOException {
         String feedName = "test_ioc_upload";
         String feedFormat = "STIX";
-        SourceConfigType sourceConfigType = SourceConfigType.IOC_UPLOAD;
+        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
 
-        List<STIX2IOCDto> iocs = List.of(new STIX2IOCDto(
-                "id",
-                "name",
-                new IOCType(IOCType.IPV4_TYPE),
-                "value",
-                "severity",
-                null,
-                null,
-                "description",
-                List.of("labels"),
-                "specversion",
-                "feedId",
-                "feedName",
-                1L));
+        String jsonString = "{\"iocs\":[{\"ipath\":\"" + IOCType.IPV4_TYPE+"invalid" + "\"},{\"ivalue\":[\"10.0.0.1\", \"10.0.0.2\"],\"ipath\":\"" + IOCType.IPV4_TYPE + "\"},{\"ivalue\":\"malware.com\",\"ipath\":\"" + IOCType.DOMAIN_NAME_TYPE + "\"}]}";
 
-        IocUploadSource iocUploadSource = new IocUploadSource(null, iocs);
+        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
+                jsonString);
         Boolean enabled = false;
-        List<String> iocTypes = List.of(IOCType.IPV4_TYPE);
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE);
+        SATIFSourceConfigDto saTifSourceConfigDto = getSaTifSourceConfigDto(feedName, feedFormat, sourceConfigType, iocUploadSource, enabled, iocTypes, new JsonPathIocSchema(null,
+                null,
+                new JsonPathSchemaField("$..ipath", false),
+                new JsonPathSchemaField("$..ivalue", false),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
+        Assert.assertEquals(RestStatus.CREATED, restStatus(response));
+        Map<String, Object> responseBody = asMap(response);
+
+        String createdId = responseBody.get("_id").toString();
+        Assert.assertNotEquals("response is missing Id", SATIFSourceConfigDto.NO_ID, createdId);
+
+        int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+        Assert.assertTrue("incorrect version", createdVersion > 0);
+        Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, createdId), response.getHeader("Location"));
+
+        String request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match_all\":{\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+
+        // Retrieve all IOCs by feed Ids
+        Response iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId + ",random"), null);
+        Assert.assertEquals(RestStatus.OK, restStatus(iocResponse));
+        Map<String, Object> respMap = asMap(iocResponse);
+
+        // Evaluate response
+        int totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
+        assertEquals(3, totalHits);
+
+    }
+
+    public void testCustomSchemaIocUpload1() throws IOException {
+        String feedName = "test_ioc_upload";
+        String feedFormat = "STIX";
+        SourceConfigType sourceConfigType = SourceConfigType.CUSTOM_SCHEMA_IOC_UPLOAD;
+        String filePath = "threatIntel/custom_schema_ioc/custom_schema_1.json";
+        String jsonString = readResource(filePath);
+
+        CustomSchemaIocUploadSource iocUploadSource = new CustomSchemaIocUploadSource(null,
+                jsonString);
+        Boolean enabled = false;
+        List<String> iocTypes = List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE);
+        SATIFSourceConfigDto saTifSourceConfigDto = getSaTifSourceConfigDto(feedName, feedFormat, sourceConfigType, iocUploadSource, enabled, iocTypes, new JsonPathIocSchema(null,
+                null,
+                new JsonPathSchemaField("$.*[*].ioc_type", false),
+                new JsonPathSchemaField("$.*[*].ioc_value", false),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
+        Assert.assertEquals(RestStatus.CREATED, restStatus(response));
+        Map<String, Object> responseBody = asMap(response);
+
+        String createdId = responseBody.get("_id").toString();
+        Assert.assertNotEquals("response is missing Id", SATIFSourceConfigDto.NO_ID, createdId);
+
+        int createdVersion = Integer.parseInt(responseBody.get("_version").toString());
+        Assert.assertTrue("incorrect version", createdVersion > 0);
+        Assert.assertEquals("Incorrect Location header", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, createdId), response.getHeader("Location"));
+
+        String request = "{\n" +
+                "   \"query\" : {\n" +
+                "     \"match_all\":{\n" +
+                "     }\n" +
+                "   }\n" +
+                "}";
+
+        // Retrieve all IOCs by feed Ids
+        Response iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId + ",random"), null);
+        Assert.assertEquals(RestStatus.OK, restStatus(iocResponse));
+        Map<String, Object> respMap = asMap(iocResponse);
+
+        // Evaluate response
+        int totalHits = (int) respMap.get(ListIOCsActionResponse.TOTAL_HITS_FIELD);
+        assertEquals(3, totalHits);
+
+    }
+
+    private static SATIFSourceConfigDto getSaTifSourceConfigDto(String feedName, String feedFormat, SourceConfigType sourceConfigType, CustomSchemaIocUploadSource iocUploadSource, Boolean enabled, List<String> iocTypes, JsonPathIocSchema iocSchema) {
         return new SATIFSourceConfigDto(
                 null,
                 null,
@@ -592,9 +458,10 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
                 null,
                 enabled,
                 iocTypes, true,
-                null
+                iocSchema
         );
     }
+
 
     @Override
     protected boolean preserveIndicesUponCompletion() {

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
@@ -18,7 +18,7 @@ import org.opensearch.securityanalytics.threatIntel.action.ListIOCsActionRespons
 import org.opensearch.securityanalytics.threatIntel.common.SourceConfigType;
 import org.opensearch.securityanalytics.threatIntel.model.CustomSchemaIocUploadSource;
 import org.opensearch.securityanalytics.threatIntel.model.JsonPathIocSchema;
-import org.opensearch.securityanalytics.threatIntel.model.JsonPathIocSchema.JsonPathSchemaField;
+import org.opensearch.securityanalytics.threatIntel.model.JsonPathSchemaField;
 import org.opensearch.securityanalytics.threatIntel.model.SATIFSourceConfigDto;
 import org.opensearch.securityanalytics.util.STIX2IOCGenerator;
 
@@ -428,7 +428,7 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
                 "}";
 
         // Retrieve all IOCs by feed Ids
-        Response iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId + ",random"), null);
+        Response iocResponse = makeRequest(client(), "GET", STIX2IOCGenerator.getListIOCsURI(), Map.of("feed_ids", createdId), null);
         Assert.assertEquals(RestStatus.OK, restStatus(iocResponse));
         Map<String, Object> respMap = asMap(iocResponse);
 

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ListIOCsRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ListIOCsRestApiIT.java
@@ -56,7 +56,7 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
                     new STIX2IOCDto(
                             iocId,
                             iocId + "-name",
-                            new IOCType(IOCType.IPV4_TYPE),
+                            IOCType.IPV4_TYPE,
                             "ipv4value" + i,
                             "severity",
                             null,
@@ -140,7 +140,7 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
                 new STIX2IOCDto(
                         "id1",
                         searchString,
-                        new IOCType(IOCType.IPV4_TYPE),
+                        IOCType.IPV4_TYPE,
                         "ipv4value",
                         "severity",
                         null,
@@ -156,7 +156,7 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
                 new STIX2IOCDto(
                         "id2",
                         TestHelpers.randomLowerCaseString(),
-                        new IOCType(IOCType.IPV4_TYPE),
+                        IOCType.IPV4_TYPE,
                         searchString,
                         "severity",
                         null,
@@ -172,7 +172,7 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
                 new STIX2IOCDto(
                         "id3",
                         "name",
-                        new IOCType(IOCType.IPV4_TYPE),
+                        IOCType.IPV4_TYPE,
                         "ipv4value",
                         "severity",
                         null,
@@ -243,7 +243,7 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
                     new STIX2IOCDto(
                             iocId,
                             iocId + "-name",
-                            new IOCType(IOCType.IPV4_TYPE),
+                            IOCType.IPV4_TYPE,
                             "ipv4value",
                             "severity",
                             null,

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ListIOCsRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ListIOCsRestApiIT.java
@@ -91,7 +91,8 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 false,
                 List.of(IOCType.IPV4_TYPE),
-                true
+                true,
+                null
         );
 
         // Create the IOC system indexes using IOC_UPLOAD config
@@ -204,7 +205,7 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 false,
                 List.of(IOCType.IPV4_TYPE),
-                true
+                true, null
         );
 
         // Create the IOC system indexes using IOC_UPLOAD config
@@ -284,7 +285,8 @@ public class ListIOCsRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 false,
                 List.of(IOCType.IPV4_TYPE),
-                true
+                true,
+                null
         );
 
         // Create the IOC system indexes using IOC_UPLOAD config

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
@@ -199,7 +199,8 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 true,
                 iocTypes,
-                true
+                true,
+                null
         );
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
         Assert.assertEquals(201, response.getStatusLine().getStatusCode());
@@ -272,7 +273,8 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 true,
                 iocTypes,
-                true
+                true,
+                null
         );
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -340,7 +342,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 true,
                 iocTypes,
-                true
+                true, null
         );
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -413,7 +415,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 true,
                 iocTypes,
-                true
+                true, null
         );
 
             // Confirm test feed was created successfully
@@ -515,8 +517,8 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                     null,
                     true,
                     IOCType.types,
-                    true
-            );
+                    true, null
+        );
 
             // Confirm test feed was created successfully
             Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -620,8 +622,8 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                     null,
                     true,
                     iocTypes,
-                    true
-            );
+                    true, null
+        );
 
             Exception exception = assertThrows(ResponseException.class, () ->
                     makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto))
@@ -671,8 +673,8 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                     null,
                     true,
                     iocTypes,
-                    true
-            );
+                    true, null
+        );
 
             Exception exception = assertThrows(ResponseException.class, () ->
                     makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto))
@@ -723,8 +725,8 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                     null,
                     true,
                     iocTypes,
-                    true
-            );
+                    true, null
+        );
 
             Exception exception = assertThrows(ResponseException.class, () ->
                     makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto))
@@ -777,7 +779,8 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                     null,
                     true,
                     iocTypes,
-                    true
+                    true,
+                    null
             );
 
             try {
@@ -840,7 +843,8 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 true,
                 iocTypes,
-                true
+                true,
+                null
         );
 
         Exception exception = assertThrows(ResponseException.class, () ->

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
@@ -169,7 +169,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
 
         // Generate test IOCs, and upload them to S3 to create the bucket object. Feed creation fails if the bucket object doesn't exist.
         int numOfIOCs = 1;
-        stix2IOCGenerator = new STIX2IOCGenerator(List.of(new IOCType(IOCType.IPV4_TYPE)));
+        stix2IOCGenerator = new STIX2IOCGenerator(List.of(IOCType.IPV4_TYPE));
         s3ObjectGenerator.write(numOfIOCs, objectKey, stix2IOCGenerator);
         assertEquals("Incorrect number of test IOCs generated.", numOfIOCs, stix2IOCGenerator.getIocs().size());
 
@@ -243,7 +243,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
 
         // Generate test IOCs, and upload them to S3 to create the bucket object. Feed creation fails if the bucket object doesn't exist.
         int numOfIOCs = 1;
-        stix2IOCGenerator = new STIX2IOCGenerator(List.of(new IOCType(IOCType.HASHES_TYPE)));
+        stix2IOCGenerator = new STIX2IOCGenerator(List.of(IOCType.HASHES_TYPE));
         s3ObjectGenerator.write(numOfIOCs, objectKey, stix2IOCGenerator);
         assertEquals("Incorrect number of test IOCs generated.", numOfIOCs, stix2IOCGenerator.getIocs().size());
 
@@ -312,7 +312,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
 
         // Generate test IOCs, and upload them to S3 to create the bucket object. Feed creation fails if the bucket object doesn't exist.
         int numOfIOCs = 1;
-        stix2IOCGenerator = new STIX2IOCGenerator(List.of(new IOCType(IOCType.IPV4_TYPE)));
+        stix2IOCGenerator = new STIX2IOCGenerator(List.of(IOCType.IPV4_TYPE));
         s3ObjectGenerator.write(numOfIOCs, objectKey, stix2IOCGenerator);
         assertEquals("Incorrect number of test IOCs generated.", numOfIOCs, stix2IOCGenerator.getIocs().size());
 
@@ -385,7 +385,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
         for (String type : IOCType.types) {
             // Generate test IOCs, and upload them to S3
             int numOfIOCs = 5;
-            stix2IOCGenerator = new STIX2IOCGenerator(List.of(new IOCType(type)));
+            stix2IOCGenerator = new STIX2IOCGenerator(List.of(type));
             s3ObjectGenerator.write(numOfIOCs, objectKey, stix2IOCGenerator);
             assertEquals("Incorrect number of test IOCs generated for type: " + type, numOfIOCs, stix2IOCGenerator.getIocs().size());
 
@@ -586,7 +586,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
 
         // Generate test IOCs, and upload them to S3
         int numOfIOCs = 5;
-        stix2IOCGenerator = new STIX2IOCGenerator(List.of(new IOCType(IOCType.IPV4_TYPE)));
+        stix2IOCGenerator = new STIX2IOCGenerator(List.of(IOCType.IPV4_TYPE));
         s3ObjectGenerator.write(numOfIOCs, objectKey, stix2IOCGenerator);
         assertEquals("Incorrect number of test IOCs generated.", numOfIOCs, stix2IOCGenerator.getIocs().size());
 
@@ -640,7 +640,7 @@ public class SATIFSourceConfigRestApiIT extends SecurityAnalyticsRestTestCase {
 
         // Generate test IOCs, and upload them to S3
         int numOfIOCs = 5;
-        stix2IOCGenerator = new STIX2IOCGenerator(List.of(new IOCType(IOCType.IPV4_TYPE)));
+        stix2IOCGenerator = new STIX2IOCGenerator(List.of(IOCType.IPV4_TYPE));
         s3ObjectGenerator.write(numOfIOCs, objectKey, stix2IOCGenerator);
         assertEquals("Incorrect number of test IOCs generated.", numOfIOCs, stix2IOCGenerator.getIocs().size());
 

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
@@ -92,7 +92,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -201,7 +202,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         try {
@@ -253,7 +255,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         // create source config with ipv4 ioc type
@@ -344,7 +347,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         // update source config with hashes ioc type
@@ -410,7 +414,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         // create source config with ipv4 ioc type
@@ -474,7 +479,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, false
+                iocTypes, false,
+                null
         );
 
         // update source config with hashes ioc type
@@ -523,7 +529,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         // update source config with hashes ioc type
@@ -583,7 +590,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, false
+                iocTypes, false,
+                null
         );
 
         // update default source config with enabled_for_scan updated
@@ -627,7 +635,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         // update default source config with enabled_for_scan updated
@@ -684,7 +693,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -769,7 +779,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -842,7 +853,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         Response response = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));
@@ -936,7 +948,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
 
         // update default source config
@@ -1050,7 +1063,8 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null,
                 null,
                 enabled,
-                iocTypes, true
+                iocTypes, true,
+                null
         );
     }
 

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
@@ -59,7 +59,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
         List<STIX2IOCDto> iocs = List.of(new STIX2IOCDto(
                 "id",
                 "name",
-                new IOCType(IOCType.IPV4_TYPE),
+                IOCType.IPV4_TYPE,
                 "value",
                 "severity",
                 null,
@@ -169,7 +169,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
         List<STIX2IOCDto> iocs = List.of(new STIX2IOCDto(
                 "id",
                 "name",
-                new IOCType(IOCType.IPV4_TYPE),
+                IOCType.IPV4_TYPE,
                 "value",
                 "severity",
                 null,
@@ -222,7 +222,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
         List<STIX2IOCDto> iocs = List.of(new STIX2IOCDto(
                 "1",
                 "ioc",
-                new IOCType(IOCType.IPV4_TYPE),
+                IOCType.IPV4_TYPE,
                 "value",
                 "severity",
                 null,
@@ -301,7 +301,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
         iocs = List.of(new STIX2IOCDto(
                         "2",
                         "ioc",
-                        new IOCType(IOCType.HASHES_TYPE),
+                        IOCType.HASHES_TYPE,
                         "value",
                         "severity",
                         null,
@@ -315,7 +315,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 new STIX2IOCDto(
                         "3",
                         "ioc",
-                        new IOCType(IOCType.DOMAIN_NAME_TYPE),
+                        IOCType.DOMAIN_NAME_TYPE,
                         "value",
                         "severity",
                         null,
@@ -381,7 +381,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
         List<STIX2IOCDto> iocs = List.of(new STIX2IOCDto(
                 "1",
                 "ioc",
-                new IOCType(IOCType.IPV4_TYPE),
+                IOCType.IPV4_TYPE,
                 "value",
                 "severity",
                 null,
@@ -660,7 +660,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
         List<STIX2IOCDto> iocs = List.of(new STIX2IOCDto(
                 "id",
                 "name",
-                new IOCType(IOCType.IPV4_TYPE),
+                IOCType.IPV4_TYPE,
                 "value",
                 "severity",
                 null,
@@ -746,7 +746,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
         List<STIX2IOCDto> iocs = List.of(new STIX2IOCDto(
                 "id",
                 "name",
-                new IOCType(IOCType.IPV4_TYPE),
+                IOCType.IPV4_TYPE,
                 "value",
                 "severity",
                 null,
@@ -820,7 +820,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
         List<STIX2IOCDto> iocs = List.of(new STIX2IOCDto(
                 "id",
                 "name",
-                new IOCType(IOCType.IPV4_TYPE),
+                IOCType.IPV4_TYPE,
                 "value",
                 "severity",
                 null,
@@ -1030,7 +1030,7 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
         List<STIX2IOCDto> iocs = List.of(new STIX2IOCDto(
                 "id",
                 "name",
-                new IOCType(IOCType.IPV4_TYPE),
+                IOCType.IPV4_TYPE,
                 "value",
                 "severity",
                 null,

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
@@ -168,7 +168,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 false,
                 List.of(IOCType.IPV4_TYPE, IOCType.HASHES_TYPE, IOCType.DOMAIN_NAME_TYPE),
-                true
+                true, null
         );
 
         Response makeResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.THREAT_INTEL_SOURCE_URI, Collections.emptyMap(), toHttpEntity(saTifSourceConfigDto));

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
@@ -18,12 +18,12 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.search.SearchHit;
 import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
 import org.opensearch.securityanalytics.SecurityAnalyticsRestTestCase;
-import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
-import org.opensearch.securityanalytics.threatIntel.action.ListIOCsActionRequest;
 import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.model.Detector;
 import org.opensearch.securityanalytics.model.DetectorTrigger;
 import org.opensearch.securityanalytics.model.STIX2IOCDto;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
+import org.opensearch.securityanalytics.threatIntel.action.ListIOCsActionRequest;
 import org.opensearch.securityanalytics.threatIntel.common.RefreshType;
 import org.opensearch.securityanalytics.threatIntel.common.SourceConfigType;
 import org.opensearch.securityanalytics.threatIntel.common.TIFJobState;
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
-import static org.opensearch.securityanalytics.TestHelpers.randomAction;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorType;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithTriggers;
 import static org.opensearch.securityanalytics.TestHelpers.randomIndex;
@@ -55,7 +54,7 @@ import static org.opensearch.securityanalytics.threatIntel.resthandler.monitor.R
 
 public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
     private final Logger log = LogManager.getLogger(ThreatIntelMonitorRestApiIT.class);
-
+    private static final String RANDOM_TYPE = "SOMETHING";
     private List<STIX2IOCDto> testIocDtos = new ArrayList<>();
 
     public String indexSourceConfigsAndIocs(List<String> iocVals) throws IOException {
@@ -65,7 +64,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             STIX2IOCDto stix2IOCDto = new STIX2IOCDto(
                     "id" + i1,
                     "random",
-                    IOCType.IPV4_TYPE,
+                    RANDOM_TYPE,
                     iocVals.get(i1),
                     "",
                     Instant.now(),
@@ -90,7 +89,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             STIX2IOCDto stix2IOCDto = new STIX2IOCDto(
                     "id" + randomAlphaOfLength(3),
                     "random",
-                    IOCType.IPV4_TYPE,
+                    RANDOM_TYPE,
                     ipVals.get(i1),
                     "",
                     Instant.now(),
@@ -167,7 +166,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 null,
                 false,
-                List.of(IOCType.IPV4_TYPE, IOCType.HASHES_TYPE, IOCType.DOMAIN_NAME_TYPE),
+                List.of(RANDOM_TYPE, IOCType.HASHES_TYPE, IOCType.DOMAIN_NAME_TYPE),
                 true, null
         );
 
@@ -979,7 +978,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
     }
 
     public static ThreatIntelMonitorDto randomIocScanMonitorDto(String index) {
-        ThreatIntelTriggerDto t1 = new ThreatIntelTriggerDto(List.of(index, "randomIndex"), List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE), emptyList(), "match", null, "severity");
+        ThreatIntelTriggerDto t1 = new ThreatIntelTriggerDto(List.of(index, "randomIndex"), List.of(RANDOM_TYPE, IOCType.DOMAIN_NAME_TYPE), emptyList(), "match", null, "severity");
         ThreatIntelTriggerDto t2 = new ThreatIntelTriggerDto(List.of("randomIndex"), List.of(IOCType.DOMAIN_NAME_TYPE), emptyList(), "nomatch", null, "severity");
         ThreatIntelTriggerDto t3 = new ThreatIntelTriggerDto(emptyList(), List.of(IOCType.DOMAIN_NAME_TYPE), emptyList(), "domainmatchsonomatch", null, "severity");
         ThreatIntelTriggerDto t4 = new ThreatIntelTriggerDto(List.of(index), emptyList(), emptyList(), "indexmatch", null, "severity");
@@ -987,7 +986,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
         return new ThreatIntelMonitorDto(
                 Monitor.NO_ID,
                 randomAlphaOfLength(10),
-                List.of(new PerIocTypeScanInputDto(IOCType.IPV4_TYPE, Map.of(index, List.of("ip")))),
+                List.of(new PerIocTypeScanInputDto(RANDOM_TYPE, Map.of(index, List.of("ip")))),
                 new IntervalSchedule(1, ChronoUnit.MINUTES, Instant.now()),
                 false,
                 null,
@@ -995,12 +994,12 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
     }
 
     public static ThreatIntelMonitorDto randomIocScanMonitorDtoWithTriggers(String index, List<Action> actions) {
-        ThreatIntelTriggerDto t1 = new ThreatIntelTriggerDto(List.of(), List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE), actions, "match", null, "severity");
+        ThreatIntelTriggerDto t1 = new ThreatIntelTriggerDto(List.of(), List.of(RANDOM_TYPE, IOCType.DOMAIN_NAME_TYPE), actions, "match", null, "severity");
 
         return new ThreatIntelMonitorDto(
                 Monitor.NO_ID,
                 randomAlphaOfLength(10),
-                List.of(new PerIocTypeScanInputDto(IOCType.IPV4_TYPE, Map.of(index, List.of("ip")))),
+                List.of(new PerIocTypeScanInputDto(RANDOM_TYPE, Map.of(index, List.of("ip")))),
                 new IntervalSchedule(1, ChronoUnit.MINUTES, Instant.now()),
                 false,
                 null,
@@ -1008,7 +1007,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
     }
 
     public static ThreatIntelMonitorDto randomIocScanMonitorDtoWithMultipleIndicatorTypesToScan(String ipIndex, String hashIndex, String domainIndex) {
-        ThreatIntelTriggerDto t1 = new ThreatIntelTriggerDto(List.of(ipIndex, "randomIndex"), List.of(IOCType.IPV4_TYPE, IOCType.DOMAIN_NAME_TYPE), emptyList(), "match", null, "severity");
+        ThreatIntelTriggerDto t1 = new ThreatIntelTriggerDto(List.of(ipIndex, "randomIndex"), List.of(RANDOM_TYPE, IOCType.DOMAIN_NAME_TYPE), emptyList(), "match", null, "severity");
         ThreatIntelTriggerDto t2 = new ThreatIntelTriggerDto(List.of("randomIndex"), List.of(IOCType.DOMAIN_NAME_TYPE), emptyList(), "nomatch", null, "severity");
         ThreatIntelTriggerDto t3 = new ThreatIntelTriggerDto(emptyList(), List.of(IOCType.DOMAIN_NAME_TYPE), emptyList(), "domainmatchsonomatch", null, "severity");
         ThreatIntelTriggerDto t4 = new ThreatIntelTriggerDto(List.of(ipIndex), emptyList(), emptyList(), "indexmatch", null, "severity");
@@ -1017,7 +1016,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                 Monitor.NO_ID,
                 randomAlphaOfLength(10),
                 List.of(
-                        new PerIocTypeScanInputDto(IOCType.IPV4_TYPE, Map.of(ipIndex, List.of("ip"))),
+                        new PerIocTypeScanInputDto(RANDOM_TYPE, Map.of(ipIndex, List.of("ip"))),
                         new PerIocTypeScanInputDto(IOCType.HASHES_TYPE, Map.of(hashIndex, List.of("hash"))),
                         new PerIocTypeScanInputDto(IOCType.DOMAIN_NAME_TYPE, Map.of(domainIndex, List.of("domain")))
                 ),

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
@@ -1,8 +1,8 @@
 package org.opensearch.securityanalytics.resthandler;
 
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
@@ -65,7 +65,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             STIX2IOCDto stix2IOCDto = new STIX2IOCDto(
                     "id" + i1,
                     "random",
-                    new IOCType(IOCType.IPV4_TYPE),
+                    IOCType.IPV4_TYPE,
                     iocVals.get(i1),
                     "",
                     Instant.now(),
@@ -90,7 +90,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             STIX2IOCDto stix2IOCDto = new STIX2IOCDto(
                     "id" + randomAlphaOfLength(3),
                     "random",
-                    new IOCType(IOCType.IPV4_TYPE),
+                    IOCType.IPV4_TYPE,
                     ipVals.get(i1),
                     "",
                     Instant.now(),
@@ -110,7 +110,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             STIX2IOCDto stix2IOCDto = new STIX2IOCDto(
                     "id" + randomAlphaOfLength(3),
                     "random",
-                    new IOCType(IOCType.HASHES_TYPE),
+                    IOCType.HASHES_TYPE,
                     hashVals.get(i1),
                     "",
                     Instant.now(),
@@ -130,7 +130,7 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             STIX2IOCDto stix2IOCDto = new STIX2IOCDto(
                     "id" + randomAlphaOfLength(3),
                     "random",
-                    new IOCType(IOCType.DOMAIN_NAME_TYPE),
+                    IOCType.DOMAIN_NAME_TYPE,
                     domainVals.get(i1),
                     "",
                     Instant.now(),

--- a/src/test/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchemaTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchemaTests.java
@@ -1,0 +1,4 @@
+package org.opensearch.securityanalytics.threatIntel.model;
+
+public class JsonPathIocSchemaTests {
+}

--- a/src/test/java/org/opensearch/securityanalytics/util/STIX2IOCGenerator.java
+++ b/src/test/java/org/opensearch/securityanalytics/util/STIX2IOCGenerator.java
@@ -36,7 +36,7 @@ import static org.opensearch.test.OpenSearchTestCase.randomLong;
 
 public class STIX2IOCGenerator implements PojoGenerator {
     private List<STIX2IOC> iocs;
-    private List<IOCType> types = IOCType.types.stream().map(IOCType::new).collect(Collectors.toList());
+    private List<String> types = IOCType.types;
 
     private final ObjectMapper objectMapper;
 
@@ -44,7 +44,7 @@ public class STIX2IOCGenerator implements PojoGenerator {
         this.objectMapper = new ObjectMapper();
     }
 
-    public STIX2IOCGenerator(List<IOCType> types) {
+    public STIX2IOCGenerator(List<String> types) {
         this();
         this.types = types;
     }
@@ -64,7 +64,7 @@ public class STIX2IOCGenerator implements PojoGenerator {
      */
     private void writeLines(final int numberOfIOCs, final PrintWriter printWriter) {
         final List<STIX2IOC> iocs = new ArrayList<>();
-        for (IOCType type : types) {
+        for (String type : types) {
             final List<STIX2IOC> newIocs = IntStream.range(0, numberOfIOCs)
                     .mapToObj(i -> randomIOC(type))
                     .collect(Collectors.toList());
@@ -88,7 +88,7 @@ public class STIX2IOCGenerator implements PojoGenerator {
         }
     }
 
-    public static STIX2IOC randomIOC(IOCType type) {
+    public static STIX2IOC randomIOC(String type) {
         return randomIOC(
                 null,
                 null,
@@ -114,14 +114,14 @@ public class STIX2IOCGenerator implements PojoGenerator {
         return iocs;
     }
 
-    public List<IOCType> getTypes() {
+    public List<String> getTypes() {
         return types;
     }
 
     public static STIX2IOC randomIOC(
             String id,
             String name,
-            IOCType type,
+            String type,
             String value,
             String severity,
             Instant created,
@@ -137,7 +137,7 @@ public class STIX2IOCGenerator implements PojoGenerator {
             name = randomLowerCaseString();
         }
         if (type == null) {
-            type = new IOCType(IOCType.types.get(randomInt(IOCType.types.size() - 1)));
+            type = IOCType.types.get(randomInt(IOCType.types.size() - 1));
         }
         if (value == null) {
             value = randomLowerCaseString();
@@ -193,14 +193,14 @@ public class STIX2IOCGenerator implements PojoGenerator {
         return new STIX2IOCDto(randomIOC());
     }
 
-    public static STIX2IOCDto randomIocDto(IOCType type) {
+    public static STIX2IOCDto randomIocDto(String type) {
         return new STIX2IOCDto(randomIOC(type));
     }
 
     public static STIX2IOCDto randomIocDto(
             String id,
             String name,
-            IOCType type,
+            String type,
             String value,
             String severity,
             Instant created,

--- a/src/test/resources/threatIntel/custom_schema_ioc/custom_schema_1.json
+++ b/src/test/resources/threatIntel/custom_schema_ioc/custom_schema_1.json
@@ -1,0 +1,5306 @@
+{
+  "1344180": [
+    {
+      "ioc_value": "204.10.160.239:9682",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-11 08:50:11",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "https://bazaar.abuse.ch/sample/84d5e09f1dec559db8fe63f3f9f9d2fab52963d9aba8d0f590d266fb7da6b30d/",
+      "tags": "remcos",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344179": [
+    {
+      "ioc_value": "45.147.46.188:1604",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-11 08:10:09",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "AsyncRAT,RAT",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344178": [
+    {
+      "ioc_value": "185.149.234.209:29000",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-11 08:05:14",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "https://bazaar.abuse.ch/sample/7e1c0ca51cd0f6806f1fe6ddbb45fa4e00b288c686003f3e50b5ee71d2c6818d/",
+      "tags": "remcos",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344177": [
+    {
+      "ioc_value": "185.149.234.209:28000",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-11 08:05:13",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "https://bazaar.abuse.ch/sample/7e1c0ca51cd0f6806f1fe6ddbb45fa4e00b288c686003f3e50b5ee71d2c6818d/",
+      "tags": "remcos",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344176": [
+    {
+      "ioc_value": "185.149.234.209:27000",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-11 08:05:12",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "https://bazaar.abuse.ch/sample/7e1c0ca51cd0f6806f1fe6ddbb45fa4e00b288c686003f3e50b5ee71d2c6818d/",
+      "tags": "remcos",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344175": [
+    {
+      "ioc_value": "185.149.234.209:2700",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-11 08:05:11",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "https://bazaar.abuse.ch/sample/7e1c0ca51cd0f6806f1fe6ddbb45fa4e00b288c686003f3e50b5ee71d2c6818d/",
+      "tags": "remcos",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344174": [
+    {
+      "ioc_value": "94.159.113.79:8888",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.strelastealer",
+      "malware_alias": null,
+      "malware_printable": "StrelaStealer",
+      "first_seen_utc": "2024-11-11 08:03:03",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "https://bazaar.abuse.ch/sample/16d767a9d05c17140fd3f1a6c6e106015681c3b8f46b32f3a1b4f97663ce5e4a/",
+      "tags": "StrelaStealer",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344173": [
+    {
+      "ioc_value": "193.58.121.40:8080",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "apk.ermac",
+      "malware_alias": null,
+      "malware_printable": "ERMAC",
+      "first_seen_utc": "2024-11-11 08:02:22",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/193.58.121.40",
+      "tags": "AS215439,C2,censys,Ermac,panel,PLAY2GO-NET",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344172": [
+    {
+      "ioc_value": "198.167.199.232:19132",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.quasar_rat",
+      "malware_alias": "CinaRAT,QuasarRAT,Yggdrasil",
+      "malware_printable": "Quasar RAT",
+      "first_seen_utc": "2024-11-11 08:02:14",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/198.167.199.232",
+      "tags": "ABSTRACT,AS39287,C2,censys,Quasar,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344171": [
+    {
+      "ioc_value": "193.26.115.178:8808",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-11 08:02:01",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/193.26.115.178",
+      "tags": "AS23470,AsyncRAT,C2,censys,RAT,RELIABLESITE",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344170": [
+    {
+      "ioc_value": "104.243.47.79:8888",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-11 08:02:00",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/104.243.47.79",
+      "tags": "AS23470,AsyncRAT,C2,censys,RAT,RELIABLESITE",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344169": [
+    {
+      "ioc_value": "62.234.65.53:8888",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-11 08:01:58",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/62.234.65.53",
+      "tags": "AS45090,C2,censys,Supershell,TENCENT-NET-AP",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344168": [
+    {
+      "ioc_value": "165.192.158.140:31337",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.sliver",
+      "malware_alias": null,
+      "malware_printable": "Sliver",
+      "first_seen_utc": "2024-11-11 08:01:53",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/165.192.158.140",
+      "tags": "AS36351,C2,censys,Sliver,SOFTLAYER",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344166": [
+    {
+      "ioc_value": "45.88.186.186:2404",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-11 08:01:50",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/45.88.186.186",
+      "tags": "AS23470,C2,censys,RAT,RELIABLESITE,Remcos",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344167": [
+    {
+      "ioc_value": "192.3.101.149:8764",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-11 08:01:50",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/192.3.101.149",
+      "tags": "AS-COLOCROSSING,AS36352,C2,censys,RAT,Remcos",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344165": [
+    {
+      "ioc_value": "116.62.190.75:8080",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 08:01:05",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/116.62.190.75",
+      "tags": "ALIBABA-CN-NET,AS37963,C2,censys,CobaltStrike,cs-watermark-305419896",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344164": [
+    {
+      "ioc_value": "45.14.226.17:8443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 08:01:03",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/45.14.226.17",
+      "tags": "AS49042,C2,censys,CobaltStrike,cs-watermark-666666666,PHANES-NETWORKS",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344163": [
+    {
+      "ioc_value": "103.136.150.15:7443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 08:01:01",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/103.136.150.15",
+      "tags": "AS26383,ASNET,C2,censys,CobaltStrike,cs-watermark-100000",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344162": [
+    {
+      "ioc_value": "119.45.19.232:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 08:00:59",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/119.45.19.232",
+      "tags": "AS45090,C2,censys,CobaltStrike,cs-watermark-987654321,TENCENT-NET-AP",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344161": [
+    {
+      "ioc_value": "47.101.147.34:9000",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 08:00:58",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/47.101.147.34",
+      "tags": "ALIBABA-CN-NET,AS37963,C2,censys,CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344160": [
+    {
+      "ioc_value": "54.205.245.188:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:56:52",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344159": [
+    {
+      "ioc_value": "121.43.62.51:8443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:56:51",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344158": [
+    {
+      "ioc_value": "80.78.24.206:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:56:47",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344157": [
+    {
+      "ioc_value": "47.108.159.178:5555",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:56:46",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344156": [
+    {
+      "ioc_value": "1.194.50.126:7777",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:56:43",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344155": [
+    {
+      "ioc_value": "81.70.38.249:8888",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:56:42",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344154": [
+    {
+      "ioc_value": "34.55.187.149:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:56:19",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344153": [
+    {
+      "ioc_value": "156.238.247.148:2096",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:56:14",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344152": [
+    {
+      "ioc_value": "15.204.244.46:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:56:12",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344151": [
+    {
+      "ioc_value": "18.246.39.189:801",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:55:40",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-1234567890",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344150": [
+    {
+      "ioc_value": "185.208.159.156:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:55:27",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344149": [
+    {
+      "ioc_value": "45.140.42.226:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:55:26",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-1580103814",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344148": [
+    {
+      "ioc_value": "18.246.39.189:808",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:55:21",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-1234567890",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344147": [
+    {
+      "ioc_value": "121.43.110.28:81",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 07:55:20",
+      "last_seen_utc": "2024-11-11 08:00:59",
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1344146": [
+    {
+      "ioc_value": "events.socalpocis.org",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "js.fakeupdates",
+      "malware_alias": "FakeUpdate,SocGholish",
+      "malware_printable": "FAKEUPDATES",
+      "first_seen_utc": "2024-11-11 07:42:51",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://infosec.exchange/@monitorsg/113463122724541433",
+      "tags": "SocGholish",
+      "anonymous": "0",
+      "reporter": "monitorsg"
+    }
+  ],
+  "1344132": [
+    {
+      "ioc_value": "http://human-verification5.b-cdn.net/captcha-verify-v3.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:12:04",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344129": [
+    {
+      "ioc_value": "https://human-verification5.b-cdn.net/captcha-verify-v7.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:12:03",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344130": [
+    {
+      "ioc_value": "https://greenenorgusd.b-cdn.net/verify-captcha-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:12:03",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344131": [
+    {
+      "ioc_value": "https://human-check.b-cdn.net/verify-captcha-v7.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:12:03",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344127": [
+    {
+      "ioc_value": "https://pub-9c4ec7f3f95c448b85e464d2b533aac1.r2.dev/CAptcha-verify-Approvals-system.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:12:02",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344128": [
+    {
+      "ioc_value": "https://provenotrobot.b-cdn.net/verify-captcha-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:12:02",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344126": [
+    {
+      "ioc_value": "https://human-verification4.b-cdn.net/captcha-verify-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:12:01",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344124": [
+    {
+      "ioc_value": "http://bot-checker.b-cdn.net/captcha-verify-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:12:00",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344125": [
+    {
+      "ioc_value": "http://pub-9c4ec7f3f95c448b85e464d2b533aac1.r2.dev/captcha-verify-approval-sys.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:12:00",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344122": [
+    {
+      "ioc_value": "https://newvideozones.click/verify-captcha-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:59",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344123": [
+    {
+      "ioc_value": "https://pub-9c4ec7f3f95c448b85e464d2b533aac1.r2.dev/human-verify-systemms.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:59",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344119": [
+    {
+      "ioc_value": "https://get-verified2.b-cdn.net/captcha-verify-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:58",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344120": [
+    {
+      "ioc_value": "https://spam.b-cdn.net/verify-captcha-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:58",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344121": [
+    {
+      "ioc_value": "https://sdkjhfdskjnck.s3.amazonaws.com/human-verify-system.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:58",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344117": [
+    {
+      "ioc_value": "http://bot-test.b-cdn.net/verify-captcha-v3.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:57",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344118": [
+    {
+      "ioc_value": "http://myapt67.s3.amazonaws.com/human-verify-system-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:57",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344115": [
+    {
+      "ioc_value": "https://second-step.b-cdn.net/verify-captcha-v4.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:56",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344116": [
+    {
+      "ioc_value": "http://lengo-20cb4.kxcdn.com/human-verify-system.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:56",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344112": [
+    {
+      "ioc_value": "https://human-verify1.b-cdn.net/captcha-verify-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:55",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344113": [
+    {
+      "ioc_value": "http://verifyhuman476.b-cdn.net/human-verify-system.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:55",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344114": [
+    {
+      "ioc_value": "https://href.li/?https://pub-9c4ec7f3f95c448b85e464d2b533aac1.r2.dev/captcha-verify-Approval-sys.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:55",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344111": [
+    {
+      "ioc_value": "http://anti-bot1.b-cdn.net/verify-captcha-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:54",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344110": [
+    {
+      "ioc_value": "https://human-verify02.b-cdn.net/captcha-verify-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:53",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344108": [
+    {
+      "ioc_value": "https://stream-checker.b-cdn.net/captcha-verify-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:51",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344109": [
+    {
+      "ioc_value": "https://bot-checker.b-cdn.net/captcha-verify-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:51",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344105": [
+    {
+      "ioc_value": "https://bot-detector.b-cdn.net/captcha-verify-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:50",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344106": [
+    {
+      "ioc_value": "https://verify-captcha-987.b-cdn.net/verify-captcha-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:50",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344107": [
+    {
+      "ioc_value": "https://bot-check2.b-cdn.net/captcha-verify-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:50",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344103": [
+    {
+      "ioc_value": "https://pub-9c4ec7f3f95c448b85e464d2b533aac1.r2.dev/captcha-verify-Approval-sys.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:49",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344104": [
+    {
+      "ioc_value": "https://myapt67.s3.amazonaws.com/verify-captcha-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:49",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344101": [
+    {
+      "ioc_value": "https://check-bot11.b-cdn.net/captcha-verify-v11.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:48",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344102": [
+    {
+      "ioc_value": "https://botcheck.b-cdn.net/captcha-verify-v7.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:48",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344100": [
+    {
+      "ioc_value": "https://bot-detector.b-cdn.net/captcha-verify-v3.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:47",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344099": [
+    {
+      "ioc_value": "https://bot-check3.b-cdn.net/captcha-verify-v8.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:46",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344097": [
+    {
+      "ioc_value": "https://human-verification5.b-cdn.net/captcha-verify-v3.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:45",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344098": [
+    {
+      "ioc_value": "http://bot-check3.b-cdn.net/captcha-verify-v8.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:45",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344093": [
+    {
+      "ioc_value": "https://human-check2.b-cdn.net/verify-captcha-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:44",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344096": [
+    {
+      "ioc_value": "http://botcheck.b-cdn.net/captcha-verify-v7.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:44",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344134": [
+    {
+      "ioc_value": "https://hbhjkbjhbjkhv11.b-cdn.net/verify-captcha-fast-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:42",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344133": [
+    {
+      "ioc_value": "https://provenotrobot.b-cdn.net/verify-captcha-vm.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:41",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344135": [
+    {
+      "ioc_value": "https://bot-check2.b-cdn.net/captcha-verify-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:40",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344136": [
+    {
+      "ioc_value": "http://newvideozones.click/verify-captcha-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:40",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344137": [
+    {
+      "ioc_value": "http://human-check.b-cdn.net/verify-captcha-v7.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:39",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344138": [
+    {
+      "ioc_value": "https://spam-check1.b-cdn.net/captcha-verify-v9.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:39",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344139": [
+    {
+      "ioc_value": "https://bot-check3.b-cdn.net/captcha-verify-v3.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:37",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344140": [
+    {
+      "ioc_value": "https://pub-9c4ec7f3f95c448b85e464d2b533aac1.r2.dev/human-verify-system.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:37",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344141": [
+    {
+      "ioc_value": "http://captcha-verf-sys-v3.b-cdn.net/verify-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:36",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344142": [
+    {
+      "ioc_value": "https://verifyhuman476.b-cdn.net/human-verify-system.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:36",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344143": [
+    {
+      "ioc_value": "http://apzzz-20c7e.kxcdn.com/verify-captcha-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:35",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344144": [
+    {
+      "ioc_value": "https://robo-step.b-cdn.net/verify-captcha-vt.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:35",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344145": [
+    {
+      "ioc_value": "http://bot-check3.b-cdn.net/captcha-verify-v3.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:34",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344057": [
+    {
+      "ioc_value": "b323100233914a4abb4d47c21289801e",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-11 06:11:31",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/submissions",
+      "tags": "mirai,moobot",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344095": [
+    {
+      "ioc_value": "https://get-verified.b-cdn.net/captcha-verify-v5.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:30",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344092": [
+    {
+      "ioc_value": "http://human-check2.b-cdn.net/verify-captcha-v2.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:29",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344094": [
+    {
+      "ioc_value": "http://bot-detector.b-cdn.net/captcha-verify-v1.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:29",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344090": [
+    {
+      "ioc_value": "http://104.168.50.203:9988/supershell/login/",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-11 06:11:28",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "AS36352,HostPapa,supershell",
+      "anonymous": "0",
+      "reporter": "antiphishorg"
+    }
+  ],
+  "1344091": [
+    {
+      "ioc_value": "http://first-steps.b-cdn.net/captcha-verify-v7.html",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-11 06:11:28",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "LummaStealer",
+      "anonymous": "0",
+      "reporter": "lontze7"
+    }
+  ],
+  "1344060": [
+    {
+      "ioc_value": "56191824016419a928a4b537fc602f6d",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-11 06:11:27",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/submissions",
+      "tags": "mirai,moobot",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344058": [
+    {
+      "ioc_value": "2f987e0f5eca776cd0c39996b2e5ac54",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-11 06:11:26",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/submissions",
+      "tags": "mirai,moobot",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344056": [
+    {
+      "ioc_value": "7b6ab415c71284b4c35e8690d71af208",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-11 06:11:25",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/submissions",
+      "tags": "mirai,moobot",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344048": [
+    {
+      "ioc_value": "http://103.233.9.10:8888/supershell/login/",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-11 06:11:24",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "ABCDE GROUP,AS133201,supershell",
+      "anonymous": "0",
+      "reporter": "antiphishorg"
+    }
+  ],
+  "1344059": [
+    {
+      "ioc_value": "2c6888b9b00b4f21da3b3d81d5e62205",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-11 06:11:24",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/submissions",
+      "tags": "mirai,moobot",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344061": [
+    {
+      "ioc_value": "7005b86eb81d192f72dd572e63456677",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-11 06:11:23",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/submissions",
+      "tags": "mirai,moobot",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344062": [
+    {
+      "ioc_value": "178e5859d8d729693d85709e9454bdf6",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-11 06:11:23",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/submissions",
+      "tags": "mirai,moobot",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344063": [
+    {
+      "ioc_value": "a4607b1c8b7260da9dfa220db57df301",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-11 06:11:22",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/submissions",
+      "tags": "mirai,moobot",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344064": [
+    {
+      "ioc_value": "b6460b975d5453afdde9da16ef21b9c8",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-11 06:11:22",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/submissions",
+      "tags": "mirai,moobot",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344065": [
+    {
+      "ioc_value": "91.219.215.229:30426",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 06:11:21",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "",
+      "tags": "c2,cobaltstrike",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344066": [
+    {
+      "ioc_value": "154.213.189.2:61231",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.mirai",
+      "malware_alias": "Katana",
+      "malware_printable": "Mirai",
+      "first_seen_utc": "2024-11-11 06:11:21",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": null,
+      "tags": "Mirai",
+      "anonymous": "0",
+      "reporter": "elfdigest"
+    }
+  ],
+  "1344089": [
+    {
+      "ioc_value": "46.200.psinetpa.net.prodejdilu.cz",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.mimikatz",
+      "malware_alias": null,
+      "malware_printable": "MimiKatz",
+      "first_seen_utc": "2024-11-11 04:03:06",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/62.109.5.25+46.200.psinetpa.net.prodejdilu.cz",
+      "tags": "AS29182,C2,censys,hacktool,Mimikatz,open-dir,RU-JSCIOT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344088": [
+    {
+      "ioc_value": "gsttrust.org",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-11 04:02:49",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/172.67.169.37+gsttrust.org",
+      "tags": "Android,AS13335,censys,CLOUDFLARENET,GhostSpy,GoatRAT,panel",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344087": [
+    {
+      "ioc_value": "ol.d123f23f32.ip-ddns.com",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-11 04:02:45",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/149.88.84.204+ol.d123f23f32.ip-ddns.com",
+      "tags": "AS142032,censys,EvilGinx,HFTCL-AS-AP,panel,Phishing",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344086": [
+    {
+      "ioc_value": "13.125.222.217:35554",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.netsupportmanager_rat",
+      "malware_alias": "NetSupport",
+      "malware_printable": "NetSupportManager RAT",
+      "first_seen_utc": "2024-11-11 04:02:26",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/13.125.222.217",
+      "tags": "AMAZON-02,AS16509,C2,censys,Netsupport,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344085": [
+    {
+      "ioc_value": "94.141.120.170:45051",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "apk.hook",
+      "malware_alias": null,
+      "malware_printable": "Hook",
+      "first_seen_utc": "2024-11-11 04:02:11",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/94.141.120.170",
+      "tags": "AS214940,C2,censys,Hookbot,KPRONET",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344083": [
+    {
+      "ioc_value": "78.162.164.147:20000",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-11 04:01:56",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/78.162.164.147",
+      "tags": "AS9121,AsyncRAT,C2,censys,RAT,TTNET",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344084": [
+    {
+      "ioc_value": "193.255.70.34.bc.googleusercontent.com",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-11 04:01:56",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/34.70.255.193+193.255.70.34.bc.googleusercontent.com",
+      "tags": "AS396982,AsyncRAT,C2,censys,GOOGLE-CLOUD-PLATFORM,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344082": [
+    {
+      "ioc_value": "83.147.53.93:7707",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-11 04:01:55",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/83.147.53.93",
+      "tags": "AS399486,AsyncRAT,C2,censys,RAT,VIRTUO",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344081": [
+    {
+      "ioc_value": "103.233.9.20:8888",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-11 04:01:51",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/103.233.9.20",
+      "tags": "AS133201,C2,censys,COMING-AS,Supershell",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344080": [
+    {
+      "ioc_value": "8.218.244.117:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.shadowpad",
+      "malware_alias": "POISONPLUG.SHADOW,XShellGhost",
+      "malware_printable": "ShadowPad",
+      "first_seen_utc": "2024-11-11 04:01:49",
+      "last_seen_utc": null,
+      "confidence_level": 90,
+      "reference": "https://search.censys.io/hosts/8.218.244.117",
+      "tags": "ALIBABA-CN-NET,AS45102,C2,censys,RAT,ShadowPad",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344079": [
+    {
+      "ioc_value": "195.10.205.207:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-11 04:01:10",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/195.10.205.207",
+      "tags": "0debug,AS215826,C2,censys,panel,PARTNER-HOSTING-LTD,Stealer",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344078": [
+    {
+      "ioc_value": "206.119.160.250:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 04:00:59",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/206.119.160.250",
+      "tags": "AS133199,C2,censys,CobaltStrike,cs-watermark-987654321,SONDERCLOUDLIMITED-AS-AP",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344077": [
+    {
+      "ioc_value": "206.119.160.250:8080",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 04:00:58",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/206.119.160.250",
+      "tags": "AS133199,C2,censys,CobaltStrike,cs-watermark-987654321,SONDERCLOUDLIMITED-AS-AP",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344076": [
+    {
+      "ioc_value": "1.94.33.219:8848",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.dcrat",
+      "malware_alias": "DarkCrystal RAT",
+      "malware_printable": "DCRat",
+      "first_seen_utc": "2024-11-11 00:02:26",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/1.94.33.219",
+      "tags": "AS55990,C2,censys,DcRAT,HWCSNET,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344075": [
+    {
+      "ioc_value": "181.162.182.77:8080",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.quasar_rat",
+      "malware_alias": "CinaRAT,QuasarRAT,Yggdrasil",
+      "malware_printable": "Quasar RAT",
+      "first_seen_utc": "2024-11-11 00:02:23",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/181.162.182.77",
+      "tags": "AS7418,C2,censys,Quasar,RAT,TELEFONICA",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344074": [
+    {
+      "ioc_value": "135.125.9.127:7443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-11 00:02:16",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/135.125.9.127",
+      "tags": "AS16276,C2,censys,Mythic,OVH",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344073": [
+    {
+      "ioc_value": "92.255.85.128:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.matanbuchus",
+      "malware_alias": null,
+      "malware_printable": "Matanbuchus",
+      "first_seen_utc": "2024-11-11 00:02:01",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/92.255.85.128",
+      "tags": "AS207566,C2,censys,LD007-AS,Matanbuchus",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344072": [
+    {
+      "ioc_value": "104.131.185.147:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.sliver",
+      "malware_alias": null,
+      "malware_printable": "Sliver",
+      "first_seen_utc": "2024-11-11 00:01:58",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/104.131.185.147",
+      "tags": "AS14061,C2,censys,DIGITALOCEAN-ASN,Sliver",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344071": [
+    {
+      "ioc_value": "45.141.84.135:54184",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.pupy",
+      "malware_alias": "Patpoopy",
+      "malware_printable": "pupy",
+      "first_seen_utc": "2024-11-11 00:01:54",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/45.141.84.135",
+      "tags": "AS206728,C2,censys,MEDIALAND-AS,Pupy,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344070": [
+    {
+      "ioc_value": "172.111.139.141:2404",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-11 00:01:51",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/172.111.139.141",
+      "tags": "AS212238,C2,CDNEXT,censys,RAT,Remcos",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344069": [
+    {
+      "ioc_value": "87.120.117.233:2404",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-11 00:01:49",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/87.120.117.233",
+      "tags": "AS401115,C2,censys,EKABI,RAT,Remcos",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344068": [
+    {
+      "ioc_value": "208.115.220.58:2404",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-11 00:01:48",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/208.115.220.58",
+      "tags": "AS46475,C2,censys,LIMESTONENETWORKS,RAT,Remcos",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344067": [
+    {
+      "ioc_value": "123.207.196.103:1111",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-11 00:01:05",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/123.207.196.103",
+      "tags": "AS45090,C2,censys,CobaltStrike,cs-watermark-987654321,TENCENT-NET-AP",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344055": [
+    {
+      "ioc_value": "mail.izoa.netsons.org",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-10 20:02:26",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/46.252.158.186+mail.izoa.netsons.org",
+      "tags": "AS60087,ASSUPERNOVA,C2,censys,panel,Unam",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344054": [
+    {
+      "ioc_value": "95.215.204.91:7222",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.venom",
+      "malware_alias": null,
+      "malware_printable": "Venom RAT",
+      "first_seen_utc": "2024-11-10 20:02:04",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/95.215.204.91",
+      "tags": "AS211381,C2,censys,PODAON,RAT,Venom",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344052": [
+    {
+      "ioc_value": "34.69.89.225:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-10 20:01:53",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/34.69.89.225",
+      "tags": "AS396982,C2,censys,GOOGLE-CLOUD-PLATFORM,Mythic",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344053": [
+    {
+      "ioc_value": "20.121.120.162:7443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-10 20:01:53",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/20.121.120.162",
+      "tags": "AS8075,C2,censys,MICROSOFT-CORP-MSN-AS-BLOCK,Mythic",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344051": [
+    {
+      "ioc_value": "vmi1669379.contaboserver.net",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-10 20:01:43",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/109.199.104.52+vmi1669379.contaboserver.net",
+      "tags": "AS51167,AsyncRAT,C2,censys,CONTABO,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344050": [
+    {
+      "ioc_value": "159.223.77.188:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 20:00:58",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/159.223.77.188",
+      "tags": "AS14061,C2,censys,CobaltStrike,cs-watermark-391144938,DIGITALOCEAN-ASN",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344049": [
+    {
+      "ioc_value": "156.238.227.43:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 20:00:56",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/156.238.227.43",
+      "tags": "AS8796,C2,censys,CobaltStrike,cs-watermark-987654321,FD-298-8796",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344047": [
+    {
+      "ioc_value": "193.31.41.56:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.koiloader",
+      "malware_alias": null,
+      "malware_printable": "Koi Loader",
+      "first_seen_utc": "2024-11-10 17:17:40",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "KoiLoader",
+      "anonymous": "0",
+      "reporter": "NDA0E"
+    }
+  ],
+  "1344046": [
+    {
+      "ioc_value": "http://193.31.41.56/take.php",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.koiloader",
+      "malware_alias": null,
+      "malware_printable": "Koi Loader",
+      "first_seen_utc": "2024-11-10 17:17:21",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://bazaar.abuse.ch/sample/60f408d3351c35ecd4227a04eba05c7378b5ac08e6bbb7b12872829f901cef48/",
+      "tags": "KoiLoader",
+      "anonymous": "0",
+      "reporter": "NDA0E"
+    }
+  ],
+  "1344031": [
+    {
+      "ioc_value": "moviecentral-petparade2.com",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.amadey",
+      "malware_alias": null,
+      "malware_printable": "Amadey",
+      "first_seen_utc": "2024-11-10 16:21:04",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "",
+      "tags": "amadey,c2c",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344032": [
+    {
+      "ioc_value": "moviecentral-petparade3.com",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.amadey",
+      "malware_alias": null,
+      "malware_printable": "Amadey",
+      "first_seen_utc": "2024-11-10 16:21:03",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "",
+      "tags": "amadey,c2c",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344033": [
+    {
+      "ioc_value": "wanderlust-gadgetnews.shop",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 16:21:03",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/tasks/5007b8c6-b274-434c-bd8c-54a66a6a4471",
+      "tags": "lumma,stealer",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344034": [
+    {
+      "ioc_value": "tech-tribune.online",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 16:21:02",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/tasks/5007b8c6-b274-434c-bd8c-54a66a6a4471",
+      "tags": "lumma,stealer",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344041": [
+    {
+      "ioc_value": "joinykeryzi.fun",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 16:21:02",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/tasks/717f128f-0a7a-4ecb-9272-a2dc8fe72942",
+      "tags": "lumma,stealer",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344043": [
+    {
+      "ioc_value": "intentiongi.cyou",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 16:21:01",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "https://app.any.run/tasks/6a175b84-ac82-4c4f-8653-6f7b0e73ea99",
+      "tags": "lumma,stealer",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344044": [
+    {
+      "ioc_value": "217.195.153.196:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.koiloader",
+      "malware_alias": null,
+      "malware_printable": "Koi Loader",
+      "first_seen_utc": "2024-11-10 16:21:01",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "",
+      "tags": "koi,koiloader",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1344042": [
+    {
+      "ioc_value": "https://livelol.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 16:05:25",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,lumma,stealer",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344040": [
+    {
+      "ioc_value": "94.237.101.5:8080",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.mimikatz",
+      "malware_alias": null,
+      "malware_printable": "MimiKatz",
+      "first_seen_utc": "2024-11-10 16:02:15",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/94.237.101.5",
+      "tags": "AS202053,C2,censys,hacktool,Mimikatz,open-dir,UPCLOUD",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344039": [
+    {
+      "ioc_value": "94.237.29.84:8000",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.mimikatz",
+      "malware_alias": null,
+      "malware_printable": "MimiKatz",
+      "first_seen_utc": "2024-11-10 16:02:14",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/94.237.29.84",
+      "tags": "AS202053,C2,censys,hacktool,Mimikatz,open-dir,UPCLOUD",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344038": [
+    {
+      "ioc_value": "103.117.122.232:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-10 16:02:01",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/103.117.122.232",
+      "tags": "AS134365,C2,censys,HKLNIL,moobot",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344037": [
+    {
+      "ioc_value": "185.213.20.208:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-10 16:01:51",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/185.213.20.208",
+      "tags": "AS49367,ASSEFLOW,C2,censys,Covenant",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344036": [
+    {
+      "ioc_value": "136.144.166.132:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.havoc",
+      "malware_alias": "Havokiz",
+      "malware_printable": "Havoc",
+      "first_seen_utc": "2024-11-10 16:01:44",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/136.144.166.132",
+      "tags": "AS20857,C2,censys,Havoc,TRANSIP-AS",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1344035": [
+    {
+      "ioc_value": "196.70.94.53:8080",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-10 16:01:32",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/196.70.94.53",
+      "tags": "AS36903,AsyncRAT,C2,censys,MT-MPLS,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343995": [
+    {
+      "ioc_value": "67e949f4c3d6c38347d961a6340704a9",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "win.redline_stealer",
+      "malware_alias": "RECORDSTEALER",
+      "malware_printable": "RedLine Stealer",
+      "first_seen_utc": "2024-11-10 15:29:12",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1343996": [
+    {
+      "ioc_value": "3ed57cff0ba2a6dc82891d44aa7617f7",
+      "ioc_type": "md5_hash",
+      "threat_type": "payload",
+      "malware": "win.redline_stealer",
+      "malware_alias": "RECORDSTEALER",
+      "malware_printable": "RedLine Stealer",
+      "first_seen_utc": "2024-11-10 15:29:11",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1343976": [
+    {
+      "ioc_value": "https://thinkyyokej.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:56",
+      "last_seen_utc": "2024-11-11 05:50:19",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343977": [
+    {
+      "ioc_value": "https://ducksringjk.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:56",
+      "last_seen_utc": "2024-11-11 05:50:18",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343978": [
+    {
+      "ioc_value": "https://explainvees.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:56",
+      "last_seen_utc": "2024-11-11 05:50:14",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343979": [
+    {
+      "ioc_value": "https://brownieyuz.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:55",
+      "last_seen_utc": "2024-11-11 05:50:16",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343980": [
+    {
+      "ioc_value": "https://rottieud.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:54",
+      "last_seen_utc": "2024-11-11 05:50:17",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343981": [
+    {
+      "ioc_value": "https://relalingj.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:54",
+      "last_seen_utc": "2024-11-11 05:50:15",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343991": [
+    {
+      "ioc_value": "http://185.215.113.209/Fru7Nk9/Login.php",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.amadey",
+      "malware_alias": null,
+      "malware_printable": "Amadey",
+      "first_seen_utc": "2024-11-10 15:28:53",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "1337TEAM LIMITED,amadey,AS51381",
+      "anonymous": "0",
+      "reporter": "antiphishorg"
+    }
+  ],
+  "1343982": [
+    {
+      "ioc_value": "https://tamedgeesy.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:52",
+      "last_seen_utc": "2024-11-11 05:50:18",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343992": [
+    {
+      "ioc_value": "https://marshal-zhukov.com/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:52",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343990": [
+    {
+      "ioc_value": "cb974d42183c1b779dd9b15f5014893e4ccd7bcb1c56c62416f028de759ce607",
+      "ioc_type": "sha256_hash",
+      "threat_type": "payload",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-10 15:28:51",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1343989": [
+    {
+      "ioc_value": "bd3b1910de0908ebf93905730c594ab28058103110ab459ce3e4920b4d193933",
+      "ioc_type": "sha256_hash",
+      "threat_type": "payload",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-10 15:28:50",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "asyncrat,vbs",
+      "anonymous": "0",
+      "reporter": "juroots"
+    }
+  ],
+  "1343974": [
+    {
+      "ioc_value": "https://pragapin.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:49",
+      "last_seen_utc": "2024-11-11 05:50:18",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343975": [
+    {
+      "ioc_value": "https://repostebhu.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:49",
+      "last_seen_utc": "2024-11-11 05:50:16",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343947": [
+    {
+      "ioc_value": "https://pragapin.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:47",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Lumma",
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343948": [
+    {
+      "ioc_value": "https://repostebhu.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:21",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Lumma",
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343949": [
+    {
+      "ioc_value": "https://thinkyyokej.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:20",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Lumma",
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343950": [
+    {
+      "ioc_value": "https://ducksringjk.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:20",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Lumma",
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343951": [
+    {
+      "ioc_value": "https://explainvees.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:20",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Lumma",
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343952": [
+    {
+      "ioc_value": "https://brownieyuz.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:19",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Lumma",
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343953": [
+    {
+      "ioc_value": "https://rottieud.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:18",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Lumma",
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343954": [
+    {
+      "ioc_value": "https://relalingj.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:18",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Lumma",
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343955": [
+    {
+      "ioc_value": "https://tamedgeesy.sbs/api",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:17",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Lumma",
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343956": [
+    {
+      "ioc_value": "https://marshal-zhukov.com/api",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 15:28:17",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Lumma",
+      "anonymous": "0",
+      "reporter": "g3ph4z"
+    }
+  ],
+  "1343957": [
+    {
+      "ioc_value": "45.221.97.86:57899",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.mirai",
+      "malware_alias": "Katana",
+      "malware_printable": "Mirai",
+      "first_seen_utc": "2024-11-10 15:28:17",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": null,
+      "tags": "Mirai",
+      "anonymous": "0",
+      "reporter": "elfdigest"
+    }
+  ],
+  "1343958": [
+    {
+      "ioc_value": "omg.rekugg.pro",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "elf.mirai",
+      "malware_alias": "Katana",
+      "malware_printable": "Mirai",
+      "first_seen_utc": "2024-11-10 15:28:16",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": null,
+      "tags": "Mirai",
+      "anonymous": "0",
+      "reporter": "elfdigest"
+    }
+  ],
+  "1343963": [
+    {
+      "ioc_value": "195.133.13.89:443",
+      "ioc_type": "ip:port",
+      "threat_type": "payload_delivery",
+      "malware": "js.fakeupdates",
+      "malware_alias": "FakeUpdate,SocGholish",
+      "malware_printable": "FAKEUPDATES",
+      "first_seen_utc": "2024-11-10 15:28:15",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "SocGholish",
+      "anonymous": "0",
+      "reporter": "threatcat_ch"
+    }
+  ],
+  "1343999": [
+    {
+      "ioc_value": "23.158.56.103:56744",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.mirai",
+      "malware_alias": "Katana",
+      "malware_printable": "Mirai",
+      "first_seen_utc": "2024-11-10 14:13:48",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "1049hUsername,Mirai",
+      "anonymous": "0",
+      "reporter": "NDA0E"
+    }
+  ],
+  "1343998": [
+    {
+      "ioc_value": "http://45.88.76.207/b38a59c5b911e689.php",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.stealc",
+      "malware_alias": null,
+      "malware_printable": "Stealc",
+      "first_seen_utc": "2024-11-10 14:10:19",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "Stealc",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343986": [
+    {
+      "ioc_value": "elejpi11ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-10 12:46:07",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343987": [
+    {
+      "ioc_value": "fvtest5pt.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-10 12:46:07",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343988": [
+    {
+      "ioc_value": "tenja10sb.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-10 12:46:07",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343985": [
+    {
+      "ioc_value": "eightja8sb.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-10 12:46:06",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343983": [
+    {
+      "ioc_value": "fivjp5ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-10 12:45:14",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343984": [
+    {
+      "ioc_value": "sixjp6ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-10 12:45:14",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343973": [
+    {
+      "ioc_value": "i97889ae.beget.tech",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.dcrat",
+      "malware_alias": "DarkCrystal RAT",
+      "malware_printable": "DCRat",
+      "first_seen_utc": "2024-11-10 12:42:48",
+      "last_seen_utc": "2024-11-10 12:42:48",
+      "confidence_level": 100,
+      "reference": "https://www.virustotal.com/gui/domain/i97889ae.beget.tech",
+      "tags": "c2,domain,rat,VirusTotal",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343972": [
+    {
+      "ioc_value": "fvteja5sb.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-10 12:42:40",
+      "last_seen_utc": "2024-11-10 12:45:15",
+      "confidence_level": 100,
+      "reference": "https://www.virustotal.com/gui/domain/fvteja5sb.top",
+      "tags": "c2,domain,virustotal",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343971": [
+    {
+      "ioc_value": "twelja12sb.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-10 12:42:39",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "https://www.virustotal.com/gui/domain/twelja12sb.top",
+      "tags": "c2,domain,virustotal",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343970": [
+    {
+      "ioc_value": "ninja19sb.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-10 12:42:37",
+      "last_seen_utc": "2024-11-10 12:42:38",
+      "confidence_level": 100,
+      "reference": "https://www.virustotal.com/gui/domain/ninja19sb.top",
+      "tags": "c2,domain,virustotal",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343969": [
+    {
+      "ioc_value": "healthprosystems.com",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 12:27:15",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/91.240.202.191",
+      "tags": "AS62904,c2,censys,CobaltStrike,cs-watermark-678358251,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343968": [
+    {
+      "ioc_value": "http://185.215.113.209/Fru7Nk9/index.php",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.amadey",
+      "malware_alias": null,
+      "malware_printable": "Amadey",
+      "first_seen_utc": "2024-11-10 12:20:01",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://www.virustotal.com/gui/url/ef7c9fd58c15641e4173839889ca7e025b648df58470d14d1a005f6c4931d035/",
+      "tags": "Amadey,AS51381,c2,ELITETEAM-PEERING-AZ1,virustotal",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343966": [
+    {
+      "ioc_value": "adp-login.com",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.vidar",
+      "malware_alias": null,
+      "malware_printable": "Vidar",
+      "first_seen_utc": "2024-11-10 12:03:30",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "stealc,vidar",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343967": [
+    {
+      "ioc_value": "adp-auth.com",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.vidar",
+      "malware_alias": null,
+      "malware_printable": "Vidar",
+      "first_seen_utc": "2024-11-10 12:03:30",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "stealc,vidar",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343965": [
+    {
+      "ioc_value": "174.104.8.127:8080",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.quasar_rat",
+      "malware_alias": "CinaRAT,QuasarRAT,Yggdrasil",
+      "malware_printable": "Quasar RAT",
+      "first_seen_utc": "2024-11-10 12:02:05",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/174.104.8.127",
+      "tags": "AS10796,C2,censys,Quasar,RAT,TWC-10796-MIDWEST",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343964": [
+    {
+      "ioc_value": "78.162.164.147:888",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-10 12:01:52",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/78.162.164.147",
+      "tags": "AS9121,AsyncRAT,C2,censys,RAT,TTNET",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343962": [
+    {
+      "ioc_value": "45.149.241.51:8080",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 12:00:55",
+      "last_seen_utc": "2024-11-11 07:55:34",
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/45.149.241.51",
+      "tags": "AS401116,C2,censys,CobaltStrike,cs-watermark-100000,NYBULA",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343961": [
+    {
+      "ioc_value": "http://qlauncher.ru/L1nc0In.php",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.dcrat",
+      "malware_alias": "DarkCrystal RAT",
+      "malware_printable": "DCRat",
+      "first_seen_utc": "2024-11-10 11:50:20",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "DCRat",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343960": [
+    {
+      "ioc_value": "http://83.222.191.225/31c11d12f15e92b7.php",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.stealc",
+      "malware_alias": null,
+      "malware_printable": "Stealc",
+      "first_seen_utc": "2024-11-10 11:35:18",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "Stealc",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343959": [
+    {
+      "ioc_value": "http://147.45.47.98/js/error.js",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-10 11:23:20",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "socgholish",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343946": [
+    {
+      "ioc_value": "https://sirault.be/chrome_93.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:51:05",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343945": [
+    {
+      "ioc_value": "https://perseverclinic.com/chrome_131.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:51:04",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343944": [
+    {
+      "ioc_value": "https://osteo9.esalnuvol.com/adjunts/chrome_131.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:51:03",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343943": [
+    {
+      "ioc_value": "https://gosp.xaman.es/chrome_131.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:51:01",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343942": [
+    {
+      "ioc_value": "https://gosp.xaman.es/chrome_130.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:51:00",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343941": [
+    {
+      "ioc_value": "https://gosp.davidmolins.com/chrome_131.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:50:59",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343940": [
+    {
+      "ioc_value": "https://gosp.davidmolins.com/chrome_130.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:50:58",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343939": [
+    {
+      "ioc_value": "https://gosp.clinicavertigen.com/tmpp/chrome_131.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:50:56",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343938": [
+    {
+      "ioc_value": "https://gosp.clinicavertigen.com/chrome_131.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:50:55",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343937": [
+    {
+      "ioc_value": "https://gest.llevadonas.es/acts/chrome_131.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:50:54",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343936": [
+    {
+      "ioc_value": "https://campuspersever.es/chrome_93.exe",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.coinminer",
+      "malware_alias": null,
+      "malware_printable": "Coinminer",
+      "first_seen_utc": "2024-11-10 10:50:53",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "Infected-with-coinminer-through,stealc",
+      "anonymous": "0",
+      "reporter": "abus3reports"
+    }
+  ],
+  "1343935": [
+    {
+      "ioc_value": "https://hellishaluhg.fun/api",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 08:25:05",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "https://bazaar.abuse.ch/sample/f136737183d05a85af99d27e7db1efe5de9a18336ebc0360ee4420425f0d10aa/",
+      "tags": "lumma",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343934": [
+    {
+      "ioc_value": "20.6.130.111:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-10 08:02:08",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/20.6.130.111",
+      "tags": "AS8075,C2,censys,MICROSOFT-CORP-MSN-AS-BLOCK,moobot",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343933": [
+    {
+      "ioc_value": "178.215.238.198:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-10 08:02:07",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/178.215.238.198",
+      "tags": "AS215479,C2,censys,moobot,PERFECTO-AS",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343932": [
+    {
+      "ioc_value": "88.120.202.79:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.havoc",
+      "malware_alias": "Havokiz",
+      "malware_printable": "Havoc",
+      "first_seen_utc": "2024-11-10 08:01:51",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/88.120.202.79",
+      "tags": "AS12322,C2,censys,Havoc,PROXAD",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343931": [
+    {
+      "ioc_value": "185.208.156.146:9999",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-10 08:01:35",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/185.208.156.146",
+      "tags": "AS42624,AsyncRAT,C2,censys,RAT,SWISSNETWORK02",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343930": [
+    {
+      "ioc_value": "8.217.104.91:55443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.sliver",
+      "malware_alias": null,
+      "malware_printable": "Sliver",
+      "first_seen_utc": "2024-11-10 08:01:28",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/8.217.104.91",
+      "tags": "ALIBABA-CN-NET,AS45102,C2,censys,Sliver",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343929": [
+    {
+      "ioc_value": "103.233.186.63:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 07:24:33",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343928": [
+    {
+      "ioc_value": "154.92.19.29:12358",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 07:24:00",
+      "last_seen_utc": "2024-11-11 07:56:39",
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343927": [
+    {
+      "ioc_value": "111.230.214.161:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 07:23:41",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343926": [
+    {
+      "ioc_value": "101.43.1.44:8089",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 07:23:36",
+      "last_seen_utc": "2024-11-11 07:55:50",
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343925": [
+    {
+      "ioc_value": "101.43.25.107:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 07:23:25",
+      "last_seen_utc": "2024-11-11 07:55:39",
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343924": [
+    {
+      "ioc_value": "http://pizdi2m7.beget.tech/L1nc0In.php",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.dcrat",
+      "malware_alias": "DarkCrystal RAT",
+      "malware_printable": "DCRat",
+      "first_seen_utc": "2024-11-10 07:00:21",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "DCRat",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343923": [
+    {
+      "ioc_value": "http://117.63.21.46:57389/Mozi.m",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "elf.mozi",
+      "malware_alias": null,
+      "malware_printable": "Mozi",
+      "first_seen_utc": "2024-11-10 06:40:04",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": null,
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "sicehicetf"
+    }
+  ],
+  "1343910": [
+    {
+      "ioc_value": "rottieud.sbs",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 05:46:23",
+      "last_seen_utc": "2024-11-10 14:36:23",
+      "confidence_level": 100,
+      "reference": "https://www.malwarebytes.com/blog/news/2024/11/hello-again-fakebat-popular-loader-returns-after-months-long-hiatus",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "500mk500"
+    }
+  ],
+  "1343911": [
+    {
+      "ioc_value": "thinkyyokej.sbs",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 05:46:23",
+      "last_seen_utc": "2024-11-10 14:36:23",
+      "confidence_level": 100,
+      "reference": "https://www.malwarebytes.com/blog/news/2024/11/hello-again-fakebat-popular-loader-returns-after-months-long-hiatus",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "500mk500"
+    }
+  ],
+  "1343909": [
+    {
+      "ioc_value": "slippyhost.cfd",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 05:46:22",
+      "last_seen_utc": "2024-11-10 14:36:23",
+      "confidence_level": 100,
+      "reference": "https://www.malwarebytes.com/blog/news/2024/11/hello-again-fakebat-popular-loader-returns-after-months-long-hiatus",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "500mk500"
+    }
+  ],
+  "1343913": [
+    {
+      "ioc_value": "ducksringjk.sbs",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 05:46:22",
+      "last_seen_utc": "2024-11-10 14:36:23",
+      "confidence_level": 100,
+      "reference": "https://www.malwarebytes.com/blog/news/2024/11/hello-again-fakebat-popular-loader-returns-after-months-long-hiatus",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "500mk500"
+    }
+  ],
+  "1343914": [
+    {
+      "ioc_value": "explainvees.sbs",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 05:46:22",
+      "last_seen_utc": "2024-11-10 14:36:23",
+      "confidence_level": 100,
+      "reference": "https://www.malwarebytes.com/blog/news/2024/11/hello-again-fakebat-popular-loader-returns-after-months-long-hiatus",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "500mk500"
+    }
+  ],
+  "1343912": [
+    {
+      "ioc_value": "relalingj.sbs",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 05:46:21",
+      "last_seen_utc": "2024-11-10 14:36:23",
+      "confidence_level": 100,
+      "reference": "https://www.malwarebytes.com/blog/news/2024/11/hello-again-fakebat-popular-loader-returns-after-months-long-hiatus",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "500mk500"
+    }
+  ],
+  "1343915": [
+    {
+      "ioc_value": "repostebhu.sbs",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 05:46:21",
+      "last_seen_utc": "2024-11-10 14:36:23",
+      "confidence_level": 100,
+      "reference": "https://www.malwarebytes.com/blog/news/2024/11/hello-again-fakebat-popular-loader-returns-after-months-long-hiatus",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "500mk500"
+    }
+  ],
+  "1343916": [
+    {
+      "ioc_value": "tamedgeesy.sbs",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 05:46:21",
+      "last_seen_utc": "2024-11-10 14:36:23",
+      "confidence_level": 100,
+      "reference": "https://www.malwarebytes.com/blog/news/2024/11/hello-again-fakebat-popular-loader-returns-after-months-long-hiatus",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "500mk500"
+    }
+  ],
+  "1343917": [
+    {
+      "ioc_value": "brownieyuz.sbs",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.lumma",
+      "malware_alias": "LummaC2 Stealer",
+      "malware_printable": "Lumma Stealer",
+      "first_seen_utc": "2024-11-10 05:46:21",
+      "last_seen_utc": "2024-11-10 14:36:23",
+      "confidence_level": 100,
+      "reference": "https://www.malwarebytes.com/blog/news/2024/11/hello-again-fakebat-popular-loader-returns-after-months-long-hiatus",
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "500mk500"
+    }
+  ],
+  "1343922": [
+    {
+      "ioc_value": "185-215-113-209.cprapid.com",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.amadey",
+      "malware_alias": null,
+      "malware_printable": "Amadey",
+      "first_seen_utc": "2024-11-10 04:02:25",
+      "last_seen_utc": null,
+      "confidence_level": 90,
+      "reference": "https://search.censys.io/hosts/185.215.113.209+185-215-113-209.cprapid.com",
+      "tags": "Amadey,AS51381,C2,censys,ELITETEAM-PEERING-AZ1,Payloads",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343921": [
+    {
+      "ioc_value": "191.96.207.223:8888",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-10 04:01:48",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/191.96.207.223",
+      "tags": "AS199654,AsyncRAT,C2,censys,OXIDE-GROUP-LIMITED,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343920": [
+    {
+      "ioc_value": "47.242.37.176:5432",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 04:00:56",
+      "last_seen_utc": "2024-11-10 12:43:13",
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/47.242.37.176",
+      "tags": "ALIBABA-CN-NET,AS45102,C2,censys,CobaltStrike,cs-watermark-100000",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343919": [
+    {
+      "ioc_value": "1.92.131.24:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 04:00:54",
+      "last_seen_utc": "2024-11-11 07:56:47",
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/1.92.131.24",
+      "tags": "AS55990,C2,censys,CobaltStrike,cs-watermark-391144938,HWCSNET",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343918": [
+    {
+      "ioc_value": "154.204.34.150:8443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 04:00:53",
+      "last_seen_utc": "2024-11-11 07:55:22",
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/154.204.34.150",
+      "tags": "AS133199,C2,censys,CobaltStrike,cs-watermark-987654321,SONDERCLOUDLIMITED-AS-AP",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343908": [
+    {
+      "ioc_value": "http://103.10.227.247:51556/Mozi.m",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "elf.mozi",
+      "malware_alias": null,
+      "malware_printable": "Mozi",
+      "first_seen_utc": "2024-11-10 00:40:08",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": null,
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "sicehicetf"
+    }
+  ],
+  "1343907": [
+    {
+      "ioc_value": "146.190.109.188:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.nimplant",
+      "malware_alias": null,
+      "malware_printable": "Nimplant",
+      "first_seen_utc": "2024-11-10 00:02:21",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/146.190.109.188",
+      "tags": "AS14061,C2,censys,DIGITALOCEAN-ASN,Nimplant",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343906": [
+    {
+      "ioc_value": "87.120.117.193:8082",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "apk.hook",
+      "malware_alias": null,
+      "malware_printable": "Hook",
+      "first_seen_utc": "2024-11-10 00:02:07",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/87.120.117.193",
+      "tags": "AS401115,C2,censys,EKABI,Hookbot",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343905": [
+    {
+      "ioc_value": "8.148.5.228:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.cobalt_strike",
+      "malware_alias": "Agentemis,BEACON,CobaltStrike,cobeacon",
+      "malware_printable": "Cobalt Strike",
+      "first_seen_utc": "2024-11-10 00:00:53",
+      "last_seen_utc": "2024-11-11 07:56:42",
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/8.148.5.228",
+      "tags": "ALIBABA-CN-NET,AS37963,C2,censys,CobaltStrike,cs-watermark-987654321",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343904": [
+    {
+      "ioc_value": "172.111.244.104:2879",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-09 22:40:13",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "RAT,RemcosRAT",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343903": [
+    {
+      "ioc_value": "http://b902470r.beget.tech/DarkCrystal/PollHttpprocessApimultilinuxAsynclocalCentral.php",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.dcrat",
+      "malware_alias": "DarkCrystal RAT",
+      "malware_printable": "DCRat",
+      "first_seen_utc": "2024-11-09 21:20:19",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "DCRat",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343902": [
+    {
+      "ioc_value": "162.245.221.12:56999",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-09 21:09:50",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://urlhaus.abuse.ch/host/162.245.221.12/",
+      "tags": "CVE-2017-17215,ily,Mirai,Moobot",
+      "anonymous": "0",
+      "reporter": "NDA0E"
+    }
+  ],
+  "1343900": [
+    {
+      "ioc_value": "bot.proy.lol",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-09 20:40:21",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://urlhaus.abuse.ch/host/bot.proy.lol/",
+      "tags": "fbi.gov,Mirai,MooBot",
+      "anonymous": "0",
+      "reporter": "NDA0E"
+    }
+  ],
+  "1343901": [
+    {
+      "ioc_value": "proy.lol",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-09 20:40:21",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://urlhaus.abuse.ch/host/bot.proy.lol/",
+      "tags": "fbi.gov,Mirai,MooBot",
+      "anonymous": "0",
+      "reporter": "NDA0E"
+    }
+  ],
+  "1343899": [
+    {
+      "ioc_value": "178.215.238.198:47925",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-09 20:39:11",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://urlhaus.abuse.ch/host/209.141.52.86/",
+      "tags": "fbi.gov,Mirai,MooBot",
+      "anonymous": "0",
+      "reporter": "NDA0E"
+    }
+  ],
+  "1343898": [
+    {
+      "ioc_value": "51.16.209.105:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.bianlian",
+      "malware_alias": null,
+      "malware_printable": "BianLian",
+      "first_seen_utc": "2024-11-09 20:02:30",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/51.16.209.105",
+      "tags": "AMAZON-02,AS16509,BianLian,C2,censys",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343897": [
+    {
+      "ioc_value": "209.126.0.207:9876",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.bashlite",
+      "malware_alias": "gayfgt,Gafgyt,qbot,torlus,lizkebab",
+      "malware_printable": "Bashlite",
+      "first_seen_utc": "2024-11-09 20:02:18",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/209.126.0.207",
+      "tags": "AS40021,C2,censys,Gafgyt,NL-811-40021,open-dir",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343896": [
+    {
+      "ioc_value": "209.141.52.86:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-09 20:02:08",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/209.141.52.86",
+      "tags": "AS53667,C2,censys,moobot,PONYNET",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343895": [
+    {
+      "ioc_value": "102.117.168.178:7443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-09 20:01:46",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/102.117.168.178",
+      "tags": "AS23889,C2,censys,MauritiusTelecom,Mythic",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343894": [
+    {
+      "ioc_value": "49.113.76.69:8888",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-09 20:01:36",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/49.113.76.69",
+      "tags": "AS4134,C2,censys,CHINANET-BACKBONE,Supershell",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343893": [
+    {
+      "ioc_value": "172.94.127.3:5290",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-09 20:01:28",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/172.94.127.3",
+      "tags": "AS7040,C2,censys,NETMINDERS,RAT,Remcos",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343892": [
+    {
+      "ioc_value": "http://62.204.41.163/16fa04073490929d.php",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.stealc",
+      "malware_alias": null,
+      "malware_printable": "Stealc",
+      "first_seen_utc": "2024-11-09 19:20:09",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "Stealc",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343891": [
+    {
+      "ioc_value": "http://102.33.83.188:35482/Mozi.m",
+      "ioc_type": "url",
+      "threat_type": "payload_delivery",
+      "malware": "elf.mozi",
+      "malware_alias": null,
+      "malware_printable": "Mozi",
+      "first_seen_utc": "2024-11-09 18:40:06",
+      "last_seen_utc": null,
+      "confidence_level": 50,
+      "reference": null,
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "sicehicetf"
+    }
+  ],
+  "1343890": [
+    {
+      "ioc_value": "185.78.76.132:1995",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-09 17:03:27",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://urlhaus.abuse.ch/host/185.78.76.132/",
+      "tags": "fbi.gov,mirai,MooBot",
+      "anonymous": "0",
+      "reporter": "NDA0E"
+    }
+  ],
+  "1343889": [
+    {
+      "ioc_value": "xred.mooo.com",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.darkcomet",
+      "malware_alias": "Breut,Fynloski,klovbot",
+      "malware_printable": "DarkComet",
+      "first_seen_utc": "2024-11-09 16:44:59",
+      "last_seen_utc": null,
+      "confidence_level": 80,
+      "reference": null,
+      "tags": null,
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343888": [
+    {
+      "ioc_value": "185.121.15.90:443",
+      "ioc_type": "ip:port",
+      "threat_type": "payload_delivery",
+      "malware": "js.fakeupdates",
+      "malware_alias": "FakeUpdate,SocGholish",
+      "malware_printable": "FAKEUPDATES",
+      "first_seen_utc": "2024-11-09 16:09:55",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "SocGholish",
+      "anonymous": "0",
+      "reporter": "threatcat_ch"
+    }
+  ],
+  "1343887": [
+    {
+      "ioc_value": "94.237.31.241:20000",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.mimikatz",
+      "malware_alias": null,
+      "malware_printable": "MimiKatz",
+      "first_seen_utc": "2024-11-09 16:02:45",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/94.237.31.241",
+      "tags": "AS202053,C2,censys,hacktool,Mimikatz,open-dir,UPCLOUD",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343886": [
+    {
+      "ioc_value": "185.78.76.132:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "elf.moobot",
+      "malware_alias": null,
+      "malware_printable": "MooBot",
+      "first_seen_utc": "2024-11-09 16:02:26",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/185.78.76.132",
+      "tags": "AS-NUXTCLOUD,AS216127,C2,censys,moobot",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343885": [
+    {
+      "ioc_value": "98.66.183.110:9443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.havoc",
+      "malware_alias": "Havokiz",
+      "malware_printable": "Havoc",
+      "first_seen_utc": "2024-11-09 16:02:10",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/98.66.183.110",
+      "tags": "AS8075,C2,censys,Havoc,MICROSOFT-CORP-MSN-AS-BLOCK",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343884": [
+    {
+      "ioc_value": "87.121.86.108:50555",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "apk.hook",
+      "malware_alias": null,
+      "malware_printable": "Hook",
+      "first_seen_utc": "2024-11-09 16:02:03",
+      "last_seen_utc": "2024-11-09 17:00:04",
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/87.121.86.108",
+      "tags": "AS401116,C2,censys,Hookbot,NYBULA",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343883": [
+    {
+      "ioc_value": "88.214.25.17:15647",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.sectop_rat",
+      "malware_alias": "1xxbot,ArechClient",
+      "malware_printable": "SectopRAT",
+      "first_seen_utc": "2024-11-09 16:01:52",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/88.214.25.17",
+      "tags": "AS35042,C2,censys,LAYER7-NETWORKS-,RAT,Sectop",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343881": [
+    {
+      "ioc_value": "185.241.208.88:111",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-09 16:01:50",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/185.241.208.88",
+      "tags": "AS210558,AsyncRAT,C2,censys,RAT,SERVICES-1337-GMBH",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343882": [
+    {
+      "ioc_value": "196.74.238.102:8080",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-09 16:01:50",
+      "last_seen_utc": "2024-11-09 16:41:52",
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/196.74.238.102",
+      "tags": "AS36903,AsyncRAT,C2,censys,MT-MPLS,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343880": [
+    {
+      "ioc_value": "185.49.126.52:8808",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-09 16:01:49",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/185.49.126.52",
+      "tags": "AS199654,AsyncRAT,C2,censys,OXIDE-GROUP-LIMITED,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343879": [
+    {
+      "ioc_value": "124.71.192.162:8888",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-09 16:01:45",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/124.71.192.162",
+      "tags": "AS55990,C2,censys,HWCSNET,Supershell",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343878": [
+    {
+      "ioc_value": "103.233.9.10:8888",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "unknown",
+      "malware_alias": null,
+      "malware_printable": "Unknown malware",
+      "first_seen_utc": "2024-11-09 16:01:44",
+      "last_seen_utc": "2024-11-10 19:00:05",
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/103.233.9.10",
+      "tags": "AS133201,C2,censys,COMING-AS,Supershell",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343877": [
+    {
+      "ioc_value": "206.119.167.171:31337",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.sliver",
+      "malware_alias": null,
+      "malware_printable": "Sliver",
+      "first_seen_utc": "2024-11-09 16:01:37",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/206.119.167.171",
+      "tags": "AS133199,C2,censys,Sliver,SONDERCLOUDLIMITED-AS-AP",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343876": [
+    {
+      "ioc_value": "92.255.85.63:5002",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-09 16:01:34",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/92.255.85.63",
+      "tags": "AS207566,C2,censys,LD007-AS,RAT,Remcos",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343875": [
+    {
+      "ioc_value": "185.208.156.182:2404",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.remcos",
+      "malware_alias": "RemcosRAT,Remvio,Socmer",
+      "malware_printable": "Remcos",
+      "first_seen_utc": "2024-11-09 16:01:32",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/185.208.156.182",
+      "tags": "AS42624,C2,censys,RAT,Remcos,SWISSNETWORK02",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343874": [
+    {
+      "ioc_value": "http://77.83.175.91/69d96d770568584a.php",
+      "ioc_type": "url",
+      "threat_type": "botnet_cc",
+      "malware": "win.stealc",
+      "malware_alias": null,
+      "malware_printable": "Stealc",
+      "first_seen_utc": "2024-11-09 15:15:16",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "Stealc",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343873": [
+    {
+      "ioc_value": "139.99.3.47:6669",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-09 14:15:21",
+      "last_seen_utc": null,
+      "confidence_level": 75,
+      "reference": "https://bazaar.abuse.ch/sample/4c8a37bba1eda81eb0e51922a98fa61f278fcab7b58870fa650865a53e308b1d/",
+      "tags": "asyncrat",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ],
+  "1343872": [
+    {
+      "ioc_value": "121.37.128.90:8848",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.dcrat",
+      "malware_alias": "DarkCrystal RAT",
+      "malware_printable": "DCRat",
+      "first_seen_utc": "2024-11-09 12:01:47",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/121.37.128.90",
+      "tags": "AS55990,C2,censys,DcRAT,HWCSNET,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343871": [
+    {
+      "ioc_value": "34.146.88.47:80",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.havoc",
+      "malware_alias": "Havokiz",
+      "malware_printable": "Havoc",
+      "first_seen_utc": "2024-11-09 12:01:45",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/34.146.88.47",
+      "tags": "AS396982,C2,censys,GOOGLE-CLOUD-PLATFORM,Havoc",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343870": [
+    {
+      "ioc_value": "31.59.131.84:2000",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-09 12:01:30",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/31.59.131.84",
+      "tags": "AS215238,AsyncRAT,C2,censys,ONEMBILISIM,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343869": [
+    {
+      "ioc_value": "45.143.199.184:8088",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-09 12:01:29",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/45.143.199.184",
+      "tags": "AS212027,AsyncRAT,C2,censys,PEBBLEHOST,RAT",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343868": [
+    {
+      "ioc_value": "13.40.115.95:443",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.sliver",
+      "malware_alias": null,
+      "malware_printable": "Sliver",
+      "first_seen_utc": "2024-11-09 12:01:23",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/13.40.115.95",
+      "tags": "AMAZON-02,AS16509,C2,censys,Sliver",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343867": [
+    {
+      "ioc_value": "91.199.147.205:31337",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.sliver",
+      "malware_alias": null,
+      "malware_printable": "Sliver",
+      "first_seen_utc": "2024-11-09 12:01:22",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "https://search.censys.io/hosts/91.199.147.205",
+      "tags": "AS62212,C2,censys,Sliver",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343863": [
+    {
+      "ioc_value": "thirtjo13ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:30:47",
+      "last_seen_utc": "2024-11-09 11:31:57",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343864": [
+    {
+      "ioc_value": "eightjo8ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:30:47",
+      "last_seen_utc": "2024-11-09 11:31:57",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343865": [
+    {
+      "ioc_value": "elejoi11ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:30:47",
+      "last_seen_utc": "2024-11-09 11:31:57",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343859": [
+    {
+      "ioc_value": "fiftjp15ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:30:46",
+      "last_seen_utc": "2024-11-09 11:31:57",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343860": [
+    {
+      "ioc_value": "fivejo5ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:30:46",
+      "last_seen_utc": "2024-11-09 11:31:57",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343861": [
+    {
+      "ioc_value": "forjo14ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:30:46",
+      "last_seen_utc": "2024-11-09 11:31:57",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343862": [
+    {
+      "ioc_value": "neinjo9ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:30:46",
+      "last_seen_utc": "2024-11-09 11:31:57",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343850": [
+    {
+      "ioc_value": "tventjp20sr.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:29:08",
+      "last_seen_utc": "2024-11-10 12:42:41",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343851": [
+    {
+      "ioc_value": "forjp14ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:29:08",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343852": [
+    {
+      "ioc_value": "sixjp16ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:29:08",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343853": [
+    {
+      "ioc_value": "thirp13vt.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:29:08",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343854": [
+    {
+      "ioc_value": "sevjp17sr.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:29:08",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343855": [
+    {
+      "ioc_value": "elejpi11vt.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:29:08",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343856": [
+    {
+      "ioc_value": "forjp14vt.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:29:08",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343857": [
+    {
+      "ioc_value": "neinjp9vt.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:29:08",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343858": [
+    {
+      "ioc_value": "tenjp10vt.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:29:08",
+      "last_seen_utc": "2024-11-09 11:31:57",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343844": [
+    {
+      "ioc_value": "thirp13sr.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:32",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343845": [
+    {
+      "ioc_value": "tweljp12sr.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:32",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343846": [
+    {
+      "ioc_value": "forjp14sr.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:32",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343847": [
+    {
+      "ioc_value": "elejpi11sr.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:32",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343848": [
+    {
+      "ioc_value": "fivet15vs.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:32",
+      "last_seen_utc": "2024-11-09 11:35:36",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343849": [
+    {
+      "ioc_value": "thirt13vs.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:32",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343837": [
+    {
+      "ioc_value": "eightja8ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:31",
+      "last_seen_utc": "2024-11-10 12:46:06",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343838": [
+    {
+      "ioc_value": "tenja10ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:31",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343839": [
+    {
+      "ioc_value": "tweljp12ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:31",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343840": [
+    {
+      "ioc_value": "fivetjp15sr.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:31",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343841": [
+    {
+      "ioc_value": "sixft6vs.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:31",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343842": [
+    {
+      "ioc_value": "sixjp16sr.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:31",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343843": [
+    {
+      "ioc_value": "tenjp10sr.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:27:31",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343834": [
+    {
+      "ioc_value": "neinja9ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:25:55",
+      "last_seen_utc": "2024-11-10 12:46:07",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343835": [
+    {
+      "ioc_value": "onejp1ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:25:55",
+      "last_seen_utc": "2024-11-10 12:45:14",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343836": [
+    {
+      "ioc_value": "fivetjp15ht.top",
+      "ioc_type": "domain",
+      "threat_type": "botnet_cc",
+      "malware": "win.cryptbot",
+      "malware_alias": null,
+      "malware_printable": "CryptBot",
+      "first_seen_utc": "2024-11-09 11:25:55",
+      "last_seen_utc": "2024-11-10 12:42:43",
+      "confidence_level": 100,
+      "reference": "",
+      "tags": "c2,domain",
+      "anonymous": "0",
+      "reporter": "DonPasci"
+    }
+  ],
+  "1343833": [
+    {
+      "ioc_value": "93.123.109.195:1987",
+      "ioc_type": "ip:port",
+      "threat_type": "botnet_cc",
+      "malware": "win.asyncrat",
+      "malware_alias": null,
+      "malware_printable": "AsyncRAT",
+      "first_seen_utc": "2024-11-09 10:40:14",
+      "last_seen_utc": null,
+      "confidence_level": 100,
+      "reference": null,
+      "tags": "AsyncRAT,RAT",
+      "anonymous": "0",
+      "reporter": "abuse_ch"
+    }
+  ]
+}


### PR DESCRIPTION
### Description
Currently we support users uploading threat intelligence in the fixed STIX2 based JSON format only.
This change adds the ability to provide a schema with JsonPath notation for the existing fields and uploading a json file that is then parsed to extract a list of threat intel iocs.

Changes the index Threat intel source API to accept an IoC Schema with all the fields having JsonPath notations. only ioc value and ioc type field are mandatory. Rest of the fields in the threat intel ioc list such as created date, modified date, name, id etc are optional.

### Related Issues
#1421 
