### PR TITLE
Refactor GetAlerts API to not throw 404 error when detector is not found

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/action/GetAlertsRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/GetAlertsRequest.java
@@ -12,7 +12,6 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.commons.alerting.model.Table;
-import org.opensearch.securityanalytics.model.Detector;
 
 
 import static org.opensearch.action.ValidateActions.addValidationError;

--- a/src/main/java/org/opensearch/securityanalytics/action/GetAlertsResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/GetAlertsResponse.java
@@ -5,18 +5,13 @@
 package org.opensearch.securityanalytics.action;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
-import org.opensearch.commons.alerting.model.Alert;
-import org.opensearch.commons.alerting.model.FindingWithDocs;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.securityanalytics.model.Detector;
 
 public class GetAlertsResponse extends ActionResponse implements ToXContentObject {
 

--- a/src/main/java/org/opensearch/securityanalytics/alerts/AlertsService.java
+++ b/src/main/java/org/opensearch/securityanalytics/alerts/AlertsService.java
@@ -125,7 +125,12 @@ public class AlertsService {
 
             @Override
             public void onFailure(Exception e) {
-                listener.onFailure(e);
+                if(e.getMessage().matches("(.*)Detector(.*) not found(.*)")) {
+                    listener.onResponse(new GetAlertsResponse(List.of(), 0));
+                }
+                else{
+                    listener.onFailure(e);
+                }
             }
         });
     }


### PR DESCRIPTION
### Description
Rather than throw an 404 error, the GetAlerts API should instead return an empty list when there are no detectors defined for the specified detectorType or detector_id.

### Related Issues
Resolves #872.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
