### PR TITLE
Add validate url check while reading thread intel feed (#1660)

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/UrlDownloadSource.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/UrlDownloadSource.java
@@ -1,5 +1,7 @@
 package org.opensearch.securityanalytics.threatIntel.model;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -9,11 +11,13 @@ import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Locale;
 
 /**
  * This is a Threat Intel Source config where the iocs are downloaded from the URL
  */
 public class UrlDownloadSource extends Source implements Writeable, ToXContent {
+    private static final Logger log = LogManager.getLogger(UrlDownloadSource.class);
     public static final String URL_FIELD = "url";
     public static final String FEED_FORMAT_FIELD = "feed_format";
     public static final String HAS_CSV_HEADER_FIELD = "has_csv_header_field";
@@ -71,6 +75,11 @@ public class UrlDownloadSource extends Source implements Writeable, ToXContent {
                 case URL_FIELD:
                     String urlString = xcp.text();
                     url = new URL(urlString);
+                    String protocol = url.getProtocol().toLowerCase(Locale.ROOT);
+                    if (!"http".equals(protocol) && !"https".equals(protocol)) {
+                        log.error("Unsupported protocol [{}]. Only http and https are allowed. Url:{}", protocol, urlString);
+                        throw new IOException("Unsupported protocol [" + protocol + "]. Only http and https are allowed.");
+                    }
                     break;
                 case FEED_FORMAT_FIELD:
                     feedFormat = xcp.text();

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelFeedParser.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelFeedParser.java
@@ -17,10 +17,13 @@ import org.opensearch.securityanalytics.threatIntel.model.TIFMetadata;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.UnknownHostException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Locale;
 
 //Parser helper class
 public class ThreatIntelFeedParser {
@@ -34,6 +37,11 @@ public class ThreatIntelFeedParser {
      */
     @SuppressForbidden(reason = "Need to connect to http endpoint to read threat intel feed database file")
     public static CSVParser getThreatIntelFeedReaderCSV(final TIFMetadata tifMetadata) {
+        try {
+            validateUrl(new URL(tifMetadata.getUrl()));
+        } catch (IOException e) {
+            throw new OpenSearchException("Invalid threat intel feed URL [{}]", tifMetadata.getUrl(), e);
+        }
         SpecialPermission.check();
         return AccessController.doPrivileged((PrivilegedAction<CSVParser>) () -> {
             try {
@@ -53,6 +61,7 @@ public class ThreatIntelFeedParser {
      */
     @SuppressForbidden(reason = "Need to connect to http endpoint to read threat intel feed database file")
     public static CSVParser getThreatIntelFeedReaderCSV(URL url) {
+        validateUrl(url);
         SpecialPermission.check();
         return AccessController.doPrivileged((PrivilegedAction<CSVParser>) () -> {
             try {
@@ -64,5 +73,33 @@ public class ThreatIntelFeedParser {
                 throw new OpenSearchException("failed to read threat intel feed data from {}", url, e);
             }
         });
+    }
+
+    private static void validateUrl(URL url) {
+        String protocol = url.getProtocol().toLowerCase(Locale.ROOT);
+        if (!"http".equals(protocol) && !"https".equals(protocol)) {
+            log.error("Unsupported protocol [{}]. Only http and https are allowed.", protocol);
+            throw new OpenSearchException("Unsupported protocol [{}]. Only http and https are allowed.", protocol);
+        }
+
+        InetAddress address;
+        try {
+            address = InetAddress.getByName(url.getHost());
+        } catch (UnknownHostException e) {
+            log.error("Unable to resolve host [{}]", url.getHost());
+            throw new OpenSearchException("Unable to resolve host [{}]", url.getHost());
+        }
+
+        if (address.isLoopbackAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()
+                || address.isAnyLocalAddress()) {
+            log.error("URL [{}] points to a restricted address. Loopback, link-local, and private addresses are not allowed.",
+                    url);
+            throw new OpenSearchException(
+                    "URL [{}] points to a restricted address. Loopback, link-local, and private addresses are not allowed.",
+                    url
+            );
+        }
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/threatIntel/model/ThreatIntelSourceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/threatIntel/model/ThreatIntelSourceTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.securityanalytics.threatIntel.model;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.opensearch.securityanalytics.TestHelpers;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class ThreatIntelSourceTests extends OpenSearchTestCase {
+
+    @Test
+    public void testParseWithUrlDownloadSource_fileProtocolBlocked() {
+        Pair<String, String>[] blockedUrls = new Pair[] {
+                Pair.of("file:///etc/passwd", "file"),
+                Pair.of("ftp://example.com/feed.csv", "ftp"),
+                Pair.of("jar:file:///tmp/test.jar!/", "jar")
+        };
+
+        for (Pair<String, String> blockedUrl : blockedUrls) {
+            String sourceString = "{\n" +
+                    "  \"url_download\": {\n" +
+                    "    \"url\": \"" + blockedUrl.getLeft() + "\",\n" +
+                    "    \"feed_format\": \"csv\"\n" +
+                    "  }\n" +
+                    "}";
+            Exception e = assertThrows(IOException.class,
+                    () -> Source.parse(TestHelpers.parser(sourceString)));
+            assertEquals(String.format("Unsupported protocol [%s]. Only http and https are allowed.", blockedUrl.getRight()),
+                    e.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelFeedParserTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelFeedParserTests.java
@@ -1,0 +1,52 @@
+package org.opensearch.securityanalytics.threatIntel.util;
+
+import org.junit.Test;
+import org.opensearch.OpenSearchException;
+import org.opensearch.securityanalytics.threatIntel.model.TIFMetadata;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.net.URL;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ThreatIntelFeedParserTests extends OpenSearchTestCase {
+
+    @Test
+    public void testGetThreatIntelFeedReaderCSV_blockedUrls() {
+        String[] blockedUrls = {
+                "file:///etc/passwd", //fileProtocolBlocked
+                "ftp://example.com/feed.csv", //ftpProtocolBlocked
+                "http://127.0.0.1:9200", //loopbackBlocked
+                "http://localhost:9200", //localhostBlocked
+                "http://169.254.169.254/latest/meta-data/", //linkLocalBlocked
+                "http://10.0.0.1/feed.csv", //siteLocalBlocked
+                "http://192.168.1.1/feed.csv", //privateNetworkBlocked
+                "jar:file:///tmp/test.jar!/" //jarProtocolBlocked
+        };
+
+        for (String blockedUrl : blockedUrls) {
+            expectThrows(OpenSearchException.class,
+                    () -> ThreatIntelFeedParser.getThreatIntelFeedReaderCSV(new URL(blockedUrl)));
+        }
+    }
+
+    @Test
+    public void testGetThreatIntelFeedReaderCSV_tifMetadata_blockedUrls() {
+        String[] blockedUrls = {
+                "file:///etc/passwd",
+                "http://127.0.0.1:9200",
+                "http://localhost:9200",
+                "http://169.254.169.254/latest/meta-data/",
+                "http://10.0.0.1/feed.csv",
+                "http://192.168.1.1/feed.csv"
+        };
+
+        for (String blockedUrl : blockedUrls) {
+            TIFMetadata tifMetadata = mock(TIFMetadata.class);
+            when(tifMetadata.getUrl()).thenReturn(blockedUrl);
+            expectThrows(OpenSearchException.class,
+                    () -> ThreatIntelFeedParser.getThreatIntelFeedReaderCSV(tifMetadata));
+        }
+    }
+}


### PR DESCRIPTION
### Description

Add URL validation to threat intel URL_DOWNLOAD source type to prevent SSRF and local file read vulnerabilities.

The ThreatIntelFeedParser.getThreatIntelFeedReaderCSV() methods pass user-supplied URLs directly to url.openConnection() inside AccessController.doPrivileged() without any validation. This allows users with the 
security_analytics_full_access role to:

1. Read local files via file:// protocol (e.g., /etc/passwd, environment variables, deployment details)
2. Bypass RBAC via SSRF to http://127.0.0.1:9200, enabling reads of all indices including .opendistro_security (admin password hashes) and .plugins-ml-config (ML Commons encryption key)

This change adds a validateUrl() method in ThreatIntelFeedParser that enforces:
- **Protocol allowlist**: Only http and https are permitted. Blocks file://, jar://, ftp://, etc.
- **Host blocklist**: Blocks loopback (127.0.0.1), link-local (169.254.x.x — including EC2 IMDS), site-local/private, and any-local addresses via DNS resolution before connection.

Validation is applied in three locations:
- ThreatIntelFeedParser.getThreatIntelFeedReaderCSV(URL url) — the URL_DOWNLOAD fetch path
- ThreatIntelFeedParser.getThreatIntelFeedReaderCSV(TIFMetadata tifMetadata) — the built-in feed updater path (defense in depth)
- UrlDownloadSource.parse() — early rejection at config creation/update time

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- Related: P403913658 — SecOps Bug Bounty report for SSRF + local file read in threat intel URL_DOWNLOAD -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using --signoff.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-
certificate-of-origin).