### PR TITLE
Feat: Make system index auto-expand replicas setting configurable

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -515,7 +515,10 @@ public class SecurityAnalyticsPlugin extends Plugin implements ActionPlugin, Map
                 SecurityAnalyticsSettings.IOC_INDEX_RETENTION_PERIOD,
                 SecurityAnalyticsSettings.IOC_MAX_INDICES_PER_INDEX_PATTERN,
                 SecurityAnalyticsSettings.IOC_SCAN_MAX_TERMS_COUNT,
-                SecurityAnalyticsSettings.ENABLE_DETECTORS_WITH_DEDICATED_QUERY_INDICES
+                SecurityAnalyticsSettings.ENABLE_DETECTORS_WITH_DEDICATED_QUERY_INDICES,
+                SecurityAnalyticsSettings.AUTO_EXPAND_SYSTEM_INDEX_REPLICAS,
+                SecurityAnalyticsSettings.MIN_SYSTEM_INDEX_REPLICAS,
+                SecurityAnalyticsSettings.MAX_SYSTEM_INDEX_REPLICAS
         );
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/indexmanagment/DetectorIndexManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/indexmanagment/DetectorIndexManagementService.java
@@ -562,12 +562,12 @@ public class DetectorIndexManagementService extends AbstractLifecycleComponent i
                                 .put("index.hidden", true)
                                 .put("index.correlation", true)
                                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                                .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                                .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                                 .build():
                         Settings.builder()
                                 .put("index.hidden", true)
                                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                                .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                                .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                                 .build()
                 );
         request.addMaxIndexDocsCondition(docsCondition);

