### PR TITLE
Ensure that user attributes are in expected format attrKey=attrVal for testing

### DIFF
--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -2975,7 +2975,7 @@ public class TestHelpers {
                 feedFormat,
                 sourceConfigType,
                 description,
-                new User("wrgrer", List.of("b1"), List.of("r1"), List.of("ca")),
+                new User("wrgrer", List.of("b1"), List.of("r1"), List.of("attrKey=ca")),
                 createdAt,
                 source,
                 enabledTime,

--- a/src/test/java/org/opensearch/securityanalytics/model/WriteableTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/WriteableTests.java
@@ -35,7 +35,7 @@ public class WriteableTests extends OpenSearchTestCase {
     public void testDetector() throws IOException { // an edge case of detector serialization that failed testDetectorAsAStream() intermittently
         String detectorString = "{\"type\":\"detector\",\"name\":\"MczAuRCrve\",\"detector_type\":\"test_windows\"," +
                 "\"user\":{\"name\":\"QhKrfthgxw\",\"backend_roles\":[\"uYvGLCPhfX\",\"fOLkcRxMWR\"],\"roles\"" +
-                ":[\"YuucNpVzTm\",\"all_access\"],\"custom_attributes\":{\"test_attr\":\"test\"}," +
+                ":[\"YuucNpVzTm\",\"all_access\"],\"custom_attribute_names\":[\"test_attr=test\"]," +
                 "\"user_requested_tenant\":null},\"threat_intel_enabled\":false,\"enabled\":false,\"enabled_time\"" +
                 ":null,\"schedule\":{\"period\":{\"interval\":5,\"unit\":\"MINUTES\"}},\"inputs\":[{\"detector_input\"" +
                 ":{\"description\":\"\",\"indices\":[],\"custom_rules\":[],\"pre_packaged_rules\":[]}}],\"triggers\"" +

--- a/src/test/java/org/opensearch/securityanalytics/model/threatintel/ThreatIntelAlertTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/threatintel/ThreatIntelAlertTests.java
@@ -89,7 +89,7 @@ public class ThreatIntelAlertTests extends OpenSearchTestCase {
                 randomAlphaOfLength(10),
                 randomLong(),
                 randomLong(),
-                new User(randomAlphaOfLength(10), List.of(randomAlphaOfLength(10)), List.of(randomAlphaOfLength(10)), List.of(randomAlphaOfLength(10))),
+                new User(randomAlphaOfLength(10), List.of(randomAlphaOfLength(10)), List.of(randomAlphaOfLength(10)), List.of("attrKey=attrVal")),
                 randomAlphaOfLength(10),
                 randomAlphaOfLength(10),
                 randomAlphaOfLength(10),


### PR DESCRIPTION
### Description

Many repos have a user attribute called `custom_attribute_names` that is in their system index mappings when storing a copy of the user. This field exists, but was never plumbed rendering this field as useless. 

There is a bugfix underway to fix an [issue in the alerting repo](https://github.com/opensearch-project/alerting/issues/1829) when an alerting monitor is created by a user that has DLS restrictions that have user attribute substitutions. As part of fixing the bug, the field `custom_attribute_names` will now be used and each entry in the list is expected to be in the `attrKey=attrVal` format. This PR ensures that test data that the security-analytics plugin creates conforms to this expected format.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
