### PR TITLE
fix: Prevent NPE in OSQueryBackend when fieldMappings is null

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/backend/OSQueryBackend.java
@@ -520,7 +520,7 @@ public class OSQueryBackend extends QueryBackend {
     }
 
     private String getMappedField(String field) {
-        if (this.enableFieldMappings && this.fieldMappings.containsKey(field) && this.fieldMappings.get(field) != null) {
+        if (this.enableFieldMappings && this.fieldMappings != null && this.fieldMappings.containsKey(field) && this.fieldMappings.get(field) != null) {
             return this.fieldMappings.get(field);
         }
         return field;

--- a/src/main/java/org/opensearch/securityanalytics/rules/backend/QueryBackend.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/backend/QueryBackend.java
@@ -60,7 +60,7 @@ public abstract class QueryBackend {
         this.queryFields = new HashMap<>();
 
         if (this.enableFieldMappings) {
-            this.fieldMappings = fieldMappings;
+            this.fieldMappings = fieldMappings != null ? fieldMappings : new HashMap<>();
         } else {
             this.fieldMappings = new HashMap<>();
         }

--- a/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/backend/QueryBackendTests.java
@@ -1148,6 +1148,55 @@ public class QueryBackendTests extends OpenSearchTestCase {
         });
     }
 
+    /**
+     * Regression test for https://github.com/opensearch-project/security-analytics/issues/1750
+     * OSQueryBackend should not throw NPE when fieldMappings is null and enableFieldMappings is true.
+     * This happens when a detector uses a custom Sigma rule with an aggregation expression but
+     * the log type's field mappings are not available for that category.
+     */
+    public void testBackendWithNullFieldMappingsAndEnableFieldMappingsTrue() throws IOException, SigmaError, CompositeSigmaErrors {
+        OSQueryBackend queryBackend = new OSQueryBackend(null, false, true);
+        List<Object> queries = queryBackend.convertRule(SigmaRule.fromYaml(
+                "            title: Test\n" +
+                        "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
+                        "            status: test\n" +
+                        "            level: critical\n" +
+                        "            description: Test null field mappings\n" +
+                        "            author: Test\n" +
+                        "            date: 2024/01/01\n" +
+                        "            logsource:\n" +
+                        "                category: test_category\n" +
+                        "                product: test_product\n" +
+                        "            detection:\n" +
+                        "                sel:\n" +
+                        "                    fieldA: valueA\n" +
+                        "                condition: sel", false));
+        // Fields should pass through unmapped when fieldMappings is null/empty
+        Assert.assertEquals("fieldA: \"valueA\"", queries.get(0).toString());
+    }
+
+    public void testBackendAggregationWithNullFieldMappings() throws IOException, SigmaError, CompositeSigmaErrors {
+        OSQueryBackend queryBackend = new OSQueryBackend(null, false, true);
+        List<Object> queries = queryBackend.convertRule(SigmaRule.fromYaml(
+                "            title: Test Aggregation\n" +
+                        "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2c\n" +
+                        "            status: test\n" +
+                        "            level: critical\n" +
+                        "            description: Test aggregation with null mappings\n" +
+                        "            author: Test\n" +
+                        "            date: 2024/01/01\n" +
+                        "            logsource:\n" +
+                        "                category: test_category\n" +
+                        "                product: test_product\n" +
+                        "            detection:\n" +
+                        "                sel:\n" +
+                        "                    fieldA: valueA\n" +
+                        "                condition: sel | count(fieldA) by fieldA > 10", false));
+        // Should not throw NPE — aggregation queries should work with null mappings
+        Assert.assertNotNull(queries);
+        Assert.assertTrue(queries.size() > 0);
+    }
+
     private OSQueryBackend testBackend() throws IOException {
         return new OSQueryBackend(testFieldMapping, false, true);
     }


### PR DESCRIPTION
When creating a detector for a Sigma rule with an aggregation expression, ruleFieldMappings.get(category) can return null if the log type has no field mappings defined. This null was passed directly to the OSQueryBackend constructor, which stored it as-is when enableFieldMappings=true. Subsequent calls to getMappedField() then threw NullPointerException on this.fieldMappings.containsKey(field).

Fix: Initialize fieldMappings to an empty HashMap when the provided map is null (in QueryBackend constructor). Also adds a null guard in getMappedField() as defense-in-depth.

When fieldMappings is empty/null, fields pass through unmapped — the aggregation query uses the original Sigma field names, which is the correct degraded behavior.

Resolves opensearch-project/security-analytics#1750

### Description
When creating a detector for a Sigma rule with an aggregation expression (e.g., count(field) > N), ruleFieldMappings.get(category) returns null if the log type has no field mappings defined. This null was passed to OSQueryBackend, causing a NullPointerException at this.fieldMappings.containsKey(field) in getMappedField().

Fix: Initialize fieldMappings to an empty HashMap when the provided map is null (in QueryBackend constructor). Also adds a null guard in getMappedField() as defense-in-depth. When mappings are unavailable, fields pass through unmapped — the correct degraded behavior.

### Related Issues
Resolves #1750

### Testing

- Added testBackendWithNullFieldMappingsAndEnableFieldMappingsTrue — verifies rules convert without NPE
- Added testBackendAggregationWithNullFieldMappings — verifies aggregation rules work with null mappings
- Full QueryBackendTests suite (51 tests) passes

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
