### PR TITLE
Add ci.opensearch.org maven2 mirror to avoid throttling

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -6,6 +6,7 @@
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     }
@@ -180,6 +181,7 @@ publishing {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-security-analytics'


### PR DESCRIPTION
### Description
Add ci.opensearch.org maven2 mirror to avoid maven central throttling

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6062

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).