--- a/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
+++ b/src/main/java/org/opensearch/securityanalytics/logtype/LogTypeService.java
@@ -62,8 +62,7 @@ import org.opensearch.transport.client.Client;
 
 import static org.opensearch.securityanalytics.model.FieldMappingDoc.LOG_TYPES;
 import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.DEFAULT_MAPPING_SCHEMA;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 
 /**
  *
@@ -457,7 +456,7 @@ public class LogTypeService {
             Settings indexSettings = Settings.builder()
                     .put("index.hidden", true)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                    .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                     .build();
 
             CreateIndexRequest createIndexRequest = new CreateIndexRequest();

--- a/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/STIX2IOCFeedStore.java
@@ -51,8 +51,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 
 public class STIX2IOCFeedStore implements FeedStore {
     public static final String IOC_INDEX_NAME_BASE = ".opensearch-sap-iocs";
@@ -242,7 +241,7 @@ public class STIX2IOCFeedStore implements FeedStore {
                     .settings(Settings.builder()
                             .put("index.hidden", true)
                             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                            .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                            .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                             .build()
                     );
             client.admin().indices().create(indexRequest, ActionListener.wrap(

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.securityanalytics.settings;
 
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
 
@@ -14,6 +15,34 @@ public class SecurityAnalyticsSettings {
     public static final String CORRELATION_INDEX = "index.correlation";
     public static final int minSystemIndexReplicas = 0;
     public static final int maxSystemIndexReplicas = 20;
+
+    public static final Setting<Boolean> AUTO_EXPAND_SYSTEM_INDEX_REPLICAS = Setting.boolSetting(
+            "plugins.security_analytics.auto_expand_system_index_replicas",
+            true,
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+    );
+
+    public static final Setting<Integer> MIN_SYSTEM_INDEX_REPLICAS = Setting.intSetting(
+            "plugins.security_analytics.min_system_index_replicas",
+            0,
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+    );
+
+    public static final Setting<Integer> MAX_SYSTEM_INDEX_REPLICAS = Setting.intSetting(
+            "plugins.security_analytics.max_system_index_replicas",
+            20,
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+    );
+
+    public static String getSystemIndexAutoExpandReplicas(ClusterService clusterService) {
+        if (clusterService.getClusterSettings().get(AUTO_EXPAND_SYSTEM_INDEX_REPLICAS) == true) {
+            int min = clusterService.getClusterSettings().get(MIN_SYSTEM_INDEX_REPLICAS);
+            int max = clusterService.getClusterSettings().get(MAX_SYSTEM_INDEX_REPLICAS);
+            return min + "-" + max;
+        } else {
+            return "false";
+        }
+    }
 
     public static Setting<TimeValue> INDEX_TIMEOUT = Setting.positiveTimeSetting("plugins.security_analytics.index_timeout",
             TimeValue.timeValueSeconds(60),
@@ -221,7 +250,7 @@ public class SecurityAnalyticsSettings {
      * @return a list of all settings for threat intel feature
      */
     public static final List<Setting<?>> settings() {
-        return List.of(BATCH_SIZE, THREAT_INTEL_TIMEOUT, TIF_UPDATE_INTERVAL);
+        return List.of(BATCH_SIZE, THREAT_INTEL_TIMEOUT, TIF_UPDATE_INTERVAL, AUTO_EXPAND_SYSTEM_INDEX_REPLICAS, MIN_SYSTEM_INDEX_REPLICAS, MAX_SYSTEM_INDEX_REPLICAS);
     }
 
     // Threat Intel IOC Settings

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/BaseEntityCrudService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/BaseEntityCrudService.java
@@ -32,8 +32,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import static org.opensearch.securityanalytics.util.DetectorUtils.getEmptySearchResponse;
 
 /**
@@ -257,7 +256,7 @@ public abstract class BaseEntityCrudService<Entity extends BaseEntity> {
     protected Settings.Builder getIndexSettings() {
         return Settings.builder().put("index.hidden", true)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas);
+                .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService));
     }
 
     public abstract String getEntityAliasName();

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigService.java
@@ -28,6 +28,8 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.Preference;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
@@ -205,8 +207,13 @@ public class SATIFSourceConfigService {
         if (clusterService.state().metadata().hasIndex(SecurityAnalyticsPlugin.JOB_INDEX_NAME) == true) {
             checkAndUpdateJobIndexMapping(stepListener);
         } else {
+            Settings tifJobIndexSettings = Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
+                    .put("index.hidden", true)
+                    .build();
             final CreateIndexRequest createIndexRequest = new CreateIndexRequest(SecurityAnalyticsPlugin.JOB_INDEX_NAME).mapping(getIndexMapping())
-                    .settings(SecurityAnalyticsPlugin.TIF_JOB_INDEX_SETTING);
+                    .settings(tifJobIndexSettings);
             client.admin().indices().create(createIndexRequest, ActionListener.wrap(
                     r -> {
                         log.debug("[{}] index created", SecurityAnalyticsPlugin.JOB_INDEX_NAME);

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/TIFJobParameterService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/TIFJobParameterService.java
@@ -17,8 +17,11 @@ import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
@@ -67,8 +70,13 @@ public class TIFJobParameterService {
             stepListener.onResponse(null);
             return;
         }
+        Settings tifJobIndexSettings = Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
+                .put("index.hidden", true)
+                .build();
         final CreateIndexRequest createIndexRequest = new CreateIndexRequest(SecurityAnalyticsPlugin.JOB_INDEX_NAME).mapping(getIndexMapping())
-                .settings(SecurityAnalyticsPlugin.TIF_JOB_INDEX_SETTING);
+                .settings(tifJobIndexSettings);
         StashedThreadContext.run(client, () -> client.admin().indices().create(createIndexRequest, new ActionListener<>() {
             @Override
             public void onResponse(final CreateIndexResponse createIndexResponse) {

--- a/src/main/java/org/opensearch/securityanalytics/util/CorrelationIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/CorrelationIndices.java
@@ -27,8 +27,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Objects;
 
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 
 public class CorrelationIndices {
 
@@ -63,7 +62,7 @@ public class CorrelationIndices {
                     .put("index.hidden", true)
                     .put("index.correlation", true)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                    .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                     .build();
             CreateIndexRequest indexRequest = new CreateIndexRequest(CORRELATION_HISTORY_INDEX_PATTERN)
                     .mapping(correlationMappings())
@@ -81,7 +80,7 @@ public class CorrelationIndices {
                     .put("index.hidden", true)
                     .put("index.correlation", true)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                    .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                     .build();
             CreateIndexRequest indexRequest = new CreateIndexRequest(CORRELATION_METADATA_INDEX)
                     .mapping(correlationMappings())
@@ -153,7 +152,7 @@ public class CorrelationIndices {
         Settings correlationAlertSettings = Settings.builder()
                 .put("index.hidden", true)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                 .build();
         CreateIndexRequest indexRequest = new CreateIndexRequest(CORRELATION_ALERT_INDEX)
                 .mapping(correlationAlertIndexMappings())

--- a/src/main/java/org/opensearch/securityanalytics/util/CorrelationRuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/CorrelationRuleIndices.java
@@ -24,8 +24,7 @@ import java.nio.charset.Charset;
 import java.util.Objects;
 import org.opensearch.securityanalytics.model.CorrelationRule;
 
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 
 public class CorrelationRuleIndices {
     private static final Logger log = LogManager.getLogger(CorrelationRuleIndices.class);
@@ -52,7 +51,7 @@ public class CorrelationRuleIndices {
             Settings indexSettings = Settings.builder()
                     .put("index.hidden", true)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                    .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                     .build();
             CreateIndexRequest indexRequest = new CreateIndexRequest(CorrelationRule.CORRELATION_RULE_INDEX).mapping(
                 correlationRuleIndexMappings()

--- a/src/main/java/org/opensearch/securityanalytics/util/CustomLogTypeIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/CustomLogTypeIndices.java
@@ -21,8 +21,7 @@ import org.opensearch.transport.client.AdminClient;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Objects;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 
 public class CustomLogTypeIndices {
 
@@ -48,7 +47,7 @@ public class CustomLogTypeIndices {
             Settings indexSettings = Settings.builder()
                     .put("index.hidden", true)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                    .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                     .build();
             CreateIndexRequest indexRequest = new CreateIndexRequest(LogTypeService.LOG_TYPE_INDEX)
                     .mapping(customLogTypeMappings())

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorIndices.java
@@ -23,8 +23,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Objects;
 
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
 
 public class DetectorIndices {
 
@@ -51,7 +50,7 @@ public class DetectorIndices {
             Settings indexSettings = Settings.builder()
                     .put("index.hidden", true)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                    .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                     .build();
             CreateIndexRequest indexRequest = new CreateIndexRequest(Detector.DETECTORS_INDEX)
                     .mapping(detectorMappings())

--- a/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
@@ -60,9 +60,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
+
 import static org.opensearch.securityanalytics.model.Detector.NO_VERSION;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.maxSystemIndexReplicas;
-import static org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings.minSystemIndexReplicas;
 
 public class RuleIndices {
 
@@ -92,7 +92,7 @@ public class RuleIndices {
             Settings indexSettings = Settings.builder()
                     .put("index.hidden", true)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put("index.auto_expand_replicas", minSystemIndexReplicas + "-" + maxSystemIndexReplicas)
+                    .put("index.auto_expand_replicas", SecurityAnalyticsSettings.getSystemIndexAutoExpandReplicas(clusterService))
                     .build();
             CreateIndexRequest indexRequest = new CreateIndexRequest(getRuleIndex(isPrepackaged))
                     .mapping(ruleMappings())

--- a/src/test/java/org/opensearch/securityanalytics/threatIntel/jobscheduler/TIFJobParameterServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/threatIntel/jobscheduler/TIFJobParameterServiceTests.java
@@ -65,7 +65,7 @@ import static org.mockito.Mockito.when;
             CreateIndexRequest request = (CreateIndexRequest) actionRequest;
             assertEquals(SecurityAnalyticsPlugin.JOB_INDEX_NAME, request.index());
             assertEquals("1", request.settings().get("index.number_of_shards"));
-            assertEquals("0-all", request.settings().get("index.auto_expand_replicas"));
+            assertEquals("0-20", request.settings().get("index.auto_expand_replicas"));
             assertEquals("true", request.settings().get("index.hidden"));
             assertNotNull(request.mappings());
             return null;


### PR DESCRIPTION
### Description
This PR makes the replica configuration of system indices created by the Security Analytics plugin configurable. 

System indices created by the Security Analytics plugin have had hardcoded 'index.auto_expand_replicas' values (such as '0-20' or '0-all'). In large production clusters, this causes indices to replicate across many or all nodes, consuming excessive cluster resources (disk space and JVM heap), while overriding matching index templates configured by administrators.

This commit replaces the hardcoded replica settings with three new dynamic cluster settings:
- `plugins.security_analytics.auto_expand_system_index_replicas` (defaults to true)
- `plugins.security_analytics.min_system_index_replicas` (defaults to 0)
- `plugins.security_analytics.max_system_index_replicas` (defaults to 20)

By setting `auto_expand_system_index_replicas` to false, administrators can disable programmatic auto-expansion on index creation and allow custom index templates (such as those overriding `number_of_replicas` or `auto_expand_replicas`) to be fully respected.

### Related Issues
Resolves # [Issue number to be closed when this PR is merged]

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).