### PR TITLE
Fix detector creation with aliases and data streams

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/MapperService.java
@@ -14,6 +14,7 @@ import org.opensearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.opensearch.action.support.GroupedActionListener;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MappingMetadata;
@@ -86,7 +87,7 @@ public class MapperService {
             }
         }
 
-        GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(index);
+        GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(index).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
         indicesClient.getMappings(getMappingsRequest, new ActionListener<>() {
             @Override
             public void onResponse(GetMappingsResponse getMappingsResponse) {
@@ -383,12 +384,16 @@ public class MapperService {
     }
 
     public void doGetMappingAction(String indexName, String concreteIndexName, ActionListener<GetIndexMappingsResponse> actionListener) {
-        GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(concreteIndexName);
+        GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(concreteIndexName).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
         indicesClient.getMappings(getMappingsRequest, new ActionListener<>() {
             @Override
             public void onResponse(GetMappingsResponse getMappingsResponse) {
                 logTypeService.getRequiredFieldsForAllLogTypes(ActionListener.wrap(requiredFieldMap -> {
                     try {
+                        if (getMappingsResponse.mappings().isEmpty()) {
+                            actionListener.onResponse(new GetIndexMappingsResponse(Map.of()));
+                            return;
+                        }
                         // Extract MappingMetadata
                         MappingMetadata mappingMetadata = getMappingsResponse.mappings().entrySet().iterator().next().getValue();
                         // List of all found applied aliases on index
@@ -466,12 +471,16 @@ public class MapperService {
      * @param concreteIndex  Concrete Index name for which we're computing Mappings View
      */
     private void doGetMappingsView(String logType, ActionListener<GetMappingsViewResponse> actionListener, String concreteIndex) {
-        GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(concreteIndex);
+        GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(concreteIndex).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
         indicesClient.getMappings(getMappingsRequest, new ActionListener<>() {
             @Override
             public void onResponse(GetMappingsResponse getMappingsResponse) {
                 logTypeService.getRequiredFields(logType, ActionListener.wrap(requiredFields -> {
                     try {
+                        if (getMappingsResponse.mappings().isEmpty()) {
+                            actionListener.onResponse(new GetMappingsViewResponse(Map.of(), List.of(), List.of(), logTypeService.getIocFieldsList(logType)));
+                            return;
+                        }
                         // Extract MappingMetadata from GET _mapping response
                         MappingMetadata mappingMetadata = getMappingsResponse.mappings().entrySet().iterator().next().getValue();
                         // Get list of all non-alias fields in index
@@ -592,16 +601,15 @@ public class MapperService {
      */
     private void resolveConcreteIndex(String indexName, ActionListener<String> actionListener) throws IOException {
 
-        indicesClient.getIndex((new GetIndexRequest()).indices(indexName), new ActionListener<>() {
+        indicesClient.getIndex(
+                (new GetIndexRequest()).indices(indexName).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN),
+                new ActionListener<>() {
             @Override
             public void onResponse(GetIndexResponse getIndexResponse) {
                 String[] indices = getIndexResponse.indices();
                 if (indices.length == 0) {
-                    actionListener.onFailure(
-                            SecurityAnalyticsException.wrap(
-                                    new IllegalArgumentException("Invalid index name: [" + indexName + "]")
-                            )
-                    );
+                    // Pattern has no backing indices yet — pass the name through as-is
+                    actionListener.onResponse(indexName);
                 } else if (indices.length == 1) {
                     actionListener.onResponse(indices[0]);
                 } else if (indices.length > 1) {

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -19,6 +19,7 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.HandledTransportAction;
@@ -54,12 +55,13 @@ import org.opensearch.commons.alerting.model.Workflow;
 import org.opensearch.commons.alerting.model.action.Action;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -236,7 +238,8 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
         log.debug("check indices and execute began");
         String [] detectorIndices = request.getDetector().getInputs().stream().flatMap(detectorInput -> detectorInput.getIndices().stream()).toArray(String[]::new);
         SearchRequest searchRequest =  new SearchRequest(detectorIndices)
-                .source(SearchSourceBuilder.searchSource().size(1).query(QueryBuilders.matchAllQuery()));
+                .source(SearchSourceBuilder.searchSource().size(1).query(QueryBuilders.matchAllQuery()))
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
         searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30));
         client.search(searchRequest, new ActionListener<>() {
             @Override
@@ -253,12 +256,7 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                     listener.onFailure(SecurityAnalyticsException.wrap(
                             new OpenSearchStatusException(String.format(Locale.getDefault(), "User doesn't have read permissions for one or more configured index %s", (Object) detectorIndices), RestStatus.FORBIDDEN)
                     ));
-                } else if (e instanceof IndexNotFoundException) {
-                    listener.onFailure(SecurityAnalyticsException.wrap(
-                        new OpenSearchStatusException(String.format(Locale.getDefault(), "Indices not found %s", String.join(", ", detectorIndices)), RestStatus.NOT_FOUND)
-                    ));
-                }
-                else {
+                } else {
                     listener.onFailure(SecurityAnalyticsException.wrap(e));
                 }
             }
@@ -1013,11 +1011,12 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                     .query(QueryBuilders.queryStringQuery(rule.getQueries().get(0).getValue()))
                     .aggregation(aggregationQueries.getAggBuilder());
             // input index can also be an index pattern or alias so we have to resolve it to concrete index
-            String concreteIndex = IndexUtils.getNewIndexByCreationDate(
+            String resolvedIndex = IndexUtils.getNewIndexByCreationDate(
                     clusterService.state(),
                     indexNameExpressionResolver,
                     indices.get(0) // taking first one is fine because we expect that all indices in list share same mappings
             );
+            final String concreteIndex = resolvedIndex != null ? resolvedIndex : indices.get(0);
             client.execute(
                     GetIndexMappingsAction.INSTANCE,
                     new GetIndexMappingsRequest(concreteIndex),
@@ -1198,7 +1197,16 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
 
                                     @Override
                                     public void onFailure(Exception e) {
-                                        onFailures(e);
+                                        if (ExceptionsHelper.unwrapCause(e) instanceof ResourceAlreadyExistsException) {
+                                            // Another concurrent detector create already created the index — proceed
+                                            try {
+                                                prepareDetectorIndexing();
+                                            } catch (Exception ex) {
+                                                onFailures(ex);
+                                            }
+                                        } else {
+                                            onFailures(e);
+                                        }
                                     }
                                 });
                             } else if (!IndexUtils.detectorIndexUpdated) {
@@ -1619,13 +1627,20 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                 List<String> queryFieldNames = query.getValue().getQueryFieldNames().stream().map(Value::getValue).collect(Collectors.toList());
                 ruleFieldNames.addAll(queryFieldNames);
             }
-            client.execute(GetIndexMappingsAction.INSTANCE, new GetIndexMappingsRequest(logIndex), new ActionListener<>() {
+            // input index can also be an index pattern or alias so resolve it to a concrete index first
+            String resolvedLogIndex = IndexUtils.getNewIndexByCreationDate(
+                    clusterService.state(),
+                    indexNameExpressionResolver,
+                    logIndex
+            );
+            final String concreteLogIndex = resolvedLogIndex != null ? resolvedLogIndex : logIndex;
+            client.execute(GetIndexMappingsAction.INSTANCE, new GetIndexMappingsRequest(concreteLogIndex), new ActionListener<>() {
                 @Override
                 public void onResponse(GetIndexMappingsResponse getMappingsViewResponse) {
                     try {
                         List<Pair<String, String>> aliasPathPairs;
 
-                        aliasPathPairs = MapperUtils.getAllAliasPathPairs(getMappingsViewResponse.getMappings().get(logIndex));
+                        aliasPathPairs = MapperUtils.getAllAliasPathPairs(getMappingsViewResponse.getMappings().get(concreteLogIndex));
                         for (Pair<String, String> aliasPathPair : aliasPathPairs) {
                             if (ruleFieldNames.contains(aliasPathPair.getLeft())) {
                                 ruleFieldNames.remove(aliasPathPair.getLeft());


### PR DESCRIPTION
### Description

Fixes several bugs that prevented detector creation when the configured index is an index pattern, alias, or data stream

Six root causes addressed:
1. GetIndexMappingsRequest null index (TransportIndexDetectorAction): IndexUtils.getNewIndexByCreationDate() returns null when no concrete index matches the pattern. The null was passed directly to GetIndexMappingsRequest, triggering Validation Failed: 1: index_name is missing. Fix: resolve pattern to concrete index first; fall back to the original name when resolution returns null.
2. Strict index existence check (TransportIndexDetectorAction): The pre-creation SearchRequest used default strict IndicesOptions, producing Indices not found <pattern> for patterns with no current backing indices. Fix: use IndicesOptions.LENIENT_EXPAND_OPEN.
3. GetMappingsRequest strict resolution (MapperService): Three GetMappingsRequest calls used default options, causing OpenSearch to search for a template named <pattern>-template when the pattern had no backing index, producing a misleading 404. Fix: add LENIENT_EXPAND_OPEN to all three calls.
4. GetIndexRequest strict resolution (MapperService): resolveConcreteIndex() used a strict GetIndexRequest, failing with no such index for patterns with no current backing index. Fix: use LENIENT_EXPAND_OPEN; return the original name on empty result.
5. NoSuchElementException on empty mappings (MapperService): doGetMappingAction and doGetMappingsView called .iterator().next() on the mappings map without an emptiness check. A data stream with no mappings returned an empty map, causing an uncaught exception. Fix: guard both call sites; return an empty response instead.
6. Race condition on concurrent detector creation (TransportIndexDetectorAction): When multiple detectors are created in parallel, all requests read cluster state simultaneously, see the detectors index absent, and all issue CreateIndexRequest. The first succeeds; the remaining requests received ResourceAlreadyExistsException and failed fatally. Fix: catch ResourceAlreadyExistsException in the onFailure handler of initDetectorIndex and treat it as success.

### Related Issues
None

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.