### PR TITLE
Switch guava deps from compileOnly to implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ dependencies {
     implementation 'com.jayway.jsonpath:json-path:2.9.0'
     implementation 'net.minidev:json-smart:2.5.2'
     implementation 'net.minidev:accessors-smart:2.5.2'
-    compileOnly "com.google.guava:guava:32.1.3-jre"
+    implementation "com.google.guava:guava:32.1.3-jre"
 
     // TODO uncomment once SA commons is published to maven central
 //    api "org.opensearch:security-analytics-commons:${sa_commons_version}@jar"

--- a/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
@@ -250,11 +250,11 @@ public class RuleIndices {
                 if (Files.isDirectory(path)) {
                     rules.addAll(getRules(Files.list(path).collect(Collectors.toList())));
                 } else {
-                    try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(path.toString())) {
+                    try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(path.toString().substring(1))) {
                         if (inputStream != null) {
                             rules.add(new String(inputStream.readAllBytes(), Charset.defaultCharset()));
                         } else {
-                            log.warn("Resource not found: {}", path.toString());
+                            log.warn("Resource not found: {}", path.toString().substring(1));
                         }
                     }
                 }


### PR DESCRIPTION
### Description

SAP has its guava dependencies set at compileOnly level which means they are not packaged into the SAP assembly and available at runtime. 

SAP uses these deps at runtime, however, the way this works is because of the extending relationship between SAP and JS plugin where the deps of the extended plugin are available to the extending plugin at runtime.

In https://github.com/opensearch-project/job-scheduler/pull/773, guava was removed from JS which means these deps are no longer available to SAP at runtime. I'm creating this PR to change the guava deps from compileOnly to implementation to ensure they are included in the assembly and available at runtime.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
