### PR TITLE
Update delete_backport_branch workflow to include release-chores branches

### DIFF
--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: startsWith(github.event.pull_request.head.ref,'backport/') || startsWith(github.event.pull_request.head.ref,'release-chores/')
     steps:
       - name: Delete merged branch


### PR DESCRIPTION
This PR updates the delete_backport_branch workflow to automatically delete branches that start with 'release-chores/' after they are merged, in addition to the existing condition for 'backport/' branches.