### PR TITLE
Add API GET /rules/{id} endpoint to fetch rules directly from their IDs

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -61,6 +61,7 @@ import org.opensearch.securityanalytics.action.GetAllRuleCategoriesAction;
 import org.opensearch.securityanalytics.action.GetCorrelationAlertsAction;
 import org.opensearch.securityanalytics.action.GetDetectorAction;
 import org.opensearch.securityanalytics.action.GetFindingsAction;
+import org.opensearch.securityanalytics.action.GetRuleAction;
 import org.opensearch.securityanalytics.action.GetIndexMappingsAction;
 import org.opensearch.securityanalytics.action.GetMappingsViewAction;
 import org.opensearch.securityanalytics.action.IndexCorrelationRuleAction;
@@ -106,6 +107,7 @@ import org.opensearch.securityanalytics.resthandler.RestGetDetectorAction;
 import org.opensearch.securityanalytics.resthandler.RestGetFindingsAction;
 import org.opensearch.securityanalytics.resthandler.RestGetIndexMappingsAction;
 import org.opensearch.securityanalytics.resthandler.RestGetMappingsViewAction;
+import org.opensearch.securityanalytics.resthandler.RestGetRuleAction;
 import org.opensearch.securityanalytics.resthandler.RestIndexCorrelationRuleAction;
 import org.opensearch.securityanalytics.resthandler.RestIndexCustomLogTypeAction;
 import org.opensearch.securityanalytics.resthandler.RestIndexDetectorAction;
@@ -190,6 +192,7 @@ import org.opensearch.securityanalytics.transport.TransportGetDetectorAction;
 import org.opensearch.securityanalytics.transport.TransportGetFindingsAction;
 import org.opensearch.securityanalytics.transport.TransportGetIndexMappingsAction;
 import org.opensearch.securityanalytics.transport.TransportGetMappingsViewAction;
+import org.opensearch.securityanalytics.transport.TransportGetRuleAction;
 import org.opensearch.securityanalytics.transport.TransportIndexCorrelationRuleAction;
 import org.opensearch.securityanalytics.transport.TransportIndexCustomLogTypeAction;
 import org.opensearch.securityanalytics.transport.TransportIndexDetectorAction;
@@ -367,6 +370,7 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
                 new RestGetFindingsAction(),
                 new RestGetMappingsViewAction(),
                 new RestGetAlertsAction(),
+                new RestGetRuleAction(),
                 new RestGetThreatIntelAlertsAction(),
                 new RestUpdateThreatIntelAlertsStatusAction(),
                 new RestIndexRuleAction(),
@@ -526,6 +530,7 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
                 new ActionPlugin.ActionHandler<>(GetDetectorAction.INSTANCE, TransportGetDetectorAction.class),
                 new ActionPlugin.ActionHandler<>(SearchDetectorAction.INSTANCE, TransportSearchDetectorAction.class),
                 new ActionPlugin.ActionHandler<>(GetFindingsAction.INSTANCE, TransportGetFindingsAction.class),
+                new ActionPlugin.ActionHandler<>(GetRuleAction.INSTANCE, TransportGetRuleAction.class),
                 new ActionPlugin.ActionHandler<>(GetAlertsAction.INSTANCE, TransportGetAlertsAction.class),
                 new ActionPlugin.ActionHandler<>(IndexRuleAction.INSTANCE, TransportIndexRuleAction.class),
                 new ActionPlugin.ActionHandler<>(SearchRuleAction.INSTANCE, TransportSearchRuleAction.class),

