### PR TITLE
Add ci.opensearch.org/m2/ mirror to buildscript and project repos (security-analytics)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     }
@@ -182,6 +183,7 @@ publishing {
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/m2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }


### PR DESCRIPTION
### Description
Add ci.opensearch.org/m2/ mirror to buildscript and project repos (security-analytics)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803