### PR TITLE
[Backport 2.x] Updated commons jar to fix CVE-2025-24970, and CVE-2025-25193.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.22.0'
     id "com.netflix.nebula.ospackage" version "11.5.0"
     id 'java-library'
+    id 'com.github.johnrengelman.shadow' version "8.1.1"
 }
 
 apply plugin: 'opensearch.opensearchplugin'
@@ -190,6 +191,13 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'notifications', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+}
+
+shadowJar {
+    from(zipTree(sa_commons_file_path)) {
+        exclude 'org/apache/http/**'
+    }
+    zip64 true
 }
 
 // RPM & Debian build

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ plugins {
     id 'com.diffplug.spotless' version '6.22.0'
     id "com.netflix.nebula.ospackage" version "11.5.0"
     id 'java-library'
-    id 'com.github.johnrengelman.shadow' version "8.1.1"
 }
 
 apply plugin: 'opensearch.opensearchplugin'
@@ -166,6 +165,16 @@ configurations {
     }
 }
 
+// Filtering out some dependencies to avoid conflicts with alerting jars
+task filterSACommons(type: Jar) {
+    from zipTree(sa_commons_file_path)
+    exclude 'org/apache/http/**'
+    exclude 'org/apache/httpcomponents/**'
+    archiveFileName = "filtered-${sa_commons_file_name}"
+    destinationDirectory = file("${buildDir}/filtered-jars")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 dependencies {
     javaRestTestImplementation project.sourceSets.main.runtimeClasspath
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
@@ -182,8 +191,10 @@ dependencies {
     // TODO uncomment once SA commons is published to maven central
 //    api "org.opensearch:security-analytics-commons:${sa_commons_version}@jar"
 
-    // TODO remove once SA commons is published to maven central
-    api files(sa_commons_file_path)
+    // TODO remove consuming local SA commons jar once it is published to maven central
+    api files(filterSACommons.archiveFile) {
+        builtBy filterSACommons
+    }
 
     // Needed for integ tests
     zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${opensearch_build}"
@@ -193,14 +204,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
 }
 
-shadowJar {
-    from(zipTree(sa_commons_file_path)) {
-        exclude 'org/apache/http/**'
-    }
-    zip64 true
-}
-
-// RPM & Debian build
 apply plugin: 'com.netflix.nebula.ospackage'
 
 def es_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile


### PR DESCRIPTION
### Description
1. Manual backport of PR https://github.com/opensearch-project/security-analytics/pull/1481
1. Added filtering to exclude conflicting dependencies from alerting jar.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
