### PR TITLE
Update artifact upload names for upload-artifact v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: logs-ubuntu
+          name: logs-${{ matrix.os }}-${{ matrix.java }}
           path: build/testclusters/integTest-*/logs/*
           overwrite: true
 
@@ -125,7 +125,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() && matrix.os == 'macos-latest' }}
         with:
-          name: logs-mac
+          name: logs-${{ matrix.os }}-${{ matrix.java }}
           path: build/testclusters/integTest-*/logs/*
           overwrite: true
 
@@ -133,7 +133,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() && matrix.os == 'windows-latest' }}
         with:
-          name: logs-windows
+          name: logs-${{ matrix.os }}-${{ matrix.java }}
           path: build\testclusters\integTest-*\logs\*
           overwrite: true
 

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -48,5 +48,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: logs
+          name: logs-${{ matrix.java }}
           path: build/testclusters/integTest-*/logs/*

--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -55,6 +55,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: logs
+          name: logs-${{ matrix.java }}
           overwrite: 'true'
           path: build/testclusters/integTest-*/logs/*


### PR DESCRIPTION
## Description

Updates failed-log artifact names so matrix jobs publish unique artifacts when using `actions/upload-artifact@v4`.

`upload-artifact@v4` does not support multiple uploads to the same artifact name within a workflow run, so log artifacts now include the relevant matrix values.

## Changes

- Use OS and Java version in CI failed-log artifact names.
- Use Java version in multi-node and security test failed-log artifact names.
- Leave artifact upload paths unchanged.

## Validation

- Verified no remaining `actions/upload-artifact@v3` or `actions/download-artifact@v3` references under `.github/workflows`.
- Ran `git diff --check`.

## Related

Related: #1413