### PR TITLE
fix: set deleteQueryIndexInEveryRun=false for chained_findings monitor

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -903,7 +903,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                         detector.getAlertsHistoryIndex(),
                         detector.getAlertsHistoryIndexPattern(),
                         DetectorMonitorConfig.getRuleIndexMappingsByType(),
-                        true), enableDetectorWithDedicatedQueryIndices, true, PLUGIN_OWNER_FIELD, null, null);
+                        true), enableDetectorWithDedicatedQueryIndices, false, PLUGIN_OWNER_FIELD, null, null);
 
         return new IndexMonitorRequest(monitorId, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, refreshPolicy, restMethod, monitor, null);
     }


### PR DESCRIPTION
## Summary

- The `chained_findings` monitor was constructed with `deleteQueryIndexInEveryRun=true` in `TransportIndexDetectorAction.java` (~line 906), causing its backing query index to be deleted and recreated on every monitor execution cycle.
- The regular doc-level monitor (same file, ~line 800) correctly passes `null` for this flag.
- This one-character fix changes `true` to `false`, preventing the chained findings query index from being torn down and rebuilt on every run.

## Root cause

`createDocLevelMonitorMatchAllRequest` builds the `chained_findings` monitor's `DataSources` with `deleteQueryIndexInEveryRun=true`. This flag instructs the alerting plugin's `DocLevelMonitorQueries` to delete and recreate the backing query index (e.g., `.opensearch-sap-<detector>-detectors-queries-optimized-<uuid>_chained_findings-000001`) on every execution, even though the query index for a chained findings monitor is stable across runs.

This compounds with a related bug in opensearch-project/alerting where the condition in `DocLevelMonitorQueries.kt:500` is inverted (`!=` should be `==`), making every run unconditionally enter the delete+recreate path. The combined effect is 23,000+ `MergeSchedulerConfig` log lines per minute on clusters running detectors with chained findings enabled (3 master nodes × ~6 log lines per delete+recreate event × execution frequency).

## Change

**File:** `src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java`

```diff
-        true), enableDetectorWithDedicatedQueryIndices, true, PLUGIN_OWNER_FIELD, null, null);
+        true), enableDetectorWithDedicatedQueryIndices, false, PLUGIN_OWNER_FIELD, null, null);
```

## Related

- Fixes #1725
- Related bug in opensearch-project/alerting: inverted condition in `DocLevelMonitorQueries.kt:500` (`targetQueryIndex != monitor.dataSources.queryIndex` should be `==`) — both bugs must be fixed to fully resolve the log storm.

## Test plan

- [ ] Unit tests for `createDocLevelMonitorMatchAllRequest` confirm `deleteQueryIndexInEveryRun` is `false` on the returned monitor's `DataSources`
- [ ] Integration test: create a detector with chained findings enabled, execute it multiple times, verify the `_chained_findings` query index is not deleted/recreated between runs
- [ ] Verify regular doc-level monitor (non-chained) behavior is unchanged