### PR TITLE
[Backport 2.19] Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -4,5 +4,6 @@
  */
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     }
@@ -146,6 +147,7 @@ publishing {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-security-analytics'


### PR DESCRIPTION
### Description
Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins.

### Changes
* `build-tools/repositories.gradle` — Add CI mirror
* `build.gradle` — Add CI mirror in buildscript and project repositories
* `settings.gradle` — Add `pluginManagement` block with CI mirror

### Testing
Build verification