### PR TITLE
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (security-analytics)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'com.diffplug.spotless' version '6.22.0'
+    id 'com.diffplug.spotless' version '8.10.1'
     id "com.netflix.nebula.ospackage" version "12.0.0"
     id 'java-library'
     id "de.undercouch.download" version "5.6.0"

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -1,5 +1,9 @@
 allprojects {
     project.apply plugin: "com.diffplug.spotless"
+
+    // Only wire the Eclipse JDT step when a spotless task is actually being run, so non-spotless
+    // Gradle invocations (test, assemble) don't provision the formatter at configuration time.
+    def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
     spotless {
         java {
             // Normally this isn't necessary, but we have Java sources in
@@ -7,7 +11,13 @@ allprojects {
             target '*/com/amazon/dlic/auth/**/*.java'
 
             removeUnusedImports()
-            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            // Pin 4.27 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
+            // formatter resolves from Maven Central through the mirror below instead of querying a
+            // P2 update site at configuration time. Keep withP2Mirrors so any non-lockfile fallback
+            // still hits the ci.opensearch.org mirror rather than the eclipse.org origin.
+            if (runningSpotlessTask) {
+                eclipse('4.27').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            }
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
