### PR TITLE
Remove direct reference to Job-Scheduler Lock Index in SAP repo

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -724,19 +724,12 @@ public class SATIFSourceConfigManagementService {
                                             saTifSourceConfigService.deleteAllIocIndices(concreteIndices, false, ActionListener.wrap(
                                                     r -> {
                                                         log.debug("Successfully deleted all ioc indices");
-                                                        saTifSourceConfigService.deleteJobSchedulerLockIfJobDisabled(updateSaTifSourceConfigResponse, ActionListener.wrap(
-                                                                deleteLockResponse -> {
-                                                                    saTifSourceConfigService.deleteTIFSourceConfig(updateSaTifSourceConfigResponse, ActionListener.wrap(
-                                                                            deleteResponse -> {
-                                                                                log.debug("Successfully deleted threat intel source config [{}]", updateSaTifSourceConfigResponse.getId());
-                                                                                listener.onResponse(deleteResponse);
-                                                                            }, e -> {
-                                                                                log.error("Failed to delete threat intel source config [{}]", saTifSourceConfig.getId());
-                                                                                listener.onFailure(e);
-                                                                            }
-                                                                    ));
+                                                        saTifSourceConfigService.deleteTIFSourceConfig(updateSaTifSourceConfigResponse, ActionListener.wrap(
+                                                                deleteResponse -> {
+                                                                    log.debug("Successfully deleted threat intel source config [{}]", updateSaTifSourceConfigResponse.getId());
+                                                                    listener.onResponse(deleteResponse);
                                                                 }, e -> {
-                                                                    log.error("Failed to delete threat intel job scheduler lock [{}]", saTifSourceConfig.getId());
+                                                                    log.error("Failed to delete threat intel source config [{}]", saTifSourceConfig.getId());
                                                                     listener.onFailure(e);
                                                                 }
                                                         ));

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.opensearch.jobscheduler.spi.utils.LockService.LOCK_INDEX_NAME;
 import static org.opensearch.securityanalytics.SecurityAnalyticsPlugin.JOB_INDEX_NAME;
 import static org.opensearch.securityanalytics.TestHelpers.oldThreatIntelJobMapping;
 import static org.opensearch.securityanalytics.services.STIX2IOCFeedStore.IOC_ALL_INDEX_PATTERN;
@@ -731,10 +730,6 @@ public class SourceConfigWithoutS3RestApiIT extends SecurityAnalyticsRestTestCas
 
         // ensure all iocs are deleted
         hits = executeSearch(IOC_ALL_INDEX_PATTERN, request);
-        Assert.assertEquals(0, hits.size());
-
-        // ensure that lock is deleted
-        hits = executeSearch(LOCK_INDEX_NAME,request);
         Assert.assertEquals(0, hits.size());
     }
 


### PR DESCRIPTION
### Description

This PR removes some logic that removes a lock directly from the Job Scheduler Lock index. Job Scheduler has a mechanism to expire locks if they've been acquired for too long and keeps lock entries for scheduled jobs if the job is disabled. If a plugin removes job metadata from a job index then the corresponding lock is also deleted by job-scheduler automatically.

This work should be delegated to Job Scheduler and should not live in another plugin's repo.

### Related Issues

Resolves https://github.com/opensearch-project/job-scheduler/pull/714#discussion_r2353571549

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
