### PR TITLE
Update gradle 8.10.2 and support jdk23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [21]
+        java: [21, 23]
         os: [ ubuntu-latest ]
     name: Build and Test security-analytics with JDK ${{ matrix.java }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -67,7 +67,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: security-analytics-plugin-${{ matrix.os }}
+          name: security-analytics-plugin-${{ matrix.os }}-${{ matrix.java }}
           path: security-analytics-artifacts
           overwrite: true
 
@@ -77,7 +77,7 @@ jobs:
       WORKING_DIR: ${{ matrix.working_directory }}.
     strategy:
       matrix:
-        java: [21]
+        java: [21, 23]
         os: [ windows-latest, macos-latest ]
         include:
           - os: windows-latest
@@ -135,6 +135,6 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: security-analytics-plugin-${{ matrix.os }}
+          name: security-analytics-plugin-${{ matrix.os }}-${{ matrix.java }}
           path: security-analytics-artifacts
           overwrite: true

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ buildscript {
 plugins {
     id 'java'
     id 'com.diffplug.spotless' version '6.22.0'
-    id "com.netflix.nebula.ospackage" version "11.5.0"
+    id "com.netflix.nebula.ospackage" version "11.10.0"
     id 'java-library'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionSha256Sum=2ab88d6de2c23e6adae7363ae6e29cbdd2a709e992929b48b6530fd0c7133bd6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=9d926787066a081739e8200858338b4a69e837c3a821a33aca9db09dd4a41026


### PR DESCRIPTION
### Description
Update gradle 8.10.2 and support jdk23

### Related Issues
https://github.com/opensearch-project/security-analytics/issues/1350#issuecomment-2691259392
https://github.com/opensearch-project/security-analytics/issues/1025

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [x] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
