### PR TITLE
Remove usage of deprecated batchSize() method

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/BaseEntityCrudService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/BaseEntityCrudService.java
@@ -125,7 +125,7 @@ public abstract class BaseEntityCrudService<Entity extends BaseEntity> {
                                 client.bulk(req, groupedListener);
                             } catch (Exception e) {
                                 log.error(
-                                        () -> new ParameterizedMessage("Failed to bulk save {} {}.", req.batchSize(), getEntityName()),
+                                        () -> new ParameterizedMessage("Failed to bulk save {} {}.", batchSize, getEntityName()),
                                         e);
                                 groupedListener.onFailure(e);
                             }
@@ -177,7 +177,7 @@ public abstract class BaseEntityCrudService<Entity extends BaseEntity> {
                             for (BulkResponse response : bulkResponses) {
                                 BulkRequest request = bulkRequestList.get(idx);
                                 if (response.hasFailures()) {
-                                    log.error("Failed to bulk index {} {}s. Failure: {}", request.batchSize(), getEntityName(), response.buildFailureMessage());
+                                    log.error("Failed to bulk index {} {}s. Failure: {}", batchSize, getEntityName(), response.buildFailureMessage());
                                 }
                             }
                             actionListener.onResponse(null);
@@ -187,7 +187,7 @@ public abstract class BaseEntityCrudService<Entity extends BaseEntity> {
                                 client.bulk(req, groupedListener); //todo why stash context here?
                             } catch (Exception e) {
                                 log.error(
-                                        () -> new ParameterizedMessage("Failed to bulk save {} {}.", req.batchSize(), getEntityName()),
+                                        () -> new ParameterizedMessage("Failed to bulk save {} {}.", batchSize, getEntityName()),
                                         e);
                             }
                         }


### PR DESCRIPTION
This field on BulkRequest was never set by this code. I'm not sure why it was being logged. I can only assume it was confused with the `batchSize` parameter, so I've logged that instead.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

Closes https://github.com/opensearch-project/security-analytics/issues/1502

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
