### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add License Header
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,38 @@
+{
+  "**/*.*": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".xml",
+    ".csv",
+    ".g4",
+    ".config",
+    ".png",
+    ".jar",
+    ".gz",
+    ".lock",
+    ".toml",
+    ".ini",
+    ".bat",
+    ".policy",
+    ".properties",
+    ".git",
+    ".gitignore",
+    ".whitesource",
+    ".gradle",
+    "gradle/wrapper",
+    "settings.gradle",
+    "**/build/",
+    "licenses/",
+    "src/test/resources/",
+    "**/test/resources/",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionBaseListener.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionBaseListener.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition;
 

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionBaseVisitor.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionBaseVisitor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition;
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionLexer.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionLexer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition;
 import org.antlr.v4.runtime.Lexer;

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionListener.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionListener.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition;
 import org.antlr.v4.runtime.tree.ParseTreeListener;

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionParser.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionParser.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition;
 import org.antlr.v4.runtime.atn.*;

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionVisitor.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionVisitor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationBaseListener.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationBaseListener.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition.aggregation;
 

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationBaseVisitor.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationBaseVisitor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition.aggregation;
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationLexer.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationLexer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition.aggregation;
 import org.antlr.v4.runtime.Lexer;

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationListener.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationListener.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition.aggregation;
 import org.antlr.v4.runtime.tree.ParseTreeListener;

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationParser.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationParser.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition.aggregation;
 import org.antlr.v4.runtime.atn.*;

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationVisitor.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationVisitor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Generated from java-escape by ANTLR 4.11.1
 package org.opensearch.securityanalytics.rules.condition.aggregation;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;

--- a/src/main/java/org/opensearch/securityanalytics/action/DeleteCorrelationRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/DeleteCorrelationRuleAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/DeleteCorrelationRuleRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/DeleteCorrelationRuleRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/DeleteCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/DeleteCustomLogTypeAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/DeleteCustomLogTypeRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/DeleteCustomLogTypeRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/DeleteCustomLogTypeResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/DeleteCustomLogTypeResponse.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/IndexCorrelationRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/IndexCorrelationRuleAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/IndexCorrelationRuleRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/IndexCorrelationRuleRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/IndexCorrelationRuleResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/IndexCorrelationRuleResponse.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/IndexCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/IndexCustomLogTypeAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/IndexCustomLogTypeRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/IndexCustomLogTypeRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/IndexCustomLogTypeResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/IndexCustomLogTypeResponse.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/SearchCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/SearchCustomLogTypeAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/action/SearchCustomLogTypeRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/SearchCustomLogTypeRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/jobscheduler/SecurityAnalyticsRunner.java
+++ b/src/main/java/org/opensearch/securityanalytics/jobscheduler/SecurityAnalyticsRunner.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.jobscheduler;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/mapper/IndexTemplateManager.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/IndexTemplateManager.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 
 package org.opensearch.securityanalytics.mapper;

--- a/src/main/java/org/opensearch/securityanalytics/mapper/IndexTemplateUtils.java
+++ b/src/main/java/org/opensearch/securityanalytics/mapper/IndexTemplateUtils.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 
 package org.opensearch.securityanalytics.mapper;

--- a/src/main/java/org/opensearch/securityanalytics/model/CreateMappingResult.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/CreateMappingResult.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 
 package org.opensearch.securityanalytics.model;

--- a/src/main/java/org/opensearch/securityanalytics/model/threatintel/BaseEntity.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/threatintel/BaseEntity.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.model.threatintel;
 
 import org.opensearch.core.common.io.stream.StreamOutput;

--- a/src/main/java/org/opensearch/securityanalytics/model/threatintel/IocFinding.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/threatintel/IocFinding.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.model.threatintel;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/org/opensearch/securityanalytics/model/threatintel/IocWithFeeds.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/threatintel/IocWithFeeds.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.model.threatintel;
 
 import org.opensearch.core.common.io.stream.StreamInput;

--- a/src/main/java/org/opensearch/securityanalytics/model/threatintel/ThreatIntelAlert.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/threatintel/ThreatIntelAlert.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.model.threatintel;
 
 import org.opensearch.commons.alerting.model.ActionExecutionResult;

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestCreateIndexMappingsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestCreateIndexMappingsAction.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 package org.opensearch.securityanalytics.resthandler;
 

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestDeleteCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestDeleteCustomLogTypeAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestGetAlertsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestGetAlertsAction.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 package org.opensearch.securityanalytics.resthandler;
 

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestGetFindingsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestGetFindingsAction.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 package org.opensearch.securityanalytics.resthandler;
 

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestGetIndexMappingsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestGetIndexMappingsAction.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 package org.opensearch.securityanalytics.resthandler;
 

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestGetMappingsViewAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestGetMappingsViewAction.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 package org.opensearch.securityanalytics.resthandler;
 

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestIndexCorrelationRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestIndexCorrelationRuleAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestIndexCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestIndexCustomLogTypeAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestSearchCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestSearchCustomLogTypeAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/resthandler/RestUpdateIndexMappingsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/resthandler/RestUpdateIndexMappingsAction.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 package org.opensearch.securityanalytics.resthandler;
 

--- a/src/main/java/org/opensearch/securityanalytics/services/JsonPathAwareInputCodec.java
+++ b/src/main/java/org/opensearch/securityanalytics/services/JsonPathAwareInputCodec.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.services;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/DeleteThreatIntelMonitorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/DeleteThreatIntelMonitorAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor;
 
 import org.opensearch.action.ActionType;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/GetThreatIntelAlertsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/GetThreatIntelAlertsAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor;
 
 import org.opensearch.action.ActionType;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/IndexThreatIntelMonitorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/IndexThreatIntelMonitorAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor;
 
 import org.opensearch.action.ActionType;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/SearchThreatIntelMonitorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/SearchThreatIntelMonitorAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor;
 
 import org.opensearch.action.ActionType;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/UpdateThreatIntelAlertStatusAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/UpdateThreatIntelAlertStatusAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor;
 
 import org.opensearch.action.ActionType;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/request/DeleteThreatIntelMonitorRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/request/DeleteThreatIntelMonitorRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor.request;
 
 import org.opensearch.action.ActionRequest;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/request/GetThreatIntelAlertsRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/request/GetThreatIntelAlertsRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor.request;
 
 import org.opensearch.action.ActionRequest;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/request/IndexThreatIntelMonitorRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/request/IndexThreatIntelMonitorRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor.request;
 
 import org.opensearch.action.ActionRequest;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/request/SearchThreatIntelMonitorRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/request/SearchThreatIntelMonitorRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor.request;
 
 import org.opensearch.action.ActionRequest;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/request/UpdateThreatIntelAlertStatusRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/request/UpdateThreatIntelAlertStatusRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor.request;
 
 import org.opensearch.action.ActionRequest;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/response/GetThreatIntelAlertsResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/response/GetThreatIntelAlertsResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor.response;
 
 import org.opensearch.core.action.ActionResponse;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/response/IndexThreatIntelMonitorResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/response/IndexThreatIntelMonitorResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor.response;
 
 import org.opensearch.core.action.ActionResponse;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/response/UpdateThreatIntelAlertsStatusResponse.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/action/monitor/response/UpdateThreatIntelAlertsStatusResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.action.monitor.response;
 
 import org.opensearch.core.action.ActionResponse;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/BaseEntityCrudService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/BaseEntityCrudService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.iocscan.dao;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/IocFindingService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/IocFindingService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.iocscan.dao;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/ThreatIntelAlertService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dao/ThreatIntelAlertService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.iocscan.dao;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dto/IocScanContext.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dto/IocScanContext.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.iocscan.dto;
 
 import org.opensearch.commons.alerting.model.Monitor;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dto/PerIocTypeScanInputDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/dto/PerIocTypeScanInputDto.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.iocscan.dto;
 
 import org.opensearch.core.common.io.stream.StreamInput;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/IoCScanService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/IoCScanService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.iocscan.service;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/IoCScanServiceInterface.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/IoCScanServiceInterface.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.iocscan.service;
 
 import org.opensearch.securityanalytics.threatIntel.iocscan.dto.IocScanContext;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/SaIoCScanService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/SaIoCScanService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.iocscan.service;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/ThreatIntelAlertContext.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/ThreatIntelAlertContext.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.iocscan.service;
 
 import org.opensearch.commons.alerting.model.Alert;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/ThreatIntelMonitorRunner.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/iocscan/service/ThreatIntelMonitorRunner.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.iocscan.service;
 
 import org.opensearch.action.ActionType;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/CustomSchemaIocUploadSource.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/CustomSchemaIocUploadSource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.opensearch.core.common.io.stream.StreamInput;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/DefaultIocStoreConfig.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/DefaultIocStoreConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocSchema.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocSchema.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocStoreConfig.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocStoreConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocUploadSource.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/IocUploadSource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.opensearch.core.common.io.stream.StreamInput;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchema.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchema.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathSchemaField.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathSchemaField.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.opensearch.core.common.io.stream.StreamInput;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/S3Source.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/S3Source.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.opensearch.core.common.io.stream.StreamInput;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/Source.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/Source.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/UrlDownloadSource.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/UrlDownloadSource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/monitor/PerIocTypeScanInput.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/monitor/PerIocTypeScanInput.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model.monitor;
 
 import org.opensearch.core.common.io.stream.StreamInput;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/monitor/ThreatIntelInput.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/monitor/ThreatIntelInput.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model.monitor;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/monitor/ThreatIntelTrigger.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/monitor/ThreatIntelTrigger.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model.monitor;
 
 import org.opensearch.core.common.io.stream.StreamInput;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/model/monitor/TransportThreatIntelMonitorFanOutAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/model/monitor/TransportThreatIntelMonitorFanOutAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model.monitor;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/RestDeleteTIFSourceConfigAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/RestDeleteTIFSourceConfigAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.resthandler;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/RestGetTIFSourceConfigAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/RestGetTIFSourceConfigAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.resthandler;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/RestRefreshTIFSourceConfigAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/RestRefreshTIFSourceConfigAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.resthandler;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/RestSearchTIFSourceConfigsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/RestSearchTIFSourceConfigsAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.resthandler;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/monitor/RestDeleteThreatIntelMonitorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/monitor/RestDeleteThreatIntelMonitorAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.resthandler.monitor;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/monitor/RestGetThreatIntelAlertsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/monitor/RestGetThreatIntelAlertsAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.resthandler.monitor;
 
 import java.io.IOException;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/monitor/RestIndexThreatIntelMonitorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/monitor/RestIndexThreatIntelMonitorAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.resthandler.monitor;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/monitor/RestSearchThreatIntelMonitorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/monitor/RestSearchThreatIntelMonitorAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.resthandler.monitor;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/monitor/RestUpdateThreatIntelAlertsStatusAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/resthandler/monitor/RestUpdateThreatIntelAlertsStatusAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.resthandler.monitor;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/TIFSourceConfig.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/TIFSourceConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.sacommons;
 
 import org.opensearch.commons.authuser.User;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/TIFSourceConfigDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/TIFSourceConfigDto.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.sacommons;
 
 import org.opensearch.commons.authuser.User;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/TIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/TIFSourceConfigManagementService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.sacommons;
 
 import org.opensearch.core.action.ActionListener;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/IndexIocScanMonitorResponseInterface.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/IndexIocScanMonitorResponseInterface.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.sacommons.monitor;
 
 public interface IndexIocScanMonitorResponseInterface {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/IndexTIFSourceConfigRequestInterface.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/IndexTIFSourceConfigRequestInterface.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.sacommons.monitor;
 
 public interface IndexTIFSourceConfigRequestInterface {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/ThreatIntelAlertDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/ThreatIntelAlertDto.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.sacommons.monitor;
 
 import org.opensearch.commons.alerting.model.Alert;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/ThreatIntelMonitorActions.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/ThreatIntelMonitorActions.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.sacommons.monitor;
 
 public class ThreatIntelMonitorActions {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/ThreatIntelMonitorDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/ThreatIntelMonitorDto.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.sacommons.monitor;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/ThreatIntelMonitorDtoInterface.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/ThreatIntelMonitorDtoInterface.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.sacommons.monitor;
 
 public interface ThreatIntelMonitorDtoInterface {

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/ThreatIntelTriggerDto.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/sacommons/monitor/ThreatIntelTriggerDto.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.sacommons.monitor;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/DefaultTifSourceConfigLoaderService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/DefaultTifSourceConfigLoaderService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.service;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/JsonPathIocSchemaThreatIntelHandler.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/JsonPathIocSchemaThreatIntelHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.service;
 
 import com.jayway.jsonpath.Configuration;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/service/SATIFSourceConfigManagementService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.service;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportDeleteTIFSourceConfigAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportDeleteTIFSourceConfigAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.transport;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportGetTIFSourceConfigAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportGetTIFSourceConfigAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.transport;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportRefreshTIFSourceConfigAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportRefreshTIFSourceConfigAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.transport;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportSearchTIFSourceConfigsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportSearchTIFSourceConfigsAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.transport;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportDeleteThreatIntelMonitorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportDeleteThreatIntelMonitorAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.transport.monitor;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportGetThreatIntelAlertsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportGetThreatIntelAlertsAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.transport.monitor;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportIndexThreatIntelMonitorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportIndexThreatIntelMonitorAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.transport.monitor;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportSearchThreatIntelMonitorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportSearchThreatIntelMonitorAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.transport.monitor;
 
 import org.opensearch.OpenSearchStatusException;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportUpdateThreatIntelAlertStatusAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportUpdateThreatIntelAlertStatusAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.transport.monitor;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelMonitorUtils.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelMonitorUtils.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.util;
 
 import org.opensearch.commons.alerting.model.Alert;

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCorrelationRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCorrelationRuleAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCustomLogTypeAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexCorrelationRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexCorrelationRuleAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexCustomLogTypeAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportSearchCorrelationRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportSearchCorrelationRuleAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportSearchCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportSearchCustomLogTypeAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/util/CorrelationRuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/CorrelationRuleIndices.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/securityanalytics/util/XContentUtils.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/XContentUtils.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 
 package org.opensearch.securityanalytics.util;

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 org.opensearch.securityanalytics.correlation.index.codec.correlation950.CorrelationCodec950
 org.opensearch.securityanalytics.correlation.index.codec.correlation990.CorrelationCodec990
 org.opensearch.securityanalytics.correlation.index.codec.correlation9120.CorrelationCodec9120

--- a/src/main/resources/META-INF/services/org.opensearch.jobscheduler.spi.JobSchedulerExtension
+++ b/src/main/resources/META-INF/services/org.opensearch.jobscheduler.spi.JobSchedulerExtension
@@ -1,1 +1,4 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 org.opensearch.securityanalytics.SecurityAnalyticsPlugin

--- a/src/main/resources/META-INF/services/org.opensearch.security.spi.resources.ResourceSharingExtension
+++ b/src/main/resources/META-INF/services/org.opensearch.security.spi.resources.ResourceSharingExtension
@@ -1,1 +1,4 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 org.opensearch.securityanalytics.resources.SecurityAnalyticsResourceSharingExtension

--- a/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigResponseTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/IndexTIFSourceConfigResponseTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.action;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/mapper/MapperRestApiIT.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 package org.opensearch.securityanalytics.mapper;
 

--- a/src/test/java/org/opensearch/securityanalytics/mapper/MapperUtilsTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/mapper/MapperUtilsTests.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 package org.opensearch.securityanalytics.mapper;
 

--- a/src/test/java/org/opensearch/securityanalytics/mapper/MappingsTraverserTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/mapper/MappingsTraverserTests.java
@@ -1,6 +1,6 @@
 /*
-Copyright OpenSearch Contributors
-SPDX-License-Identifier: Apache-2.0
+ Copyright OpenSearch Contributors
+ SPDX-License-Identifier: Apache-2.0
  */
 package org.opensearch.securityanalytics.mapper;
 

--- a/src/test/java/org/opensearch/securityanalytics/model/IocFindingTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/IocFindingTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.model;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;

--- a/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigDtoTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigDtoTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.model;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;

--- a/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/SATIFSourceConfigTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.model;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;

--- a/src/test/java/org/opensearch/securityanalytics/model/threatintel/ThreatIntelAlertTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/model/threatintel/ThreatIntelAlertTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.model.threatintel;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/CustomLogTypeRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/CustomLogTypeRestApiIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/CustomSchemaSourceConfigIocUploadIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SATIFSourceConfigRestApiIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SecureThreatIntelMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SecureThreatIntelMonitorRestApiIT.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.resthandler;
 
 import org.apache.hc.core5.http.HttpHost;

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/SourceConfigWithoutS3RestApiIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelAlertIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelAlertIT.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.resthandler;
 
 import org.apache.hc.core5.http.ContentType;

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.resthandler;
 
 import org.apache.hc.core5.http.ContentType;

--- a/src/test/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchemaTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/threatIntel/model/JsonPathIocSchemaTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model;
 
 public class JsonPathIocSchemaTests {

--- a/src/test/java/org/opensearch/securityanalytics/threatIntel/model/monitor/ThreatIntelInputTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/threatIntel/model/monitor/ThreatIntelInputTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.model.monitor;
 
 

--- a/src/test/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelFeedParserTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/threatIntel/util/ThreatIntelFeedParserTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.securityanalytics.threatIntel.util;
 
 import org.junit.Test;


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files
  
### Related Issues
[#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
