### PR TITLE
Fix mutable script params for detector trigger actions (#1715)

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/model/DetectorTrigger.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/DetectorTrigger.java
@@ -23,6 +23,7 @@ import org.opensearch.script.ScriptType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -477,8 +478,8 @@ public class DetectorTrigger implements Writeable, ToXContentObject {
                 messageTemplate = messageTemplate.replace("{{ctx.detector", "{{ctx.monitor");
 
                 Action transformedAction = new Action(action.getName(), action.getDestinationId(),
-                        new Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, subjectTemplate, Collections.emptyMap()),
-                        new Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, messageTemplate, Collections.emptyMap()),
+                        new Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, subjectTemplate, new HashMap<>()),
+                        new Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, messageTemplate, new HashMap<>()),
                         action.getThrottleEnabled(), action.getThrottle(),
                         action.getId(), action.getActionExecutionPolicy());
 


### PR DESCRIPTION
### Description
This change fixes a detector create/update failure caused by using Java's immutable `Collections.emptyMap()` when constructing trigger action `Script` objects in `DetectorTrigger#getActions()`.

The Alerting plugin consumes these script params from Kotlin and expects a mutable map implementation. Replacing the immutable empty map with `new HashMap<>()` prevents the `kotlin.collections.EmptyMap cannot be cast to kotlin.collections.MutableMap` exception and allows detector operations with trigger actions to succeed.

### Related Issues
Resolves #1715, #1553, #1721

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).