### PR TITLE
Fix bug when deleting detector with 0 rules.

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteDetectorAction.java
@@ -197,6 +197,13 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
             deleteWorkflow(detector, onDeleteWorkflowStep);
             onDeleteWorkflowStep.whenComplete(acknowledgedResponse -> {
                 List<String> monitorIds = detector.getMonitorIds();
+
+                // A detector with 0 rules will have 0 monitors to delete. Skipping monitor deletion steps.
+                if (monitorIds.isEmpty()) {
+                    deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
+                    return;
+                }
+
                 ActionListener<DeleteMonitorResponse> deletesListener = new GroupedActionListener<>(new ActionListener<>() {
                     @Override
                     public void onResponse(Collection<DeleteMonitorResponse> responses) {

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
@@ -1877,4 +1877,32 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
         Assert.assertTrue(doesIndexExist(DetectorMonitorConfig.getRuleIndex(randomDetectorType()) + "-000001"));
     }
+
+    public void testDeletingDetectorEditedToHaveZeroRules() throws IOException {
+        String index = createTestIndex(randomIndex(), windowsIndexMapping());
+
+        Request createMappingRequest = new Request("POST", SecurityAnalyticsPlugin.MAPPER_BASE_URI);
+        createMappingRequest.setJsonEntity(
+                "{ \"index_name\":\"" + index + "\"," +
+                        "  \"rule_topic\":\"" + randomDetectorType() + "\", " +
+                        "  \"partial\":true" +
+                        "}"
+        );
+        Response response = client().performRequest(createMappingRequest);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        // Create a test detector that has at least 1 rule.
+        Detector detector = randomDetectorWithTriggers(getRandomPrePackagedRules(), List.of(new DetectorTrigger(null, "test-trigger", "1", List.of(randomDetectorType()), List.of(), List.of(), List.of(), List.of(), List.of())));
+        String detectorId = createDetector(detector);
+
+        // Update the detector to have 0 rules. This should update the detector's 'monitor_id' attribute to be an empty array.
+        DetectorInput input = new DetectorInput("detector with no rules", List.of(index), List.of(), List.of());
+        Detector updatedDetector = randomDetectorWithInputs(List.of(input));
+
+        Response updateResponse = makeRequest(client(), "PUT", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), toHttpEntity(updatedDetector));
+        Assert.assertEquals("Update detector failed", RestStatus.OK, restStatus(updateResponse));
+
+        Response deleteResponse = makeRequest(client(), "DELETE", SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + detectorId, Collections.emptyMap(), null);
+        Assert.assertEquals("Delete detector failed", RestStatus.OK, restStatus(deleteResponse));
+    }
 }


### PR DESCRIPTION
### Description
The DeleteDetector API is failing with a `groupSize must be greater than 0 but was 0` error when the [[monitorIds]](https://github.com/opensearch-project/security-analytics/blob/main/src/main/java/org/opensearch/securityanalytics/model/Detector.java#L101) attribute of the detector is empty. That error looks to be caused by [[this line]](https://github.com/opensearch-project/security-analytics/blob/main/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteDetectorAction.java#L229) on which we pass the list of monitorIds for the detector to the GroupedActionListener we use to listen for DeleteMonitorResponses.

The `monitor_id` attribute becomes an empty array when the detector is created/edited to have 0 rules because without any rules, there are no queries the detector needs to execute; and therefore no monitor is needed for the detector.

I tested this behavior by:
1. Creating a detector with multiple rules associated with it. The detector had a `monitor_id` list with 1 entry.
1. Editing the detector to have only 1 rule. The detector continued to have 1 entry in the list.
1. Edited the detector to have 0 rules. The `monitor_id` list was then empty.

This PR adds a check after [[this line]](https://github.com/opensearch-project/security-analytics/blob/main/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteDetectorAction.java#L199) to only perform the monitorDelete API calls if the monitorIds list is not empty.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
