### PR TITLE
Only use alerting SNAPSHOTS in SNAPSHOT build, otherwise use release artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,8 @@ buildscript {
         }
 
         alerting_spi_build = opensearch_build
-        alerting_spi_build += "-SNAPSHOT"
         if (isSnapshot) {
+            alerting_spi_build += "-SNAPSHOT"
             opensearch_build += "-SNAPSHOT"
 
             // TODO consider enabling snapshot options once SA commons is published to maven central


### PR DESCRIPTION
### Description

Only use alerting SNAPSHOTS in SNAPSHOT build, otherwise use release artifacts

### Related Issues

Resolves https://github.com/opensearch-project/security-analytics/issues/1607

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
