### PR TITLE
fix: guard against null and immutable map returns in RuleIndices and CustomLogType

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/model/CustomLogType.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/CustomLogType.java
@@ -17,6 +17,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -93,8 +94,12 @@ public class CustomLogType implements Writeable, ToXContentObject {
                 sin.readString(),
                 sin.readString(),
                 sin.readString(),
-                sin.readMap()
+                toMutableMap(sin.readMap())
         );
+    }
+
+    private static Map<String, Object> toMutableMap(Map<String, Object> map) {
+        return map != null ? new HashMap<>(map) : null;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
@@ -288,6 +288,9 @@ public class RuleIndices {
         }
         for (String category: categories) {
             Map<String, String> fieldMappings = logTypeService.getRuleFieldMappingsForBuiltinLogType(category);
+            if (fieldMappings == null) {
+                fieldMappings = new HashMap<>();
+            }
             final QueryBackend backend = new OSQueryBackend(fieldMappings, true, true);
             queries.addAll(getQueries(backend, category, logIndexToRules.get(category)));
         }


### PR DESCRIPTION
## Summary

fixes #1796 
Two defensive guards for null/immutable map returns found during a code audit.
These are independent bugs; no upstream issue existed prior to this PR.

---

### Finding 1 — NPE in `RuleIndices.ingestQueries()` (HIGH)

**File:** `src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java`, line 290

`LogTypeService.getRuleFieldMappingsForBuiltinLogType()` returns `null` when the
log type is not registered in `builtinLogTypeLoader`. That null is passed directly
into `OSQueryBackend`'s constructor, which stores it as `this.fieldMappings`
when `enableFieldMappings=true`. `getMappedField()` then calls
`this.fieldMappings.containsKey(field)` unconditionally, causing a
`NullPointerException` during pre-packaged rule ingestion at startup for any
unrecognized rule category.

**Before:**
```java
Map<String, String> fieldMappings = logTypeService.getRuleFieldMappingsForBuiltinLogType(category);
final QueryBackend backend = new OSQueryBackend(fieldMappings, true, true);
```

**After:**

```java
Map<String, String> fieldMappings = logTypeService.getRuleFieldMappingsForBuiltinLogType(category);
if (fieldMappings == null) {
    fieldMappings = new HashMap<>();
}
final QueryBackend backend = new OSQueryBackend(fieldMappings, true, true);
```

---

### Finding 2 — UnsupportedOperationException in `CustomLogType(StreamInput)` (MEDIUM)

**File:** `src/main/java/org/opensearch/securityanalytics/model/CustomLogType.java`, line 96

`StreamInput.readMap()` returns `Collections.emptyMap()` (Java's immutable singleton)
when the serialized map has zero entries. `CustomLogType` stores this value directly
as `this.tags`. Any subsequent call to `getTags().put(...)` throws
`UnsupportedOperationException`.

**Before:**

```java
public CustomLogType(StreamInput sin) throws IOException {
    this(
            sin.readString(),
            sin.readLong(),
            sin.readString(),
            sin.readString(),
            sin.readString(),
            sin.readString(),
            sin.readMap()
    );
}
```

**After:**

```java
public CustomLogType(StreamInput sin) throws IOException {
    this(
            sin.readString(),
            sin.readLong(),
            sin.readString(),
            sin.readString(),
            sin.readString(),
            sin.readString(),
            toMutableMap(sin.readMap())
    );
}

private static Map<String, Object> toMutableMap(Map<String, Object> map) {
    return map != null ? new HashMap<>(map) : null;
}
```

---

### Finding 3 — Reviewed, no action (LOW / informational)

`LogTypeService.java` lines 656 and 791 return `Map.of()` for empty field-mapping
responses. All call sites are read-only (`.containsKey()`, `.get()`). No fix required.

---

### Testing

- Existing unit and integration tests pass.
- `TransportIndexDetectorAction.java` is not modified in this PR.