### PR TITLE
fix: Prevent findings history deletion by alert retention period

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/indexmanagment/DetectorIndexManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/indexmanagment/DetectorIndexManagementService.java
@@ -384,7 +384,8 @@ public class DetectorIndexManagementService extends AbstractLifecycleComponent i
         return indicesToDelete;
     }
 
-    private String getHistoryIndexToDelete(
+    // Package-private and static for testability; does not use instance state.
+    static String getHistoryIndexToDelete(
             IndexMetadata indexMetadata,
             Long retentionPeriodMillis,
             List<HistoryIndexInfo> historyIndices,
@@ -408,8 +409,11 @@ public class DetectorIndexManagementService extends AbstractLifecycleComponent i
                     // If the index has the write alias and history is enabled, don't delete the index
                     return null;
                 }
+                // Index belongs to this history type but history is disabled — delete it
+                return indexMetadata.getIndex().getName();
             }
-            return indexMetadata.getIndex().getName();
+            // Index does not belong to this history type — do not delete
+            return null;
         }
         return null;
     }

--- a/src/test/java/org/opensearch/securityanalytics/indexmanagment/DetectorIndexManagementServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/indexmanagment/DetectorIndexManagementServiceTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.securityanalytics.indexmanagment;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.AliasMetadata;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.lang.reflect.Constructor;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit tests for {@link DetectorIndexManagementService#getHistoryIndexToDelete}.
+ * Validates that indices are only deleted when they belong to the
+ * history type being checked (i.e., have a matching alias).
+ *
+ * Regression tests for https://github.com/opensearch-project/security-analytics/issues/1759
+ */
+public class DetectorIndexManagementServiceTests extends OpenSearchTestCase {
+
+    /**
+     * Verifies that a findings index is NOT deleted when checked against
+     * alert retention, even when the findings index is older than the
+     * alert retention period.
+     *
+     * This is the core regression test for issue #1759.
+     */
+    public void testFindingsIndexNotDeletedByAlertRetention() throws Exception {
+        // Simulate a findings index that is 3 days old
+        long threeDaysAgo = Instant.now().toEpochMilli() - (3 * 24 * 60 * 60 * 1000L);
+
+        // Alert retention is 2 days (findings index IS older than this)
+        long alertRetentionMillis = 2 * 24 * 60 * 60 * 1000L;
+
+        // Create an IndexMetadata with a findings alias (not an alert alias)
+        String findingsAlias = ".opensearch-sap-findings-history-windows";
+        IndexMetadata indexMetadata = createIndexMetadata(
+                ".opensearch-sap-findings-history-windows-000001",
+                threeDaysAgo,
+                findingsAlias
+        );
+
+        // Alert history indices have a DIFFERENT alias pattern
+        String alertAlias = ".opensearch-sap-alerts-history-windows";
+        List historyIndices = createHistoryIndexInfoList(alertAlias);
+
+        // Call getHistoryIndexToDelete with alert retention and alert history indices
+        String result = DetectorIndexManagementService.getHistoryIndexToDelete(
+                indexMetadata, alertRetentionMillis, historyIndices, true
+        );
+
+        // The findings index should NOT be deleted by alert retention check
+        assertNull("Findings index should not be deleted when checked against alert retention", result);
+    }
+
+    /**
+     * Verifies that a findings index IS deleted when it exceeds the finding
+     * retention period and is checked against the correct (findings) history type
+     * with history disabled (simulating the write alias moved to newer index).
+     */
+    public void testFindingsIndexDeletedByFindingRetentionWhenExpired() throws Exception {
+        // Simulate a findings index that is 5 days old
+        long fiveDaysAgo = Instant.now().toEpochMilli() - (5 * 24 * 60 * 60 * 1000L);
+
+        // Finding retention is 4 days (findings index IS older than this)
+        long findingRetentionMillis = 4 * 24 * 60 * 60 * 1000L;
+
+        // Create an IndexMetadata with a findings alias
+        String findingsAlias = ".opensearch-sap-findings-history-windows";
+        IndexMetadata indexMetadata = createIndexMetadata(
+                ".opensearch-sap-findings-history-windows-000001",
+                fiveDaysAgo,
+                findingsAlias
+        );
+
+        // Finding history indices with the MATCHING alias
+        List historyIndices = createHistoryIndexInfoList(findingsAlias);
+
+        // historyEnabled=false: the index no longer holds the write alias (rolled over)
+        String result = DetectorIndexManagementService.getHistoryIndexToDelete(
+                indexMetadata, findingRetentionMillis, historyIndices, false
+        );
+
+        assertNotNull("Findings index should be deleted when it exceeds finding retention", result);
+        assertEquals(".opensearch-sap-findings-history-windows-000001", result);
+    }
+
+    /**
+     * Verifies that a findings index is NOT deleted when it has not yet
+     * exceeded the finding retention period.
+     */
+    public void testFindingsIndexNotDeletedWhenYoungerThanRetention() throws Exception {
+        // Simulate a findings index that is 3 days old
+        long threeDaysAgo = Instant.now().toEpochMilli() - (3 * 24 * 60 * 60 * 1000L);
+
+        // Finding retention is 4 days (findings index is NOT older than this)
+        long findingRetentionMillis = 4 * 24 * 60 * 60 * 1000L;
+
+        String findingsAlias = ".opensearch-sap-findings-history-windows";
+        IndexMetadata indexMetadata = createIndexMetadata(
+                ".opensearch-sap-findings-history-windows-000001",
+                threeDaysAgo,
+                findingsAlias
+        );
+
+        List historyIndices = createHistoryIndexInfoList(findingsAlias);
+
+        String result = DetectorIndexManagementService.getHistoryIndexToDelete(
+                indexMetadata, findingRetentionMillis, historyIndices, true
+        );
+
+        assertNull("Findings index should not be deleted when younger than retention period", result);
+    }
+
+    // --- Helpers ---
+
+    private IndexMetadata createIndexMetadata(String indexName, long creationDate, String alias) {
+        return IndexMetadata.builder(indexName)
+                .settings(Settings.builder()
+                        .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put(IndexMetadata.SETTING_CREATION_DATE, creationDate)
+                        .build())
+                .putAlias(AliasMetadata.builder(alias).build())
+                .build();
+    }
+
+    /**
+     * Creates a list containing a single HistoryIndexInfo with the given alias.
+     * Uses reflection since HistoryIndexInfo is a private static inner class.
+     */
+    @SuppressWarnings("unchecked")
+    private List createHistoryIndexInfoList(String alias) throws Exception {
+        Class<?> historyIndexInfoClass = Class.forName(
+                "org.opensearch.securityanalytics.indexmanagment.DetectorIndexManagementService$HistoryIndexInfo"
+        );
+        Constructor<?> constructor = historyIndexInfoClass.getDeclaredConstructors()[0];
+        constructor.setAccessible(true);
+        // HistoryIndexInfo(String indexAlias, String indexPattern, String indexMappings, Long maxDocs, TimeValue maxAge, boolean isInitialized)
+        Object info = constructor.newInstance(alias, alias + "-*", "{}", 1000L, TimeValue.timeValueDays(30), true);
+        List list = new ArrayList<>();
+        list.add(info);
+        return list;
+    }
+}


### PR DESCRIPTION
The getHistoryIndexToDelete method incorrectly returned the index name for deletion when the index had no matching alias in the history type being checked. A findings index with no alert-history alias would be deleted after exceeding alert_history_retention_period instead of finding_history_retention_period.

Fix: return null (do not delete) when an index does not belong to the history type being evaluated (alias == null). Only delete when the index positively matches the history type's alias AND exceeds that type's retention period.

Also makes getHistoryIndexToDelete package-private static for testability and adds unit tests covering:
- Findings index not deleted by alert retention check
- Findings index deleted when exceeding finding retention
- Findings index not deleted when younger than retention

Resolves opensearch-project/security-analytics#1759

### Description
  Fixes the getHistoryIndexToDelete method in DetectorIndexManagementService which incorrectly deleted findings indices based on alert_history_retention_period instead of finding_history_retention_period.
  
  Root cause: The method is called once per history type (alert, finding, correlation, IOC) for each index. When an index had no matching alias for the history type being checked (e.g., a findings index checked against alert history aliases), the method fell through and returned the index for deletion. It should have returned null (skip — this index doesn't belong to me).
  
  Fix: Return null when no alias match is found, meaning the index doesn't belong to this history type. Only return the index name for deletion when it positively matches the type's alias AND exceeds that type's retention period.
  
  Also makes getHistoryIndexToDelete package-private static (uses no instance state) and adds 3 unit tests.

### Related Issues
Resolves #1759


### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
