### PR TITLE
Resolve CVE-2026-34478 by forcing log4j-core to 2.25.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,7 @@ configurations {
     all {
         resolutionStrategy {
             force "com.google.guava:guava:32.0.1-jre"
+            force "org.apache.logging.log4j:log4j-core:2.25.4"
         }
     }
 }


### PR DESCRIPTION
## Summary
Resolves CVE-2026-34478 (MEDIUM severity) by adding a `force` directive for `org.apache.logging.log4j:log4j-core:2.25.4` in the Gradle `resolutionStrategy` block.

## Details
Apache Log4j Core's Rfc5424Layout, in versions 2.21.0 through 2.25.3, is vulnerable to log injection via CRLF sequences due to undocumented renames of security-relevant configuration attributes. Two distinct issues affect users of stream-based syslog services who configure Rfc5424Layout directly:

- The `newLineEscape` attribute was silently renamed, causing newline escaping to stop working for users of TCP framing (RFC 6587), exposing them to CRLF injection in log output.
- The `useTlsMessageFormat` attribute was silently renamed, causing users of TLS framing (RFC 5425) to be silently downgraded to unframed TCP (RFC 6587), without newline escaping.

Users of the SyslogAppender are not affected, as its configuration attributes were not modified.

## Impact
Apache Log4j Core's Rfc5424Layout, in versions 2.21.0 through 2.25.3, is vulnerable to log injection via CRLF sequences due to undocumented renames of security-relevant configuration attributes.

## Fix
- Added `force "org.apache.logging.log4j:log4j-core:2.25.4"` to the Gradle `resolutionStrategy` block in `build.gradle`
- Version 2.25.4 corrects the renamed attributes and restores proper CRLF escaping and TLS framing behavior

## Test Plan
- [ ] Verify `log4j-core` resolves to `2.25.4` in dependency tree
- [ ] Verify no regressions in build or tests