### PR TITLE
Remove overrides of preserveIndicesUponCompletion

### DIFF
--- a/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
@@ -574,10 +574,4 @@ public class CustomSchemaSourceConfigIocUploadIT extends SecurityAnalyticsRestTe
                 iocSchema
         );
     }
-
-
-    @Override
-    protected boolean preserveIndicesUponCompletion() {
-        return false;
-    }
 }

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
@@ -1067,9 +1067,4 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
                 null
         );
     }
-
-    @Override
-    protected boolean preserveIndicesUponCompletion() {
-        return false;
-    }
 }

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
@@ -1025,10 +1025,5 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
                 null,
                 List.of(t1, t2, t3, t4));
     }
-
-    @Override
-    protected boolean preserveIndicesUponCompletion() {
-        return false;
-    }
 }
 


### PR DESCRIPTION
### Description

Addresses failures seen in 3.0.0-alpha1 integ tests: https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/9475/pipeline/135/#step-859-log-689

While this repo is not directly deleting the security index, its delegating test cleanup to the [OpenSearchRestTestCase](https://github.com/opensearch-project/OpenSearch/blob/main/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java) base class which has logic to cleanup all indices with this override. 

### Related Issues
Resolves https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/9475/pipeline/135/#step-859-log-689

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