--- a/src/main/java/org/opensearch/securityanalytics/action/GetRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/GetRuleAction.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.securityanalytics.action;
+
+import org.opensearch.action.ActionType;
+
+public class GetRuleAction extends ActionType<GetRuleResponse> {
+
+    public static final GetRuleAction INSTANCE = new GetRuleAction();
+    public static final String NAME = "cluster:admin/opensearch/securityanalytics/rule/get";
+
+    public GetRuleAction() {
+        super(NAME, GetRuleResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/action/GetRuleRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/GetRuleRequest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.securityanalytics.action;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import static org.opensearch.action.ValidateActions.addValidationError;
+
+public class GetRuleRequest extends ActionRequest {
+
+    private String ruleId;
+    private Boolean isPrepackaged;
+    private Long version;
+
+    public static final String RULE_ID = "ruleID";
+    public static final String IS_PREPACKAGED = "pre_packaged";
+
+    public GetRuleRequest(String ruleId, Boolean isPrepackaged, Long version) {
+        super();
+        this.ruleId = ruleId;
+        this.isPrepackaged = isPrepackaged;
+        this.version = version;
+    }
+
+    public GetRuleRequest(StreamInput sin) throws IOException {
+        this(sin.readString(),
+            sin.readBoolean(),
+            sin.readLong());
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (ruleId == null || ruleId.length() == 0 || isPrepackaged) {
+            validationException = addValidationError(String.format(Locale.getDefault(), "%s is missing", RULE_ID), validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(ruleId);
+        out.writeLong(version);
+    }
+
+    public String getRuleId() {
+        return ruleId;
+    }
+
+    public Boolean isPrepackaged() {
+        return isPrepackaged;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/action/GetRuleResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/GetRuleResponse.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.securityanalytics.action;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.securityanalytics.model.Rule;
+
+import java.io.IOException;
+
+import static org.opensearch.securityanalytics.util.RestHandlerUtils._ID;
+import static org.opensearch.securityanalytics.util.RestHandlerUtils._VERSION;
+
+public class GetRuleResponse extends ActionResponse implements ToXContentObject {
+
+    private String id;
+    private Long version;
+    private RestStatus status;
+    private Rule rule;
+
+    public GetRuleResponse(String id, Long version, RestStatus status, Rule rule) {
+        super();
+        this.id = id;
+        this.version = version;
+        this.status = status;
+        this.rule = rule;
+    }
+
+    public GetRuleResponse(StreamInput sin) throws IOException {
+        this(sin.readString(),
+             sin.readLong(),
+             sin.readEnum(RestStatus.class),
+             sin.readBoolean()? Rule.readFrom(sin): null);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(id);
+        out.writeLong(version);
+        out.writeEnum(status);
+        if (rule != null) {
+            out.writeBoolean(true);
+            rule.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject()
+                .field(_ID, id)
+                .field(_VERSION, version);
+        builder.startObject("rule")
+                .field(Rule.TITLE, rule.getTitle())
+                .field(Rule.CATEGORY, rule.getCategory())
+                .field(Rule.LOG_SOURCE, rule.getLogSource())
+                .field(Rule.DESCRIPTION, rule.getDescription())
+                .field(Rule.TAGS, rule.getTags())
+                .field(Rule.REFERENCES, rule.getReferences())
+                .field(Rule.LEVEL, rule.getLevel())
+                .field(Rule.FALSE_POSITIVES, rule.getFalsePositives())
+                .field(Rule.AUTHOR, rule.getAuthor())
+                .field(Rule.STATUS, rule.getStatus())
+                .field(Rule.LAST_UPDATE_TIME_FIELD, rule.getDate())
+                .field(Rule.QUERIES, rule.getQueries())
+                .field(Rule.RULE, rule.getRule())
+                .endObject();
+        return builder.endObject();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public RestStatus getStatus() {
+        return status;
+    }
+
+    public Rule getRule() {
+        return rule;
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/model/Rule.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Rule.java
@@ -21,7 +21,6 @@ import org.opensearch.securityanalytics.rules.aggregation.AggregationItem;
 import org.opensearch.securityanalytics.rules.backend.OSQueryBackend.AggregationQueries;
 import org.opensearch.securityanalytics.rules.condition.ConditionItem;
 import org.opensearch.securityanalytics.rules.exceptions.SigmaConditionError;
-import org.opensearch.securityanalytics.rules.exceptions.CompositeSigmaErrors;
 import org.opensearch.securityanalytics.rules.objects.SigmaCondition;
 import org.opensearch.securityanalytics.rules.objects.SigmaRule;
 
@@ -32,11 +31,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import static org.opensearch.securityanalytics.model.Detector.LAST_UPDATE_TIME_FIELD;
-import static org.opensearch.securityanalytics.model.Detector.NO_ID;
-import static org.opensearch.securityanalytics.model.Detector.NO_VERSION;
-
 
 public class Rule implements Writeable, ToXContentObject {
 
@@ -56,14 +50,19 @@ public class Rule implements Writeable, ToXContentObject {
     public static final String AUTHOR = "author";
     public static final String STATUS = "status";
 
-    private static final String QUERIES = "queries";
+    public static final String QUERIES = "queries";
     public static final String QUERY_FIELD_NAMES = "query_field_names";
 
     public static final String RULE = "rule";
 
+    public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
+
     public static final String PRE_PACKAGED_RULES_INDEX = ".opensearch-sap-pre-packaged-rules-config";
     public static final String CUSTOM_RULES_INDEX = ".opensearch-sap-custom-rules-config";
     public static final String AGGREGATION_QUERIES = "aggregationQueries";
+
+    public static final String NO_ID = "";
+    public static final Long NO_VERSION = 1L;
 
     public static final NamedXContentRegistry.Entry XCONTENT_REGISTRY = new NamedXContentRegistry.Entry(
             Rule.class,

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestGetRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestGetRuleAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.securityanalytics.resthandler;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestActions;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+import org.opensearch.securityanalytics.action.GetRuleAction;
+import org.opensearch.securityanalytics.action.GetRuleRequest;
+import org.opensearch.securityanalytics.model.Rule;
+import org.opensearch.securityanalytics.SecurityAnalyticsPlugin;
+
+public class RestGetRuleAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "get_rule_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(GET, String.format(Locale.getDefault(), "%s/{%s}", SecurityAnalyticsPlugin.RULE_BASE_URI, GetRuleRequest.RULE_ID)));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        String ruleId = request.param(GetRuleRequest.RULE_ID, Rule.NO_ID);
+        Boolean isPrepackaged = request.paramAsBoolean(GetRuleRequest.IS_PREPACKAGED, false);
+
+        if (ruleId == null || ruleId.isEmpty()) {
+            throw new IllegalArgumentException("missing id");
+        }
+
+        GetRuleRequest req = new GetRuleRequest(ruleId, isPrepackaged, RestActions.parseVersion(request));
+        return channel -> client.execute(
+                GetRuleAction.INSTANCE,
+                req,
+                new RestToXContentListener<>(channel)
+        );
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportGetRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportGetRuleAction.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.securityanalytics.transport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.securityanalytics.action.GetRuleAction;
+import org.opensearch.securityanalytics.model.Rule;
+import org.opensearch.securityanalytics.action.GetRuleRequest;
+import org.opensearch.securityanalytics.action.GetRuleResponse;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
+import org.opensearch.securityanalytics.util.SecurityAnalyticsException;
+import org.opensearch.securityanalytics.util.RuleIndices;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import java.io.IOException;
+
+
+import static org.opensearch.core.rest.RestStatus.OK;
+
+public class TransportGetRuleAction extends HandledTransportAction<GetRuleRequest, GetRuleResponse> implements SecureTransportAction {
+
+    private final Client client;
+    private final NamedXContentRegistry xContentRegistry;
+    private final RuleIndices ruleIndices;
+    private final ClusterService clusterService;
+    private final Settings settings;
+    private final ThreadPool threadPool;
+
+    private volatile Boolean filterByEnabled;
+
+    @Inject
+    public TransportGetRuleAction(TransportService transportService, ActionFilters actionFilters, RuleIndices ruleIndices, ClusterService clusterService, NamedXContentRegistry xContentRegistry, Client client, Settings settings) {
+        super(GetRuleAction.NAME, transportService, actionFilters, GetRuleRequest::new);
+        this.xContentRegistry = xContentRegistry;
+        this.client = client;
+        this.ruleIndices = ruleIndices;
+        this.clusterService = clusterService;
+        this.threadPool = this.ruleIndices.getThreadPool();
+        this.settings = settings;
+        this.filterByEnabled = SecurityAnalyticsSettings.FILTER_BY_BACKEND_ROLES.get(this.settings);
+
+        this.clusterService.getClusterSettings().addSettingsUpdateConsumer(SecurityAnalyticsSettings.FILTER_BY_BACKEND_ROLES, this::setFilterByEnabled);
+    }
+
+    @Override
+    protected void doExecute(Task task, GetRuleRequest request, ActionListener<GetRuleResponse> actionListener) {
+
+        User user = readUserFromThreadContext(this.threadPool);
+
+        String validateBackendRoleMessage = validateUserBackendRoles(user, this.filterByEnabled);
+        if (!"".equals(validateBackendRoleMessage)) {
+            actionListener.onFailure(new OpenSearchStatusException("Do not have permissions to resource", RestStatus.FORBIDDEN));
+            return;
+        }
+
+        String index = Rule.CUSTOM_RULES_INDEX;
+        if(request.isPrepackaged()) {
+            index = Rule.PRE_PACKAGED_RULES_INDEX;
+        }
+
+        GetRequest getRequest = new GetRequest(index, request.getRuleId()).version(request.getVersion());
+        client.get(getRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(GetResponse response) {
+                try {
+                    if (!response.isExists()) {
+                        actionListener.onFailure(SecurityAnalyticsException.wrap(new OpenSearchStatusException("Rule not found.", RestStatus.NOT_FOUND)));
+                        return;
+                    }
+                    Rule rule = null;
+                    if (!response.isSourceEmpty()) {
+                        XContentParser xcp = XContentHelper.createParser(
+                                xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                                response.getSourceAsBytesRef(), XContentType.JSON
+                        );
+                        rule = Rule.docParse(xcp, response.getId(), response.getVersion());
+                        assert rule != null;
+                    }
+                    actionListener.onResponse(new GetRuleResponse(rule.getId(), rule.getVersion(), OK, rule));
+                } catch (IOException ex) {
+                    actionListener.onFailure(ex);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                actionListener.onFailure(e);
+            }
+        });
+    }
+
+    private void setFilterByEnabled(boolean filterByEnabled) {
+        this.filterByEnabled = filterByEnabled;
+    }
+}

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/RuleRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/RuleRestApiIT.java
@@ -388,6 +388,28 @@ public class RuleRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertEquals(1, ((Map<String, Object>) ((Map<String, Object>) responseBody.get("hits")).get("total")).get("value"));
     }
 
+    public void testGettingRuleById() throws IOException {
+        String rule = randomRule();
+
+        Response createResponse = makeRequest(client(), "POST", SecurityAnalyticsPlugin.RULE_BASE_URI, Collections.singletonMap("category", randomDetectorType()),
+                new StringEntity(rule), new BasicHeader("Content-Type", "application/json"));
+        Assert.assertEquals("Create rule failed", RestStatus.CREATED, restStatus(createResponse));
+
+        Map<String, Object> responseBody = asMap(createResponse);
+        String createdId = responseBody.get("_id").toString();
+
+        Response getResponse = makeRequest(client(), "GET", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.RULE_BASE_URI, createdId),
+         Collections.emptyMap(), null);
+        Assert.assertEquals("Getting rule from id failed", RestStatus.OK, restStatus(getResponse));
+    }
+
+    public void testGettingRuleByBadId() throws IOException {
+        String badId = "BAD_ID";
+        Response getResponse = makeRequest(client(), "GET", String.format(Locale.getDefault(), "%s/%s", SecurityAnalyticsPlugin.RULE_BASE_URI, badId),
+         Collections.emptyMap(), null);
+        Assert.assertEquals("Getting rule from bad id not failed", RestStatus.NOT_FOUND, restStatus(getResponse));
+    }
+
     public void testUpdatingUnusedRule() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 


### PR DESCRIPTION
### Description
Add a new endpoint to retrieve rules details from their IDs. 

### Related Issues
Related to #1529.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
